### PR TITLE
feat: Add Beyond Compare and update packages with user-specific app selection

### DIFF
--- a/darwin/_mixins/desktop/apps/utilities/default.nix
+++ b/darwin/_mixins/desktop/apps/utilities/default.nix
@@ -16,6 +16,9 @@ lib.mkIf (lib.elem username installFor) {
   ];
 
   homebrew = {
-    casks = [ "balenaetcher" ];
+    casks = [
+      "balenaetcher"
+      "beyond-compare"
+    ];
   };
 }

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -209,7 +209,11 @@
           "/Users/${username}/Applications/Home Manager Apps/Visual Studio Code.app"
           "/Users/${username}/Applications/Home Manager Apps/GitKraken.app"
           "/Users/${username}/Applications/Home Manager Apps/Alacritty.app"
+        ] ++ lib.optionals (username == "martin.wimpress") [
+          "/Applications/Cider.app"
+        ] ++ lib.optionals (username == "martin") [
           "/System/Applications/Music.app"
+        ] ++ [
           "/Applications/Heynote.app"
           "/Applications/Joplin.app"
           "/System/Applications/Launchpad.app"

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1752828704,
-        "narHash": "sha256-I8cCVFZIFcIy+7KBnjCuS/ISTJYeR8mkah1oxA6qBVk=",
+        "lastModified": 1753284130,
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f5d22072074b0bc3c47a3a96a00e4fad263014ff",
+        "rev": "6365c59e7506fd3e6e5050c8184b41aa7410d6e7",
         "type": "github"
       },
       "original": {
@@ -444,11 +443,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1753055804,
-        "narHash": "sha256-KerePGJYX47ex6OY3CWsid4AltO2gDtQROunYJ0eCEE=",
+        "lastModified": 1753288231,
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "adf195f021a8cbb0c317f75b52e96c82616526f9",
+        "rev": "7b5a978e00273b8676c530c03d315f5b75fae564",
         "type": "github"
       },
       "original": {
@@ -485,7 +483,6 @@
       },
       "locked": {
         "lastModified": 1746473343,
-        "narHash": "sha256-F0YpvaRbAjh4qKrBGip+CxvAkCIY3yKVKGitK1gsqkk=",
         "owner": "kolide",
         "repo": "nix-agent",
         "rev": "73d5caa7acefdf77d77fcee5ef4e482dbcaf8e47",
@@ -510,7 +507,6 @@
       },
       "locked": {
         "lastModified": 1742156590,
-        "narHash": "sha256-aTM/2CrNN5utdVEQGsOA+kl4UozgH7VPLBQL5OXtBrg=",
         "owner": "hraban",
         "repo": "mac-app-util",
         "rev": "341ede93f290df7957047682482c298e47291b4d",
@@ -571,7 +567,6 @@
       },
       "locked": {
         "lastModified": 1749744770,
-        "narHash": "sha256-MEM9XXHgBF/Cyv1RES1t6gqAX7/tvayBC1r/KPyK1ls=",
         "owner": "LnL7",
         "repo": "nix-darwin",
         "rev": "536f951efb1ccda9b968e3c9dee39fbeb6d3fdeb",
@@ -604,7 +599,6 @@
       },
       "locked": {
         "lastModified": 1752160973,
-        "narHash": "sha256-BCC8KB7TEtwv7vZN1WDu870tRbXtzUcmF9xNr6ws5Wc=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
         "rev": "69c1aa2f136f3c3326d9b6770e0eb54f12832971",
@@ -624,7 +618,6 @@
       },
       "locked": {
         "lastModified": 1752985182,
-        "narHash": "sha256-sX8Neff8lp3TCHai6QmgLr5AD8MdsQQX3b52C1DVXR8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
         "rev": "fafdcb505ba605157ff7a7eeea452bc6d6cbc23c",
@@ -644,11 +637,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1753150460,
-        "narHash": "sha256-q2dkvuIfEb5fWBF6TJePJbcP1hqxARAUddfPGVGvD38=",
+        "lastModified": 1753409666,
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "d13827556415f4050b510e9cfb9873c1ce9aaec4",
+        "rev": "38a251b6e95659b12dfb3b9fdc237d1ba2ac3786",
         "type": "github"
       },
       "original": {
@@ -660,7 +652,6 @@
     "nixos-hardware": {
       "locked": {
         "lastModified": 1753122741,
-        "narHash": "sha256-nFxE8lk9JvGelxClCmwuJYftbHqwnc01dRN4DVLUroM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
         "rev": "cc66fddc6cb04ab479a1bb062f4d4da27c936a22",
@@ -754,11 +745,10 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1752950548,
-        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
+        "lastModified": 1753250450,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
+        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
         "type": "github"
       },
       "original": {
@@ -843,11 +833,10 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1752866191,
-        "narHash": "sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M=",
+        "lastModified": 1753345091,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f01fe91b0108a7aff99c99f2e9abbc45db0adc2a",
+        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
         "type": "github"
       },
       "original": {
@@ -1027,7 +1016,6 @@
       },
       "locked": {
         "lastModified": 1752544651,
-        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
         "rev": "2c8def626f54708a9c38a5861866660395bb3461",
@@ -1123,7 +1111,6 @@
       },
       "locked": {
         "lastModified": 1750353031,
-        "narHash": "sha256-Bx7DOPLhkr8Z60U9Qw4l0OidzHoqLDKQH5rDV5ef59A=",
         "owner": "nix-community",
         "repo": "nixos-vscode-server",
         "rev": "4ec4859b12129c0436b0a471ed1ea6dd8a317993",
@@ -1144,7 +1131,6 @@
       },
       "locked": {
         "lastModified": 1723463209,
-        "narHash": "sha256-DYK2McUrn2mEpYfi5ig0poJEzAUUSoSYSzjI5CirOO8=",
         "owner": "koiuo",
         "repo": "xdg-override",
         "rev": "a3509346bb4f8542e4824b0e949c400c8d396207",

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -46,11 +46,11 @@
     linuxPackages_6_12 = prev.linuxPackages_6_12.extend (_lpself: lpsuper: {
       mwprocapture = lpsuper.mwprocapture.overrideAttrs ( old: rec {
         pname = "mwprocapture";
-        subVersion = "4418";
+        subVersion = "4479";
         version = "1.3.${subVersion}";
         src = prev.fetchurl {
-          url = "https://www.magewell.com/files/drivers/ProCaptureForLinux_${version}.tar.gz";
-          sha256 = "sha256-ZUqJkARhaMo9aZOtUMEdiHEbEq10lJO6MkGjEDnfx1g=";
+          url = "https://www.magewell.com/files/drivers/ProCaptureForLinuxPUBLIC_${version}.tar.gz";
+          sha256 = "sha256-jol3Ws3k8n6fyprqb4pgh7zOg6PJmXRpzZOQ3WALA2o=";
         };
       });
     });

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -23,22 +23,22 @@
     });
 
     gitkraken = prev.gitkraken.overrideAttrs (old: rec {
-      version = "11.1.1";
+      version = "11.2.1";
 
       src = {
         x86_64-linux = prev.fetchzip {
           url = "https://api.gitkraken.dev/releases/production/linux/x64/${version}/gitkraken-amd64.tar.gz";
-          hash = "sha256-VKJjwWAhN53h9KU06OviIEL5SiIDwPtb7cKJSR4L9YA=";
+          hash = "sha256-nxYWcw8A/lIVyjiUJOmcjmTblbxiLSxMUjo7KnlAMzs=";
         };
 
         x86_64-darwin = prev.fetchzip {
           url = "https://api.gitkraken.dev/releases/production/darwin/x64/${version}/GitKraken-v${version}.zip";
-          hash = "sha256-CNJ5EOFTGerzCQg7E23bPTPn11c41/AYP0PHHyrpUDA=";
+          hash = "sha256-7I3yAEarGGhFs/PvcqvoDx8MbJ/zEuNN/s0o357M1vc=";
         };
 
         aarch64-darwin = prev.fetchzip {
           url = "https://api.gitkraken.dev/releases/production/darwin/arm64/${version}/GitKraken-v${version}.zip";
-          hash = "sha256-5R106QjzDLDesiOaZMMLHhissvBtOQv0hgnCmVgApUc=";
+          hash = "sha256-pDPdi+cRMqhxu/84u6ojxteIi1VHfN3qy/NTruHVt8U=";
         };
       }.${prev.stdenv.hostPlatform.system} or (throw "Unsupported system: ${prev.stdenv.hostPlatform.system}");
     });

--- a/pkgs/wavebox/default.nix
+++ b/pkgs/wavebox/default.nix
@@ -172,11 +172,11 @@ let
 
   linux = stdenv.mkDerivation (finalAttrs: {
     inherit pname meta passthru;
-    version = "10.137.12-2";
+    version = "10.138.14-2";
 
     src = fetchurl {
       url = "https://download.wavebox.app/stable/linux/deb/amd64/wavebox_${finalAttrs.version}_amd64.deb";
-      hash = "sha256-hijSbNmiO+veUcal/50WopbSnNpDkHO0gxCPjrB0Kas=";
+      hash = "sha256-MyVrlUFrGhnMlHRPSI4gq4fBUzgUNtJfzB8oWGLzkmg=";
     };
 
     # With strictDeps on, some shebangs were not being patched correctly
@@ -264,11 +264,11 @@ let
 
   darwin = stdenvNoCC.mkDerivation (finalAttrs: {
     inherit pname meta passthru;
-    version = "10.137.12.2";
+    version = "10.138.14.2";
 
     src = fetchurl {
       url = "https://download.wavebox.app/stable/macuniversal/Install%20Wavebox%20${finalAttrs.version}.dmg";
-      hash = "sha256-PclTKITgJfSAdo7uc69jFZ5Ls35Yv4LXjG0jEC0oepE=";
+      hash = "sha256-r6ScEXgVbnCKKWZvNx3gDU8VpfaBI8novpKs308bJE8=";
     };
 
     dontPatch = true;


### PR DESCRIPTION
## Changes
- Add Beyond Compare to homebrew casks for utility applications
- Refactor app selection in Darwin configuration to be user-specific
  - Music app for "martin" user
  - Cider app for "martin.wimpress" user
- Update application versions:
  - GitKraken to 11.2.1
  - Wavebox to 10.138.14-2
  - Magewell ProCapture driver to 1.3.4479
- Update flake dependencies

These changes improve user experience by providing user-specific application selection while keeping core applications up-to-date.