### PR TITLE
feat(hermes): add missing shell tools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,8 @@
         shellPackages =
           p: with p; [
             deadnix
+            direnv
+            file
             git
             home-manager
             jq
@@ -159,10 +161,13 @@
             nixfmt-tree
             nixfmt
             nix-output-monitor
+            nodejs
             openssh
             sops
+            sqlite
             statix
             taplo
+            zstd
           ];
         extraFlakeInputs = with inputs; [
           determinate


### PR DESCRIPTION
## Summary
- add `direnv`, `file`, `sqlite`, and `zstd` to the nix-config development shell
- switch the shell's Node runtime to `nodejs` so `npm` is available on `PATH`
- keep the existing `openssh` package, which provides `ssh` and `scp`

## Validation
- `nix flake show --allow-import-from-derivation`
- `nix develop .#default --command python3 /var/lib/hermes/workspace/check_hermes_shell_tools.py`

## Context
Addresses the remaining Hermes shell tool gaps tracked in the-cauldron/melting-pot#10.
