### PR TITLE
feat: configure Hermes Honcho pilot

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -295,6 +295,13 @@ in
         group = "root";
         mode = "0400";
       };
+
+      HONCHO_API_KEY = {
+        sopsFile = hermesSopsFile;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
     };
 
     sops.templates."hermes-env" = {
@@ -326,6 +333,48 @@ in
       owner = "root";
       group = "root";
       mode = "0644";
+    };
+
+    sops.templates."hermes-honcho" = {
+      content = builtins.toJSON {
+        apiKey = config.sops.placeholder.HONCHO_API_KEY;
+        baseUrl = "https://api.honcho.dev";
+        workspace = "darth.cc";
+        peerName = "martin";
+        hosts = {
+          hermes = {
+            enabled = true;
+            aiPeer = "traya";
+            workspace = "darth.cc";
+            peerName = "martin";
+            recallMode = "hybrid";
+            writeFrequency = "async";
+            sessionStrategy = "per-directory";
+            dialecticReasoningLevel = "low";
+            dialecticDynamic = true;
+            dialecticCadence = 3;
+            dialecticDepth = 1;
+            contextCadence = 1;
+            contextTokens = 1200;
+            dialecticMaxChars = 600;
+            messageMaxChars = 25000;
+            saveMessages = true;
+            observation = {
+              user = {
+                observeMe = true;
+                observeOthers = true;
+              };
+              ai = {
+                observeMe = true;
+                observeOthers = true;
+              };
+            };
+          };
+        };
+      };
+      owner = hermesUser;
+      group = hermesGroup;
+      mode = "0440";
     };
 
     services.hermes-agent = {
@@ -435,7 +484,7 @@ in
         memory = {
           memory_enabled = true;
           user_profile_enabled = true;
-          provider = "holographic";
+          provider = "honcho";
         };
       };
     };
@@ -449,6 +498,7 @@ in
     systemd.tmpfiles.rules = lib.mkAfter [
       "d ${hermesHome}/skills 2770 ${hermesUser} ${hermesGroup} - -"
       "L+ ${hermesHome}/SOUL.md - - - - ${config.sops.templates."hermes-soul".path}"
+      "L+ ${hermesHome}/honcho.json - - - - ${config.sops.templates."hermes-honcho".path}"
     ];
 
     system.activationScripts.hermes-agent-skills-permissions =


### PR DESCRIPTION
## Summary
- switch the managed Hermes deployment from `holographic` to the `honcho` memory provider
- declare a `HONCHO_API_KEY` secret sourced from `secrets/hermes.yaml`
- render a managed `honcho.json` for Hermes with `aiPeer: traya`, workspace `darth.cc`, and the agreed pilot settings
- link `honcho.json` into the shared Hermes home so both the service and host-side CLI use the same Honcho config

## Why
Martin now has a Honcho API key and wants the initial deployment to use the real managed Honcho experience rather than a watered-down trial. The config keeps the pilot representative while still bounding spend with low reasoning depth and cadence.

## Validation
- `just eval`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.services.hermes-agent.settings.memory.provider --raw`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.sops.templates."hermes-honcho".content --json`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.sops.templates."hermes-honcho".mode --raw`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.sops.templates."hermes-honcho".owner --raw`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.sops.templates."hermes-honcho".group --raw`
- `/run/current-system/sw/bin/nix eval .#nixosConfigurations.revan.config.sops.secrets.HONCHO_API_KEY.sopsFile --raw`
- `git diff --check`

## Notes
- This PR assumes `HONCHO_API_KEY` will be added to `secrets/hermes.yaml` separately as an encrypted SOPS secret.
- The current packaged Hermes build exposes `hermes memory` for provider management, but does not currently expose the newer `hermes honcho` subcommand shown in some docs.

Related:
- the-cauldron/melting-pot#11
