### PR TITLE
fix(hermes): add bash, hostname, and nix to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -149,15 +149,18 @@
         inherit (self) overlays;
         shellPackages =
           p: with p; [
+            bash
             deadnix
             direnv
             file
             git
             home-manager
+            hostname
             jq
             just
             micro
             nh
+            nix
             nixfmt-tree
             nixfmt
             nix-output-monitor


### PR DESCRIPTION
## Summary
- add `bash` so `just` can find `sh` in the Hermes dev shell
- add `hostname` for shell scripts and `just` recipes that inspect the host name
- add `nix` so `nix-instantiate` and direct Nix validation tools are available in-shell

## Why
Recent Hermes work still hit three avoidable shell gaps:
- `just eval` failed because `sh` was missing
- shell tooling and recipes expected `hostname`
- validation notes had to say `nix-instantiate` was unavailable in the execution environment

This keeps the fix scoped to the Hermes development shell.

## Validation
- `git diff --check`
- `/run/current-system/sw/bin/nix develop .#default --command python3 - <<'PY' ...` to verify `sh`, `hostname`, and `nix-instantiate` are on `PATH`
- `/run/current-system/sw/bin/nix develop .#default --command just eval`

## Related
- the-cauldron/melting-pot#10
