### PR TITLE
chore(defold): update to 1.12.3

### DIFF
--- a/pkgs/defold-bob/default.nix
+++ b/pkgs/defold-bob/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/defold/defold/releases/download/${version}/bob.jar";
-    hash = "sha256-XaLRiJB/FLjdG20sOSyPhQJ/Bsscn5eiEBB6UIW4sww=";
+    hash = "sha256-6fF0/OcVF2ZBYAKedcaM+qkJb+myBDfyjWaCZAa+kvc=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/defold/default.nix
+++ b/pkgs/defold/default.nix
@@ -42,7 +42,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/defold/defold/releases/download/${version}/Defold-x86_64-linux.tar.gz";
-      hash = "sha256-CEeQWYstOOhLD9/mNj3Kf3p+pA9eUsoPar/fmeWgGlE=";
+      hash = "sha256-ATaLlo5xI5rLgILnDiQgVuDGLsseqqd9kaVa0S9AKVQ=";
     };
 
     dontBuild = true;


### PR DESCRIPTION
Automated Defold update to version 1.12.3.

Updates all three packages: defold, defold-bob, and defold-gdc.

Release: https://github.com/defold/defold/releases/tag/1.12.3