### PR TITLE
feat(hermes): add AgentMail MCP integration

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -211,7 +211,7 @@ services.hermes-agent.mcpServers = {
 
   agentmail = {
     command = "${pkgs.nodejs-slim}/bin/npx";
-    args = [ "-y" "agentmail-mcp" ];
+    args = [ "-y" "agentmail-mcp@0.2.2" ];
     env.AGENTMAIL_API_KEY = "\${AGENTMAIL_API_KEY}";
   };
 };
@@ -223,6 +223,8 @@ Notes:
   live Jina MCP server declaration in the module yet.
 - `agentmail` follows the official AgentMail Hermes guidance and only exposes
   the API key to the MCP subprocess.
+- The runtime MCP CLI is pinned to `agentmail-mcp@0.2.2` to avoid upstream
+  drift from an unversioned `npx` install.
 - AgentMail domain creation, DNS verification, and other control-plane tasks
   still happen through the AgentMail console, API, or CLI. The MCP server is
   the runtime inbox interface for Hermes itself.

--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -210,7 +210,7 @@ services.hermes-agent.mcpServers = {
   cloudflare.url = "https://docs.mcp.cloudflare.com/mcp";
 
   agentmail = {
-    command = "${pkgs.nodejs-slim}/bin/npx";
+    command = "${pkgs.nodejs}/bin/npx";
     args = [ "-y" "agentmail-mcp@0.2.2" ];
     env.AGENTMAIL_API_KEY = "\${AGENTMAIL_API_KEY}";
   };

--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -135,6 +135,7 @@ currently exports:
 - `ANTHROPIC_API_KEY`
 - `CONTEXT7_API_KEY`
 - `JINA_API_KEY`
+- `AGENTMAIL_API_KEY`
 - `GH_TOKEN`
 - `GITHUB_TOKEN`
 
@@ -185,6 +186,7 @@ The current declared MCP servers are:
 - `context7`
 - `nixos`
 - `cloudflare`
+- `agentmail`
 
 They are configured directly in
 [default.nix](default.nix).
@@ -206,6 +208,12 @@ services.hermes-agent.mcpServers = {
   };
 
   cloudflare.url = "https://docs.mcp.cloudflare.com/mcp";
+
+  agentmail = {
+    command = "${pkgs.nodejs-slim}/bin/npx";
+    args = [ "-y" "agentmail-mcp" ];
+    env.AGENTMAIL_API_KEY = "\${AGENTMAIL_API_KEY}";
+  };
 };
 ```
 
@@ -213,6 +221,11 @@ Notes:
 
 - `JINA_API_KEY` is already provisioned in the env template, but there is no
   live Jina MCP server declaration in the module yet.
+- `agentmail` follows the official AgentMail Hermes guidance and only exposes
+  the API key to the MCP subprocess.
+- AgentMail domain creation, DNS verification, and other control-plane tasks
+  still happen through the AgentMail console, API, or CLI. The MCP server is
+  the runtime inbox interface for Hermes itself.
 - The README should stay aligned with the declared set above, not the broader
   future MCP wish list.
 
@@ -299,7 +312,7 @@ The following are in place now:
 - `copilot` fallback with `gpt-5.4`
 - named custom qwen providers on `skrye` and `zannah`
 - Holographic memory
-- four live MCP servers: Exa, Context7, NixOS, Cloudflare
+- five live MCP servers: Exa, Context7, NixOS, Cloudflare, AgentMail
 
 ## What Is Deliberately Deferred
 

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -281,6 +281,13 @@ in
         mode = "0400";
       };
 
+      AGENTMAIL_API_KEY = {
+        sopsFile = mcpSopsFile;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+
       GITHUB_TOKEN = {
         sopsFile = hermesSopsFile;
         owner = "root";
@@ -296,6 +303,7 @@ in
         ANTHROPIC_API_KEY=${config.sops.placeholder.ANTHROPIC_API_KEY}
         CONTEXT7_API_KEY=${config.sops.placeholder.CONTEXT7_API_KEY}
         JINA_API_KEY=${config.sops.placeholder.JINA_API_KEY}
+        AGENTMAIL_API_KEY=${config.sops.placeholder.AGENTMAIL_API_KEY}
         GH_TOKEN=${config.sops.placeholder.GITHUB_TOKEN}
         GITHUB_TOKEN=${config.sops.placeholder.GITHUB_TOKEN}
         _HERMES_FORCE_TELEGRAM_BOT_TOKEN=${config.sops.placeholder.TELEGRAM_BOT_TOKEN}
@@ -348,6 +356,16 @@ in
         };
         cloudflare = {
           url = "https://docs.mcp.cloudflare.com/mcp";
+        };
+        agentmail = {
+          command = "${pkgs.nodejs-slim}/bin/npx";
+          args = [
+            "-y"
+            "agentmail-mcp"
+          ];
+          env = {
+            AGENTMAIL_API_KEY = "\${AGENTMAIL_API_KEY}";
+          };
         };
       };
 

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -358,7 +358,7 @@ in
           url = "https://docs.mcp.cloudflare.com/mcp";
         };
         agentmail = {
-          command = "${pkgs.nodejs-slim}/bin/npx";
+          command = "${pkgs.nodejs}/bin/npx";
           args = [
             "-y"
             "agentmail-mcp@0.2.2"

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -361,7 +361,7 @@ in
           command = "${pkgs.nodejs-slim}/bin/npx";
           args = [
             "-y"
-            "agentmail-mcp"
+            "agentmail-mcp@0.2.2"
           ];
           env = {
             AGENTMAIL_API_KEY = "\${AGENTMAIL_API_KEY}";


### PR DESCRIPTION
## Summary
- add AgentMail MCP to the live Hermes NixOS service configuration
- wire `AGENTMAIL_API_KEY` through the managed Hermes environment and MCP subprocess env
- document the new runtime integration in the Hermes deployment README

## Why MCP instead of the CLI?
AgentMail's official Hermes guidance uses the MCP server, and Hermes already has first-class native MCP support. That means the MCP path fits the existing runtime model: Hermes can call mailbox tools directly without shelling out through the terminal, parsing CLI output, or carrying extra wrapper scripts.

The CLI still matters for control-plane tasks such as creating domains, verifying DNS, and other administrative actions, but for the running Hermes service the MCP server is the better fit.

## Validation
- `git diff --check`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.services.hermes-agent.mcpServers.agentmail.command --raw`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.services.hermes-agent.mcpServers.agentmail.args --json`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.services.hermes-agent.mcpServers.agentmail.env.AGENTMAIL_API_KEY --raw`

## Context
Research and recommendation were posted to `the-cauldron/melting-pot#7`.
This PR implements the preferred Hermes-side integration from that research.
