### PR TITLE
feat(hermes): include Determinate Nix in agent shell

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -14,6 +14,9 @@ let
   claudePackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
   codexPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex;
   agentBrowserPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.agent-browser;
+  # Determinate Nix binary, matching the host-level installation, so agent
+  # shells expose the same `nix` CLI rather than stock upstream nixpkgs Nix.
+  nixPackage = inputs.determinate.packages.${pkgs.stdenv.hostPlatform.system}.default;
   hermesHome = "${config.services.hermes-agent.stateDir}/.hermes";
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the
@@ -164,6 +167,7 @@ let
     bzip2
     claudePackage
     codexPackage
+    nixPackage
     (curlMinimal.override { opensslSupport = true; })
     duf
     dua

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -181,6 +181,7 @@ let
     gnused
     gnutar
     gzip
+    inetutils
     jq
     just
     lsof
@@ -224,6 +225,7 @@ let
     EOF
 
     chmod 0555 "$out/bin/bash"
+    ln -s bash "$out/bin/sh"
   '';
   username = config.noughty.user.name;
 in

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -14,9 +14,11 @@ let
   claudePackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
   codexPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex;
   agentBrowserPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.agent-browser;
-  # Determinate Nix binary, matching the host-level installation, so agent
-  # shells expose the same `nix` CLI rather than stock upstream nixpkgs Nix.
-  nixPackage = inputs.determinate.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  # Determinate Nix CLI, matching the host-level installation, so agent shells
+  # expose the same `nix` CLI rather than stock upstream nixpkgs Nix. The
+  # `determinate` flake's `packages.default` is `determinate-nixd` (the daemon
+  # helper); the actual `nix` CLI lives in its `nix` input.
+  nixPackage = inputs.determinate.inputs.nix.packages.${pkgs.stdenv.hostPlatform.system}.default;
   hermesHome = "${config.services.hermes-agent.stateDir}/.hermes";
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the


### PR DESCRIPTION
Add Determinate Nix binary to hermesExtraPackages so the `nix` CLI available in agent shells matches the host-level installation rather than the stock upstream nixpkgs Nix.