### PR TITLE
Fix Fastmail sent folder alias for Himalaya

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -438,7 +438,7 @@ in
         display-name = "Traya"
 
         folder.aliases.inbox = "INBOX"
-        folder.aliases.sent = "Sent Items"
+        folder.aliases.sent = "Sent"
         folder.aliases.drafts = "Drafts"
         folder.aliases.trash = "Trash"
 


### PR DESCRIPTION
## Summary
- change the Hermes Fastmail Himalaya sent-folder alias from `Sent Items` to `Sent`
- match the mailbox that is exposed by the live Fastmail account
- avoid send succeeding over SMTP but failing to save a sent copy over IMAP

## Validation
- `nix eval .#nixosConfigurations.revan.config.sops.templates."hermes-himalaya-config".content --raw | sed -n '1,16p'`
- `git diff --check`
- live verification on revan before this patch: `himalaya folder list`, `himalaya envelope list --page-size 10`, and successful send with a temporary `folder.aliases.sent = "Sent"` override
