### PR TITLE
feat: add laptop-specific settings for captive portal

### DIFF
--- a/home-manager/_mixins/scripts/captive-portal/default.nix
+++ b/home-manager/_mixins/scripts/captive-portal/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ isLaptop, lib, pkgs, ... }:
 let
   inherit (pkgs.stdenv) isLinux;
   name = builtins.baseNameOf (builtins.toString ./.);
@@ -13,4 +13,4 @@ let
     text = builtins.readFile ./${name}.sh;
   };
 in
-lib.mkIf isLinux { home.packages = with pkgs; [ shellApplication ]; }
+lib.mkIf (isLaptop && isLinux) { home.packages = with pkgs; [ shellApplication ]; }

--- a/nixos/_mixins/features/network/default.nix
+++ b/nixos/_mixins/features/network/default.nix
@@ -95,6 +95,13 @@ in
 {
   imports = lib.optional (builtins.pathExists (./. + "/${hostname}.nix")) ./${hostname}.nix;
 
+  programs.captive-browser = lib.mkIf isLaptop {
+    enable = true;
+    browser = ''
+      env XDG_CONFIG_HOME="$PREV_CONFIG_HOME" ${pkgs.chromium}/bin/chromium --user-data-dir=$HOME/.local/share/chromium-captive --proxy-server="socks5://$PROXY" --host-resolver-rules="MAP * ~NOTFOUND , EXCLUDE localhost" --no-first-run --new-window --incognito -no-default-browser-check http://neverssl.com
+    '';
+  };
+
   networking = {
     extraHosts = ''
       10.10.10.1     router
@@ -130,6 +137,11 @@ in
       enable = true;
       unmanaged = unmanagedInterfaces;
       wifi.backend = "iwd";
+      extraConfig = lib.mkIf isLaptop ''
+        [connectivity]
+        uri = http://google.cn/generate_204
+        response =
+      '';
     };
     # https://wiki.nixos.org/wiki/Incus
     nftables.enable = lib.mkIf config.virtualisation.incus.enable true;


### PR DESCRIPTION
- Added a check for laptops in the captive portal script.
- Enabled captive browser with custom Chromium settings for laptops.
- Included extra connectivity configuration specifically for laptops.
