### PR TITLE
Support passing files and directories as arguments to nixfmt-plus script

### DIFF
--- a/home-manager/_mixins/scripts/nixfmt-plus/nixfmt-plus.sh
+++ b/home-manager/_mixins/scripts/nixfmt-plus/nixfmt-plus.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
+set -eou pipefail
 
-deadnix --edit
-statix fix
-nixfmt --verify .
+if [ $# -eq 0 ]; then
+  deadnix --edit
+  statix fix
+  nixfmt --verify .
+else
+  deadnix --edit "$@"
+  for target in "$@"; do
+    statix fix -- "$target"
+  done
+  nixfmt --verify "$@"
+fi


### PR DESCRIPTION
The `nixfmt-plus` script is really helpful. It's less useful when working on changes in the `nixpkgs` repository, since it always operates on the current working directory. Making it possible to pass paths as arguments really comes in handy in this situation, which is exactly what I've done in this PR.