### PR TITLE
feat: add Zen Browser as workspace productivity browser

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1043,7 +1043,8 @@
         "sops-nix": "sops-nix",
         "systems": "systems_3",
         "vscode-server": "vscode-server",
-        "xdg-override": "xdg-override"
+        "xdg-override": "xdg-override",
+        "zen-browser": "zen-browser"
       }
     },
     "rust-analyzer-src": {
@@ -1281,6 +1282,29 @@
       "original": {
         "owner": "koiuo",
         "repo": "xdg-override",
+        "type": "github"
+      }
+    },
+    "zen-browser": {
+      "inputs": {
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776144279,
+        "narHash": "sha256-eX3u6wJ34+qu7ZR1qWOaToGWmudYQSOEStZZm6goP+8=",
+        "owner": "0xc000022070",
+        "repo": "zen-browser-flake",
+        "rev": "727de8a44c85e90f899c540cf3ffa0d5d3344f9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "0xc000022070",
+        "repo": "zen-browser-flake",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,9 @@
     xdg-override.url = "github:koiuo/xdg-override";
     xdg-override.inputs.nixpkgs.follows = "nixpkgs";
     xdg-override.inputs.flake-parts.follows = "flake-parts";
+    zen-browser.url = "github:0xc000022070/zen-browser-flake";
+    zen-browser.inputs.nixpkgs.follows = "nixpkgs";
+    zen-browser.inputs.home-manager.follows = "home-manager";
   };
   outputs =
     {

--- a/home-manager/_mixins/desktop/apps/browsers/default.nix
+++ b/home-manager/_mixins/desktop/apps/browsers/default.nix
@@ -25,7 +25,7 @@ let
   ];
 in
 {
-  # Install browser extension for macOS and nix-darwin doesn't support it yet
+  # Install browser extensions for macOS; nix-darwin doesn't support it yet.
   programs = {
     brave = {
       enable = host.is.darwin;

--- a/home-manager/_mixins/desktop/apps/default.nix
+++ b/home-manager/_mixins/desktop/apps/default.nix
@@ -44,6 +44,7 @@ in
     ./streaming
     ./terminal
     ./utilities
+    ./workspace
   ];
 
   dbus = lib.mkIf (host.is.linux && host.is.workstation) {

--- a/home-manager/_mixins/desktop/apps/workspace/default.nix
+++ b/home-manager/_mixins/desktop/apps/workspace/default.nix
@@ -77,10 +77,7 @@ in
                 install_url = "https://addons.mozilla.org/firefox/downloads/latest/catppuccin-${catppuccinPalette.flavor}-${catppuccinPalette.accent}-git/latest.xpi";
                 installation_mode = "force_installed";
               };
-              "{bbb880ce-43c9-47ae-b746-c3e0096c5b76}" = {
-                install_url = "https://addons.mozilla.org/firefox/download/latest/catppuccin-web-file-icons/";
-                installation_mode = "force_installed";
-              };
+              "{bbb880ce-43c9-47ae-b746-c3e0096c5b76}" = mkExtension "catppuccin-web-file-icons";
               "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}" = mkExtension "styl-us";
               # Workspace-specific extensions.
               # Note: Ramp and Meet Linky are Chrome-only; no AMO listing exists.

--- a/home-manager/_mixins/desktop/apps/workspace/default.nix
+++ b/home-manager/_mixins/desktop/apps/workspace/default.nix
@@ -1,0 +1,164 @@
+{
+  catppuccinPalette,
+  config,
+  inputs,
+  lib,
+  noughtyLib,
+  ...
+}:
+let
+  inherit (config.noughty) host;
+  mkExtension = pluginId: {
+    install_url = "https://addons.mozilla.org/firefox/downloads/latest/${pluginId}/latest.xpi";
+    installation_mode = "force_installed";
+  };
+in
+{
+  imports = [
+    inputs.zen-browser.homeModules.beta
+  ];
+
+  config =
+    lib.mkIf (host.is.linux && noughtyLib.isUser [ "martin" ] && noughtyLib.hostHasTag "workspace")
+      {
+        programs.zen-browser = {
+          enable = true;
+
+          policies = {
+            AutofillAddressEnabled = false;
+            AutofillCreditCardEnabled = false;
+            CaptivePortal = true;
+            Cookies = {
+              AcceptThirdParty = "from-visited";
+              Behavior = "reject-tracker";
+              BehaviorPrivateBrowsing = "reject-tracker";
+              RejectTracker = true;
+            };
+            DisableAppUpdate = true;
+            DisableDefaultBrowserAgent = true;
+            DisableFeedbackCommands = true;
+            DisableFirefoxStudies = true;
+            DisableFormHistory = true;
+            DisablePocket = true;
+            DisableProfileImport = true;
+            DisableSetDesktopBackground = true;
+            DisableTelemetry = true;
+            DisplayBookmarksToolbar = "never";
+            DisplayMenuBar = "default-off";
+            DNSOverHTTPS = {
+              Enabled = false;
+            };
+            DontCheckDefaultBrowser = true;
+            EnableTrackingProtection = {
+              Value = false;
+              Locked = false;
+              Cryptomining = true;
+              EmailTracking = true;
+              Fingerprinting = true;
+            };
+            EncryptedMediaExtensions = {
+              Enabled = true;
+              Locked = true;
+            };
+            ExtensionUpdate = true;
+            # Check about:support for extension/add-on ID strings.
+            ExtensionSettings = {
+              "support@lastpass.com" = mkExtension "lastpass-password-manager";
+              "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
+              "87677a2c52b84ad3a151a4a72f5bd3c4@jetpack" = mkExtension "grammarly-1";
+              "gdpr@cavi.au.dk" = mkExtension "consent-o-matic";
+              "sponsorBlocker@ajay.app" = mkExtension "sponsorblock";
+              "{762f9885-5a13-4abd-9c77-433dcd38b8fd}" = mkExtension "return-youtube-dislikes";
+              "easyscreenshot@mozillaonline.com" = mkExtension "easyscreenshot";
+              "search@kagi.com" = mkExtension "kagi-search-for-firefox";
+              "newtaboverride@agenedia.com" = mkExtension "new-tab-override";
+              "enterprise-policy-generator@agenedia.com" = mkExtension "enterprise-policy-generator";
+              "{2adf0361-e6d8-4b74-b3bc-3f450e8ebb69}" = {
+                install_url = "https://addons.mozilla.org/firefox/downloads/latest/catppuccin-${catppuccinPalette.flavor}-${catppuccinPalette.accent}-git/latest.xpi";
+                installation_mode = "force_installed";
+              };
+              "{bbb880ce-43c9-47ae-b746-c3e0096c5b76}" = {
+                install_url = "https://addons.mozilla.org/firefox/download/latest/catppuccin-web-file-icons/";
+                installation_mode = "force_installed";
+              };
+              "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}" = mkExtension "styl-us";
+              # Workspace-specific extensions.
+              # Note: Ramp and Meet Linky are Chrome-only; no AMO listing exists.
+              "{d634138d-c276-4fc8-924b-40a0ea21d284}" = mkExtension "1password-x-password-manager"; # 1Password
+              "teamgolinks@gmail.com" = mkExtension "golinks"; # GoLinks
+              "plugin@okta.com" = mkExtension "okta-browser-plugin"; # Okta
+              "{315f61e5-f0ce-4d6e-a521-70e8da512405}" = mkExtension "glean"; # Glean
+            };
+            FirefoxHome = {
+              Search = true;
+              TopSites = false;
+              SponsoredTopSites = false;
+              Highlights = false;
+              Pocket = false;
+              SponsoredPocket = false;
+              Snippets = false;
+              Locked = true;
+            };
+            FirefoxSuggest = {
+              WebSuggestions = false;
+              SponsoredSuggestions = false;
+              ImproveSuggest = false;
+              Locked = true;
+            };
+            FlashPlugin = {
+              Default = false;
+            };
+            HardwareAcceleration = true;
+            Homepage = {
+              URL = "https://kagi.com";
+              Locked = false;
+              StartPage = "none";
+            };
+            NetworkPrediction = false;
+            NewTabPage = true;
+            NoDefaultBookmarks = true;
+            OfferToSaveLogins = false;
+            OverrideFirstRunPage = "";
+            OverridePostUpdatePage = "";
+            PasswordManagerEnabled = false;
+            PopupBlocking = {
+              Default = true;
+            };
+            PromptForDownloadLocation = true;
+            SearchBar = "unified";
+            SearchEngines = {
+              Add = [
+                {
+                  Description = "Kagi";
+                  IconURL = "https://assets.kagi.com/v2/apple-touch-icon.png";
+                  Method = "GET";
+                  Name = "Kagi";
+                  SuggestURLTemplate = "https://kagi.com/api/autosuggest?q={searchTerms}";
+                  URLTemplate = "https://kagi.com/search?q={searchTerms}";
+                }
+              ];
+              Default = "Kagi";
+              DefaultPrivate = "Kagi";
+              Remove = [
+                "Bing"
+                "eBay"
+                "Google"
+              ];
+            };
+            SearchSuggestEnabled = true;
+            ShowHomeButton = false;
+            StartDownloadsInTempDirectory = true;
+            UserMessaging = {
+              WhatsNew = false;
+              ExtensionRecommendations = true;
+              FeatureRecommendations = false;
+              UrlbarInterventions = false;
+              SkipOnboarding = true;
+              MoreFromMozilla = false;
+              Locked = false;
+            };
+            UseSystemPrintDialog = true;
+          };
+        };
+      };
+}

--- a/nixos/_mixins/desktop/apps/workspace/default.nix
+++ b/nixos/_mixins/desktop/apps/workspace/default.nix
@@ -6,6 +6,10 @@
   ...
 }:
 let
+  # Set to "wavebox" or "zen" to select the productivity browser.
+  # The xdg-override URL routing and Slack wrapper follow this preference.
+  productivityBrowser = "zen";
+
   # Google Meet icon from Wikimedia Commons (public domain)
   googleMeetIcon = pkgs.writeText "google-meet.svg" ''
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 87.5 72">
@@ -19,6 +23,7 @@ let
   '';
 
   # Google Meet desktop entry for launching Meet in a separate Wavebox window.
+  # Wavebox only: uses a Chromium --app-id PWA flag with no Firefox equivalent.
   # Install the icon into hicolor so desktop launchers can find it by name.
   googleMeetDesktopItem = pkgs.symlinkJoin {
     name = "google-meet-desktop";
@@ -44,43 +49,43 @@ let
     '';
   };
 
-  # Wrap Slack to open all URLs in Wavebox
-  slackWavebox = inputs.xdg-override.lib.wrapPackage {
+  # Wrap Slack to open all URLs in the productivity browser.
+  slackProductivityBrowser = inputs.xdg-override.lib.wrapPackage {
     nameMatch = [
       {
         case = "^https?://";
-        command = "wavebox";
+        command = productivityBrowser;
       }
     ];
   } pkgs.slack;
 
-  # Global xdg-open proxy to route specific URLs to Wavebox
-  waveboxXdgOpen = inputs.xdg-override.lib.proxyPkg {
+  # Global xdg-open proxy to route auth/OAuth URLs to the productivity browser.
+  productivityBrowserXdgOpen = inputs.xdg-override.lib.proxyPkg {
     inherit pkgs;
     nameMatch = [
       {
         case = "^https?://accounts.google.com";
-        command = "wavebox";
+        command = productivityBrowser;
       }
       {
         case = "^https?://github.com/login/device";
-        command = "wavebox";
+        command = productivityBrowser;
       }
       {
         case = "^https?://auth.chainguard.dev/activate";
-        command = "wavebox";
+        command = productivityBrowser;
       }
       {
         case = "^https?://issuer.enforce.dev";
-        command = "wavebox";
+        command = productivityBrowser;
       }
       {
         case = "^https?://oauth2.sigstore.dev/auth";
-        command = "wavebox";
+        command = productivityBrowser;
       }
       {
         case = "^https?://auth.openai.com/oauth";
-        command = "wavebox";
+        command = productivityBrowser;
       }
     ];
   };
@@ -88,13 +93,18 @@ in
 lib.mkIf (noughtyLib.hostHasTag "workspace") {
   environment.systemPackages = [
     pkgs._1password-gui
+    slackProductivityBrowser
+    productivityBrowserXdgOpen
+  ]
+  ++ lib.optionals (productivityBrowser == "wavebox") [
     pkgs.wavebox
     googleMeetDesktopItem
-    slackWavebox
-    waveboxXdgOpen
+  ]
+  ++ lib.optionals (productivityBrowser == "zen") [
+    googleMeetDesktopItem
   ];
 
-  programs.wavebox = {
+  programs.wavebox = lib.mkIf (productivityBrowser == "wavebox") {
     enable = true;
     extensions = [
       "hdokiejnpimakedhajhdlcegeplioahd" # LastPass

--- a/nixos/_mixins/desktop/apps/workspace/default.nix
+++ b/nixos/_mixins/desktop/apps/workspace/default.nix
@@ -99,9 +99,6 @@ lib.mkIf (noughtyLib.hostHasTag "workspace") {
   ++ lib.optionals (productivityBrowser == "wavebox") [
     pkgs.wavebox
     googleMeetDesktopItem
-  ]
-  ++ lib.optionals (productivityBrowser == "zen") [
-    googleMeetDesktopItem
   ];
 
   programs.wavebox = lib.mkIf (productivityBrowser == "wavebox") {


### PR DESCRIPTION
- Add zen-browser-flake input (beta channel, nixpkgs and home-manager follows)
- Create home-manager workspace mixin with full Zen policy configuration:
  policies aligned to Firefox baseline, Kagi as default search engine, standard and workspace-specific extensions (1Password, GoLinks, Okta, Glean)
- Refactor nixos workspace mixin with productivityBrowser toggle ("wavebox"
  or "zen") so xdg-override URL routing and Slack wrapper follow the selection;
  wavebox package and programs.wavebox only activate when selected
- Move zen-browser Home Manager config from browsers/zen-browser/ into home-manager workspace mixin; remove now-redundant sub-mixin