### PR TITLE
Add Fastmail Himalaya config for Hermes

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -97,6 +97,7 @@ Important paths:
 - Auth seed target: `/var/lib/hermes/.hermes/auth.json`
 - Managed env file target: `/var/lib/hermes/.hermes/.env`
 - Identity file: `/var/lib/hermes/.hermes/SOUL.md`
+- Himalaya config: `/var/lib/hermes/.config/himalaya/config.toml`
 
 `SOUL.md` is currently installed by tmpfiles as a symlink to a rendered
 template. That template composites the public repo copy in `traya-soul.md`.
@@ -126,6 +127,7 @@ Hermes currently draws from several secret sources:
 - `secrets/hermes.yaml`
 - `secrets/hermes-auth.json`
 - `secrets/mcp.yaml`
+- `secrets/traya.yaml`
 
 The live env template is rendered through `sops.templates."hermes-env"` and
 currently exports:
@@ -157,6 +159,10 @@ Operationally:
   vars or Hermes-managed auth state
 - `ANTHROPIC_API_KEY` remains available from `secrets/ai.yaml` for future
   direct Anthropic provider use
+- `traya@darth.cc` Fastmail access is rendered to the Himalaya config from
+  `secrets/traya.yaml`
+- `EMAIL_PASSWORD` must be a Fastmail app password, not the regular web login
+  password
 - live token refresh remains in Hermes state after startup
 
 ## Telegram

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -11,6 +11,7 @@ let
   bondSopsFile = ../../../../secrets + "/hermes-bond.yaml";
   hermesSopsFile = ../../../../secrets + "/hermes.yaml";
   mcpSopsFile = ../../../../secrets + "/mcp.yaml";
+  trayaSopsFile = ../../../../secrets + "/traya.yaml";
   claudePackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
   codexPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex;
   agentBrowserPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.agent-browser;
@@ -163,6 +164,8 @@ let
   hermesUser = config.services.hermes-agent.user;
   hermesGroup = config.services.hermes-agent.group;
   hermesAuthFile = "${hermesHome}/auth.json";
+  himalayaConfigDir = "${config.services.hermes-agent.stateDir}/.config/himalaya";
+  himalayaConfigPath = "${himalayaConfigDir}/config.toml";
   hermesExtraPackages = with pkgs; [
     agentBrowserPackage
     bat
@@ -336,6 +339,20 @@ in
         group = "root";
         mode = "0400";
       };
+
+      EMAIL_ADDRESS = {
+        sopsFile = trayaSopsFile;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+
+      EMAIL_PASSWORD = {
+        sopsFile = trayaSopsFile;
+        owner = hermesUser;
+        group = hermesGroup;
+        mode = "0440";
+      };
     };
 
     sops.templates."hermes-env" = {
@@ -406,6 +423,41 @@ in
           };
         };
       };
+      owner = hermesUser;
+      group = hermesGroup;
+      mode = "0440";
+    };
+
+    sops.templates."hermes-himalaya-config" = {
+      content = ''
+        display-name = "Traya"
+
+        [accounts.fastmail]
+        default = true
+        email = "${config.sops.placeholder.EMAIL_ADDRESS}"
+        display-name = "Traya"
+
+        folder.aliases.inbox = "INBOX"
+        folder.aliases.sent = "Sent Items"
+        folder.aliases.drafts = "Drafts"
+        folder.aliases.trash = "Trash"
+
+        backend.type = "imap"
+        backend.host = "imap.fastmail.com"
+        backend.port = 993
+        backend.encryption.type = "tls"
+        backend.login = "${config.sops.placeholder.EMAIL_ADDRESS}"
+        backend.auth.type = "password"
+        backend.auth.cmd = "${pkgs.coreutils}/bin/cat ${config.sops.secrets.EMAIL_PASSWORD.path}"
+
+        message.send.backend.type = "smtp"
+        message.send.backend.host = "smtp.fastmail.com"
+        message.send.backend.port = 465
+        message.send.backend.encryption.type = "tls"
+        message.send.backend.login = "${config.sops.placeholder.EMAIL_ADDRESS}"
+        message.send.backend.auth.type = "password"
+        message.send.backend.auth.cmd = "${pkgs.coreutils}/bin/cat ${config.sops.secrets.EMAIL_PASSWORD.path}"
+      '';
       owner = hermesUser;
       group = hermesGroup;
       mode = "0440";
@@ -550,7 +602,10 @@ in
     ];
 
     systemd.tmpfiles.rules = lib.mkAfter [
+      "d ${config.services.hermes-agent.stateDir}/.config 2750 ${hermesUser} ${hermesGroup} - -"
+      "d ${himalayaConfigDir} 2750 ${hermesUser} ${hermesGroup} - -"
       "d ${hermesHome}/skills 2770 ${hermesUser} ${hermesGroup} - -"
+      "L+ ${himalayaConfigPath} - - - - ${config.sops.templates."hermes-himalaya-config".path}"
       "L+ ${hermesHome}/SOUL.md - - - - ${config.sops.templates."hermes-soul".path}"
       "L+ ${hermesHome}/honcho.json - - - - ${config.sops.templates."hermes-honcho".path}"
     ];


### PR DESCRIPTION
## What
- add `secrets/traya.yaml` as the source for Hermes Fastmail credentials
- render a managed Himalaya config to `/var/lib/hermes/.config/himalaya/config.toml`
- wire the config to Fastmail IMAP and SMTP with the right Himalaya keys
- document the new runtime path and app-password requirement in the Hermes README

## Why
The Fastmail account for `traya@darth.cc` already exists and Himalaya is now in the Hermes shell, so the missing piece was a declarative config in `nix-config`.

The snippet Martin found was close, but Himalaya's current config shape needs a few extra details:
- `backend.encryption.type`, not `backend.encryption`
- `backend.auth.cmd`, not `backend.auth.command`
- explicit `backend.login` and `message.send.backend.login`
- Fastmail's IMAP sent folder is `Sent Items`

## Notes
- `EMAIL_PASSWORD` must hold a Fastmail app password, not the regular web login password
- the config reads the password from the sops secret at runtime, so the password is not embedded in the rendered TOML

## Validation
- `nix eval .#nixosConfigurations.revan.config.sops.templates."hermes-himalaya-config".content`
- `nix eval .#nixosConfigurations.revan.config.sops.secrets.EMAIL_PASSWORD.owner`
- `nix eval .#nixosConfigurations.revan.config.systemd.tmpfiles.rules | jq ... | grep himalaya/config.toml`
- `himalaya --config /tmp/himalaya-fastmail-test.toml account list`
