### PR TITLE
feat(hermes): add Traya sanctuary continuity root

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -187,19 +187,22 @@ Discord is no longer part of this design.
 
 Traya-owned continuity state now lives under `/var/lib/hermes/workspace/trayas-sanctuary`.
 
-Use the sanctuary as the canonical home for:
+Use the sanctuary as the default home for Traya-owned durable state such as:
 
-- durable plans and decisions
+- plans and decisions
 - human-facing status ledgers
 - persisted morning briefing markdown
-- Traya-owned research notes that are not better housed in a task repo
+- continuity notes and durable research notes that are not better housed in a task repo
 
-Use `runtime/` inside sanctuary for local-only operational state such as:
+When creating Traya-owned operational files:
 
-- worker queues
-- raw inbox snapshots
-- generated audio
-- logs, locks, and scratch files
+- write durable, human-facing state under tracked sanctuary paths such as `docs/`, `status/`, `plans/`, and `notes/`
+- write hot operational state under `runtime/`
+- keep worker queues, raw inbox snapshots, generated audio, logs, locks, and scratch files under ignored runtime paths
+- keep cloned repos and task-specific code outside sanctuary under `/var/lib/hermes/workspace`
+- do not leave continuity artefacts in the workspace root unless a task explicitly requires it
+
+If work belongs to a specific repo, do the work there and promote only the durable summary or continuity output into sanctuary.
 
 The runtime-local-first rule still applies.
 Hermes should keep functioning from the local sanctuary even if GitHub is unavailable.

--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -183,6 +183,28 @@ That means the current service expects:
 
 Discord is no longer part of this design.
 
+## Sanctuary
+
+Traya-owned continuity state now lives under `/var/lib/hermes/workspace/trayas-sanctuary`.
+
+Use the sanctuary as the canonical home for:
+
+- durable plans and decisions
+- human-facing status ledgers
+- persisted morning briefing markdown
+- Traya-owned research notes that are not better housed in a task repo
+
+Use `runtime/` inside sanctuary for local-only operational state such as:
+
+- worker queues
+- raw inbox snapshots
+- generated audio
+- logs, locks, and scratch files
+
+The runtime-local-first rule still applies.
+Hermes should keep functioning from the local sanctuary even if GitHub is unavailable.
+The private GitHub repo `the-cauldron/trayas-sanctuary` is for durability and audit trail, not as the only live copy.
+
 ## MCP Servers
 
 The current declared MCP servers are:

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -154,6 +154,8 @@ let
         if [ -x "$out/bin/$program" ]; then
           wrapProgram "$out/bin/$program" \
             --set-default HERMES_HOME "${hermesHome}" \
+            --set-default TRAYA_SANCTUARY_DIR "/var/lib/hermes/workspace/trayas-sanctuary" \
+            --set-default TRAYA_SANCTUARY_REPO "the-cauldron/trayas-sanctuary" \
             --prefix PATH : "${lib.makeBinPath hermesExtraPackages}" \
             --prefix PYTHONPATH : "${hermesManagedPythonPath}" \
             --set-default HERMES_MANAGED "true"
@@ -229,6 +231,8 @@ let
         ++ hermesExtraPackages
       )
     }"
+    export TRAYA_SANCTUARY_DIR="/var/lib/hermes/workspace/trayas-sanctuary"
+    export TRAYA_SANCTUARY_REPO="the-cauldron/trayas-sanctuary"
 
     # Interactive CLI sandboxing: systemd hardening does not apply to host
     # shells, so we reuse bubblewrap to hide the same paths the gateway
@@ -469,6 +473,8 @@ in
       package = hermesAgentPackage;
       environment = {
         TELEGRAM_HOME_CHANNEL = "-1003933927882";
+        TRAYA_SANCTUARY_DIR = "/var/lib/hermes/workspace/trayas-sanctuary";
+        TRAYA_SANCTUARY_REPO = "the-cauldron/trayas-sanctuary";
       };
       extraPackages = [
         wrappedHermesBash

--- a/nixos/_mixins/server/hermes/traya-soul.md
+++ b/nixos/_mixins/server/hermes/traya-soul.md
@@ -58,17 +58,22 @@ specific reason otherwise.
 # Sanctuary
 
 Traya's continuity lives in `/var/lib/hermes/workspace/trayas-sanctuary`.
-Treat it as the canonical home for your own documents, plans, status trackers,
-briefings, queued follow-up summaries, and other durable working state.
+Use it as the default home for Traya-owned durable working state:
+- plans
+- status trackers
+- briefing markdown
+- continuity notes
+- queued follow-up summaries
+- other local documents that exist to preserve continuity across sessions
 
-Use sanctuary as a pristine silo for Traya's data. Keep task repos and cloned
-codebases elsewhere under `/var/lib/hermes/workspace`.
-Do not scatter continuity files in the workspace root when they belong in
-sanctuary.
+When creating Traya-owned operational files:
+- put durable, human-facing state under tracked sanctuary paths such as `docs/`, `status/`, `plans/`, and `notes/`
+- put hot machine state under `trayas-sanctuary/runtime/`
+- keep generated audio, raw snapshots, queues, logs, locks, and scratch under ignored runtime paths
+- keep task repos and cloned codebases elsewhere under `/var/lib/hermes/workspace`
+- do not leave continuity artefacts in the workspace root unless the task explicitly requires it
 
-Within sanctuary, keep Git-tracked files for durable, human-meaningful state and
-keep transient queues, caches, logs, raw snapshots, and generated media under
-ignored runtime paths.
+If work belongs to a specific repo, do the work in that repo and promote only the durable summary or resulting continuity state into sanctuary.
 
 # Skills
 

--- a/nixos/_mixins/server/hermes/traya-soul.md
+++ b/nixos/_mixins/server/hermes/traya-soul.md
@@ -55,6 +55,21 @@ there, write files there, run builds there. Do not scatter work across `/var/lib
 directly. If a task produces artefacts, they live in workspace unless there is a
 specific reason otherwise.
 
+# Sanctuary
+
+Traya's continuity lives in `/var/lib/hermes/workspace/trayas-sanctuary`.
+Treat it as the canonical home for your own documents, plans, status trackers,
+briefings, queued follow-up summaries, and other durable working state.
+
+Use sanctuary as a pristine silo for Traya's data. Keep task repos and cloned
+codebases elsewhere under `/var/lib/hermes/workspace`.
+Do not scatter continuity files in the workspace root when they belong in
+sanctuary.
+
+Within sanctuary, keep Git-tracked files for durable, human-meaningful state and
+keep transient queues, caches, logs, raw snapshots, and generated media under
+ignored runtime paths.
+
 # Skills
 
 Traya-owned custom skills live under `~/.hermes/skills/traya/`, not mixed into the


### PR DESCRIPTION
## Summary
- add sanctuary guidance to Traya's SOUL
- export sanctuary defaults in the Hermes service and host wrappers
- document the sanctuary as the canonical continuity root in the Hermes README

## Validation
- `git diff --check`
- `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.environment.TRAYA_SANCTUARY_DIR --raw`
- `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.environment.TRAYA_SANCTUARY_REPO --raw`
- `nix eval .#nixosConfigurations.revan.config.systemd.tmpfiles.rules --json | jq ...`