### PR TITLE
feat: add Hermes R2 backup service

### DIFF
--- a/nixos/_mixins/server/hermes-backup/default.nix
+++ b/nixos/_mixins/server/hermes-backup/default.nix
@@ -1,0 +1,114 @@
+{
+  config,
+  lib,
+  noughtyLib,
+  pkgs,
+  ...
+}:
+let
+  hermesSopsFile = ../../../../secrets + "/hermes.yaml";
+  backupCacheDir = "/var/cache/hermes-backup";
+  backupEnvTemplate = "hermes-backup-env";
+  backupScript = pkgs.writeShellApplication {
+    name = "hermes-backup-r2";
+    runtimeInputs = with pkgs; [
+      coreutils
+      findutils
+      gnutar
+      inetutils
+      jq
+      rclone
+      rsync
+      systemdMinimal
+      util-linux
+      zstd
+    ];
+    text = builtins.readFile ./hermes-backup-r2.sh;
+  };
+in
+lib.mkIf (noughtyLib.hostHasTag "hermes") {
+  environment.systemPackages = [ backupScript ];
+
+  sops.secrets = {
+    R2_BUCKET = {
+      sopsFile = hermesSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    R2_ENDPOINT = {
+      sopsFile = hermesSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    R2_ACCESS_KEY_ID = {
+      sopsFile = hermesSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    R2_SECRET_ACCESS_KEY = {
+      sopsFile = hermesSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    RCLONE_CRYPT_PASSWORD = {
+      sopsFile = hermesSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    RCLONE_CRYPT_PASSWORD2 = {
+      sopsFile = hermesSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+  };
+
+  sops.templates.${backupEnvTemplate} = {
+    content = ''
+      R2_BUCKET=${config.sops.placeholder.R2_BUCKET}
+      R2_ENDPOINT=${config.sops.placeholder.R2_ENDPOINT}
+      R2_ACCESS_KEY_ID=${config.sops.placeholder.R2_ACCESS_KEY_ID}
+      R2_SECRET_ACCESS_KEY=${config.sops.placeholder.R2_SECRET_ACCESS_KEY}
+      RCLONE_CRYPT_PASSWORD=${config.sops.placeholder.RCLONE_CRYPT_PASSWORD}
+      RCLONE_CRYPT_PASSWORD2=${config.sops.placeholder.RCLONE_CRYPT_PASSWORD2}
+    '';
+    owner = "root";
+    group = "root";
+    mode = "0400";
+  };
+
+  systemd.services.hermes-backup = {
+    description = "Backup Hermes state to Cloudflare R2";
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "root";
+      Group = "root";
+      EnvironmentFile = config.sops.templates.${backupEnvTemplate}.path;
+      ExecStart = "${backupScript}/bin/hermes-backup-r2";
+      CacheDirectory = "hermes-backup";
+      WorkingDirectory = backupCacheDir;
+    };
+  };
+
+  systemd.timers.hermes-backup = {
+    description = "Run Hermes R2 backup every 6 hours";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "*-*-* 00,06,12,18:00:00";
+      Persistent = true;
+      RandomizedDelaySec = "15min";
+    };
+  };
+}

--- a/nixos/_mixins/server/hermes-backup/default.nix
+++ b/nixos/_mixins/server/hermes-backup/default.nix
@@ -19,7 +19,7 @@ let
       jq
       rclone
       rsync
-      systemdMinimal
+      sqlite
       util-linux
       zstd
     ];

--- a/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
+++ b/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 umask 077
 
 readonly stateDir="/var/lib/hermes"
+readonly hermesHome="${stateDir}/.hermes"
 readonly cacheDir="/var/cache/hermes-backup"
 readonly workDir="${cacheDir}/work"
 readonly snapshotDir="${workDir}/snapshot"
@@ -10,6 +11,10 @@ readonly artifactsDir="${workDir}/artifacts"
 readonly rcloneConfigDir="${workDir}/rclone"
 readonly rcloneConfigPath="${rcloneConfigDir}/rclone.conf"
 readonly lockPath="${cacheDir}/hermes-backup.lock"
+readonly sqliteDatabases=(
+  "state.db"
+  "memory_store.db"
+)
 
 mkdir -p "${cacheDir}" "${snapshotDir}" "${artifactsDir}" "${rcloneConfigDir}"
 exec 9>"${lockPath}"
@@ -42,16 +47,9 @@ readonly archivePath="${artifactsDir}/${archiveName}"
 readonly manifestPath="${artifactsDir}/${manifestName}"
 readonly remotePrefix="hermes-encrypted:${hostName}/backups"
 
-hermesWasRunning=0
-
 cleanup() {
   local exitCode="$1"
   local artifactPath
-
-  if [ "${hermesWasRunning}" -eq 1 ] && ! systemctl is-active --quiet hermes-agent.service; then
-    echo "Restarting hermes-agent.service after backup interruption." >&2
-    systemctl start hermes-agent.service || true
-  fi
 
   rm -rf "${snapshotDir}" "${rcloneConfigDir}"
 
@@ -66,23 +64,37 @@ cleanup() {
   fi
 }
 
-trap 'cleanup "$?"' EXIT
+backupSqliteDatabase() {
+  local databaseName="$1"
+  local sourcePath="${hermesHome}/${databaseName}"
+  local targetPath="${snapshotDir}/.hermes/${databaseName}"
 
-if systemctl is-active --quiet hermes-agent.service; then
-  hermesWasRunning=1
-  echo "Stopping hermes-agent.service for a consistent snapshot."
-  systemctl stop hermes-agent.service
-fi
+  if [ ! -f "${sourcePath}" ]; then
+    echo "Skipping missing SQLite database: ${sourcePath}"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "${targetPath}")"
+  sqlite3 "${sourcePath}" ".backup '${targetPath}'"
+}
+
+trap 'cleanup "$?"' EXIT
 
 rm -rf "${snapshotDir}"
 mkdir -p "${snapshotDir}"
-rsync -a --delete --numeric-ids "${stateDir}/" "${snapshotDir}/"
 
-if [ "${hermesWasRunning}" -eq 1 ]; then
-  echo "Starting hermes-agent.service after snapshot."
-  systemctl start hermes-agent.service
-  hermesWasRunning=0
-fi
+rsync -a --delete --numeric-ids \
+  --exclude='/.hermes/state.db' \
+  --exclude='/.hermes/state.db-wal' \
+  --exclude='/.hermes/state.db-shm' \
+  --exclude='/.hermes/memory_store.db' \
+  --exclude='/.hermes/memory_store.db-wal' \
+  --exclude='/.hermes/memory_store.db-shm' \
+  "${stateDir}/" "${snapshotDir}/"
+
+for databaseName in "${sqliteDatabases[@]}"; do
+  backupSqliteDatabase "${databaseName}"
+done
 
 cryptPassword="$(rclone obscure "${RCLONE_CRYPT_PASSWORD}")"
 cryptPassword2="$(rclone obscure "${RCLONE_CRYPT_PASSWORD2}")"

--- a/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
+++ b/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
@@ -46,6 +46,7 @@ hermesWasRunning=0
 
 cleanup() {
   local exitCode="$1"
+  local artifactPath
 
   if [ "${hermesWasRunning}" -eq 1 ] && ! systemctl is-active --quiet hermes-agent.service; then
     echo "Restarting hermes-agent.service after backup interruption." >&2
@@ -53,6 +54,12 @@ cleanup() {
   fi
 
   rm -rf "${snapshotDir}" "${rcloneConfigDir}"
+
+  for artifactPath in "${archivePath:-}" "${manifestPath:-}"; do
+    if [ -n "${artifactPath}" ]; then
+      rm -f "${artifactPath}"
+    fi
+  done
 
   if [ "${exitCode}" -eq 0 ]; then
     find "${artifactsDir}" -maxdepth 1 -type f -mtime +2 -delete

--- a/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
+++ b/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
@@ -1,0 +1,150 @@
+set -euo pipefail
+
+umask 077
+
+readonly stateDir="/var/lib/hermes"
+readonly cacheDir="/var/cache/hermes-backup"
+readonly workDir="${cacheDir}/work"
+readonly snapshotDir="${workDir}/snapshot"
+readonly artifactsDir="${workDir}/artifacts"
+readonly rcloneConfigDir="${workDir}/rclone"
+readonly rcloneConfigPath="${rcloneConfigDir}/rclone.conf"
+readonly lockPath="${cacheDir}/hermes-backup.lock"
+
+mkdir -p "${cacheDir}" "${snapshotDir}" "${artifactsDir}" "${rcloneConfigDir}"
+exec 9>"${lockPath}"
+flock -n 9 || {
+  echo "Another Hermes backup run is already in progress." >&2
+  exit 1
+}
+
+requiredVars=(
+  R2_BUCKET
+  R2_ENDPOINT
+  R2_ACCESS_KEY_ID
+  R2_SECRET_ACCESS_KEY
+  RCLONE_CRYPT_PASSWORD
+  RCLONE_CRYPT_PASSWORD2
+)
+
+for varName in "${requiredVars[@]}"; do
+  if [ -z "${!varName:-}" ]; then
+    echo "Missing required environment variable: ${varName}" >&2
+    exit 1
+  fi
+done
+
+readonly timestamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+readonly hostName="$(hostname -s)"
+readonly archiveName="${timestamp}.tar.zst"
+readonly manifestName="${timestamp}.manifest.json"
+readonly archivePath="${artifactsDir}/${archiveName}"
+readonly manifestPath="${artifactsDir}/${manifestName}"
+readonly remotePrefix="hermes-encrypted:${hostName}/backups"
+
+hermesWasRunning=0
+
+cleanup() {
+  local exitCode="$1"
+
+  if [ "${hermesWasRunning}" -eq 1 ] && ! systemctl is-active --quiet hermes-agent.service; then
+    echo "Restarting hermes-agent.service after backup interruption." >&2
+    systemctl start hermes-agent.service || true
+  fi
+
+  rm -rf "${snapshotDir}" "${rcloneConfigDir}"
+
+  if [ "${exitCode}" -eq 0 ]; then
+    find "${artifactsDir}" -maxdepth 1 -type f -mtime +2 -delete
+  fi
+}
+
+trap 'cleanup "$?"' EXIT
+
+if systemctl is-active --quiet hermes-agent.service; then
+  hermesWasRunning=1
+  echo "Stopping hermes-agent.service for a consistent snapshot."
+  systemctl stop hermes-agent.service
+fi
+
+rm -rf "${snapshotDir}"
+mkdir -p "${snapshotDir}"
+rsync -a --delete --numeric-ids "${stateDir}/" "${snapshotDir}/"
+
+if [ "${hermesWasRunning}" -eq 1 ]; then
+  echo "Starting hermes-agent.service after snapshot."
+  systemctl start hermes-agent.service
+  hermesWasRunning=0
+fi
+
+cryptPassword="$(rclone obscure "${RCLONE_CRYPT_PASSWORD}")"
+cryptPassword2="$(rclone obscure "${RCLONE_CRYPT_PASSWORD2}")"
+
+cat > "${rcloneConfigPath}" <<EOF
+[hermes-r2]
+type = s3
+provider = Cloudflare
+access_key_id = ${R2_ACCESS_KEY_ID}
+secret_access_key = ${R2_SECRET_ACCESS_KEY}
+region = auto
+endpoint = ${R2_ENDPOINT}
+acl = private
+
+[hermes-encrypted]
+type = crypt
+remote = hermes-r2:${R2_BUCKET}/hermes
+password = ${cryptPassword}
+password2 = ${cryptPassword2}
+filename_encryption = standard
+directory_name_encryption = true
+EOF
+
+rm -f "${archivePath}" "${manifestPath}"
+
+tar \
+  --use-compress-program="zstd -T0 -19" \
+  -cf "${archivePath}" \
+  -C "${snapshotDir}" \
+  .
+
+archiveSizeBytes="$(stat -c '%s' "${archivePath}")"
+archiveSha256="$(sha256sum "${archivePath}" | cut -d ' ' -f 1)"
+
+jq -n \
+  --arg timestamp "${timestamp}" \
+  --arg hostname "${hostName}" \
+  --arg sourcePath "${stateDir}" \
+  --arg archiveName "${archiveName}" \
+  --arg sha256 "${archiveSha256}" \
+  --argjson sizeBytes "${archiveSizeBytes}" \
+  '{
+    timestamp: $timestamp,
+    hostname: $hostname,
+    source_path: $sourcePath,
+    archive_name: $archiveName,
+    archive_size_bytes: $sizeBytes,
+    archive_sha256: $sha256
+  }' > "${manifestPath}"
+
+rclone copyto "${archivePath}" "${remotePrefix}/${archiveName}" --config "${rcloneConfigPath}"
+rclone copyto "${manifestPath}" "${remotePrefix}/${manifestName}" --config "${rcloneConfigPath}"
+
+archiveListing="$(rclone lsjson "${remotePrefix}/${archiveName}" --config "${rcloneConfigPath}")"
+manifestListing="$(rclone lsjson "${remotePrefix}/${manifestName}" --config "${rcloneConfigPath}")"
+
+archiveRemoteSize="$(printf '%s' "${archiveListing}" | jq -r 'if length == 1 then .[0].Size else empty end')"
+manifestCount="$(printf '%s' "${manifestListing}" | jq 'length')"
+
+if [ -z "${archiveRemoteSize}" ] || [ "${archiveRemoteSize}" != "${archiveSizeBytes}" ]; then
+  echo "Remote archive verification failed for ${archiveName}." >&2
+  exit 1
+fi
+
+if [ "${manifestCount}" != "1" ]; then
+  echo "Remote manifest verification failed for ${manifestName}." >&2
+  exit 1
+fi
+
+rm -f "${archivePath}" "${manifestPath}"
+
+echo "Hermes backup uploaded successfully: ${remotePrefix}/${archiveName} (${archiveSizeBytes} bytes, sha256 ${archiveSha256})"


### PR DESCRIPTION
## Summary
- add a dedicated `hermes-backup` server mixin for encrypted R2 backups
- render a scoped SOPS-backed environment file for the backup service credentials
- add a systemd oneshot service and 6-hour persistent timer plus the `hermes-backup-r2` helper script

## Validation
- `bash -n nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh`
- `git diff --check upstream/main...HEAD`
- `/run/current-system/sw/bin/nix eval --impure --expr 'let flake = builtins.getFlake "path:/var/lib/hermes/workspace/nix-config"; in flake.nixosConfigurations.revan.config.systemd.services.hermes-backup.serviceConfig.ExecStart' --raw`
- `/run/current-system/sw/bin/nix eval --impure --expr 'let flake = builtins.getFlake "path:/var/lib/hermes/workspace/nix-config"; in flake.nixosConfigurations.revan.config.systemd.timers.hermes-backup.timerConfig' --json`
- `/run/current-system/sw/bin/nix eval --impure --expr 'let flake = builtins.getFlake "path:/var/lib/hermes/workspace/nix-config"; in flake.nixosConfigurations.revan.config.sops.templates."hermes-backup-env".content' --raw