### PR TITLE
feat(hermes-backup): add verification and restore helpers

### DIFF
--- a/nixos/_mixins/server/hermes-backup/README.md
+++ b/nixos/_mixins/server/hermes-backup/README.md
@@ -1,0 +1,38 @@
+# Hermes Cloudflare R2 backup scripts
+
+This mixin installs three root-oriented helper commands on Hermes-tagged hosts:
+
+- `hermes-backup-r2` creates and uploads an encrypted backup archive and manifest.
+- `hermes-backup-verify-r2` downloads a backup archive and manifest, then verifies the manifest metadata, archive hash, archive size, and archive structure.
+- `hermes-restore-r2` restores a chosen backup into an explicit destination directory.
+
+## Usage
+
+Run the commands as `root` so they can read the rendered SOPS environment file and the Hermes state data.
+
+```bash
+sudo hermes-backup-r2
+sudo hermes-backup-verify-r2
+sudo hermes-backup-verify-r2 2026-04-21T00-00-00Z
+sudo hermes-restore-r2 2026-04-21T00-00-00Z /var/tmp/hermes-restore/2026-04-21T00-00-00Z
+```
+
+The verification command accepts either a full archive name such as `2026-04-21T00-00-00Z.tar.zst` or just the timestamp prefix. With no argument it verifies the latest complete backup for the current host.
+
+The restore command always requires two arguments:
+
+1. The backup timestamp or archive name to restore.
+2. The absolute destination path to extract into.
+
+## Restore safety checks
+
+The restore flow refuses:
+
+- missing destination arguments
+- relative destination paths
+- `/`, `/var`, `/var/lib`, or `/var/lib/hermes`
+- any destination nested under `/var/lib/hermes`
+- symbolic-link destinations
+- existing non-empty destination directories
+
+Restores are therefore forced into an explicit, separate target path instead of overwriting the live Hermes state in place.

--- a/nixos/_mixins/server/hermes-backup/default.nix
+++ b/nixos/_mixins/server/hermes-backup/default.nix
@@ -9,25 +9,41 @@ let
   hermesSopsFile = ../../../../secrets + "/hermes.yaml";
   backupCacheDir = "/var/cache/hermes-backup";
   backupEnvTemplate = "hermes-backup-env";
-  backupScript = pkgs.writeShellApplication {
-    name = "hermes-backup-r2";
-    runtimeInputs = with pkgs; [
-      coreutils
-      findutils
-      gnutar
-      inetutils
-      jq
-      rclone
-      rsync
-      sqlite
-      util-linux
-      zstd
-    ];
-    text = builtins.readFile ./hermes-backup-r2.sh;
-  };
+  backupRuntimeInputs = with pkgs; [
+    coreutils
+    findutils
+    gnugrep
+    gnutar
+    inetutils
+    jq
+    python3
+    rclone
+    rsync
+    sqlite
+    util-linux
+    zstd
+  ];
+  mkHermesBackupScript =
+    name: scriptFile:
+    pkgs.writeShellApplication {
+      inherit name;
+      runtimeInputs = backupRuntimeInputs;
+      text = ''
+        export HERMES_BACKUP_ENV_FILE="${config.sops.templates.${backupEnvTemplate}.path}"
+        ${builtins.readFile ./hermes-backup-common.sh}
+        ${builtins.readFile scriptFile}
+      '';
+    };
+  backupScript = mkHermesBackupScript "hermes-backup-r2" ./hermes-backup-r2.sh;
+  verifyScript = mkHermesBackupScript "hermes-backup-verify-r2" ./hermes-backup-verify-r2.sh;
+  restoreScript = mkHermesBackupScript "hermes-restore-r2" ./hermes-restore-r2.sh;
 in
 lib.mkIf (noughtyLib.hostHasTag "hermes") {
-  environment.systemPackages = [ backupScript ];
+  environment.systemPackages = [
+    backupScript
+    verifyScript
+    restoreScript
+  ];
 
   sops.secrets = {
     R2_BUCKET = {
@@ -58,14 +74,14 @@ lib.mkIf (noughtyLib.hostHasTag "hermes") {
       mode = "0400";
     };
 
-    BACKUP_CRYPT_PASSWORD = {
+    RCLONE_CRYPT_PASSWORD = {
       sopsFile = hermesSopsFile;
       owner = "root";
       group = "root";
       mode = "0400";
     };
 
-    BACKUP_CRYPT_PASSWORD2 = {
+    RCLONE_CRYPT_PASSWORD2 = {
       sopsFile = hermesSopsFile;
       owner = "root";
       group = "root";
@@ -75,12 +91,12 @@ lib.mkIf (noughtyLib.hostHasTag "hermes") {
 
   sops.templates.${backupEnvTemplate} = {
     content = ''
-      R2_BUCKET=${config.sops.placeholder.R2_BUCKET}
-      R2_ENDPOINT=${config.sops.placeholder.R2_ENDPOINT}
-      R2_ACCESS_KEY_ID=${config.sops.placeholder.R2_ACCESS_KEY_ID}
-      R2_SECRET_ACCESS_KEY=${config.sops.placeholder.R2_SECRET_ACCESS_KEY}
-      BACKUP_CRYPT_PASSWORD=${config.sops.placeholder.BACKUP_CRYPT_PASSWORD}
-      BACKUP_CRYPT_PASSWORD2=${config.sops.placeholder.BACKUP_CRYPT_PASSWORD2}
+      R2_BUCKET_FILE=${config.sops.secrets.R2_BUCKET.path}
+      R2_ENDPOINT_FILE=${config.sops.secrets.R2_ENDPOINT.path}
+      R2_ACCESS_KEY_ID_FILE=${config.sops.secrets.R2_ACCESS_KEY_ID.path}
+      R2_SECRET_ACCESS_KEY_FILE=${config.sops.secrets.R2_SECRET_ACCESS_KEY.path}
+      BACKUP_CRYPT_PASSWORD_FILE=${config.sops.secrets.RCLONE_CRYPT_PASSWORD.path}
+      BACKUP_CRYPT_PASSWORD2_FILE=${config.sops.secrets.RCLONE_CRYPT_PASSWORD2.path}
     '';
     owner = "root";
     group = "root";

--- a/nixos/_mixins/server/hermes-backup/hermes-backup-common.sh
+++ b/nixos/_mixins/server/hermes-backup/hermes-backup-common.sh
@@ -1,0 +1,465 @@
+readonly stateDir="/var/lib/hermes"
+readonly hermesHome="${stateDir}/.hermes"
+readonly cacheDir="/var/cache/hermes-backup"
+readonly workDir="${cacheDir}/work"
+readonly snapshotDir="${workDir}/snapshot"
+readonly artifactsDir="${workDir}/artifacts"
+rcloneConfigDir=""
+rcloneConfigPath=""
+readonly lockPath="${cacheDir}/hermes-backup.lock"
+readonly archiveExtension=".tar.zst"
+readonly manifestSuffix=".manifest.json"
+readonly sqliteDatabases=(
+  "state.db"
+  "memory_store.db"
+)
+
+logPhase() {
+  printf '[hermes-backup] %s\n' "$*" >&2
+}
+
+die() {
+  printf '[hermes-backup] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+ensureCacheDirectories() {
+  mkdir -p "${cacheDir}" "${workDir}" "${artifactsDir}"
+}
+
+cleanupRcloneConfig() {
+  if [ -n "${rcloneConfigDir}" ]; then
+    rm -rf "${rcloneConfigDir}"
+  fi
+
+  rcloneConfigDir=""
+  rcloneConfigPath=""
+}
+
+acquireBackupLock() {
+  exec 9>"${lockPath}"
+  flock -n 9 || die "Another Hermes backup run is already in progress."
+}
+
+loadEnvVarFromFile() {
+  local varName="$1"
+  local fileVarName="${varName}_FILE"
+  local filePath="${!fileVarName:-}"
+
+  if [ -n "${!varName:-}" ] || [ -z "${filePath}" ]; then
+    return 0
+  fi
+
+  if [ ! -r "${filePath}" ]; then
+    die "Missing readable environment file for ${varName}: ${filePath}"
+  fi
+
+  export "${varName}=$(<"${filePath}")"
+}
+
+loadBackupEnvironment() {
+  if [ -n "${HERMES_BACKUP_ENV_FILE:-}" ] && [ -r "${HERMES_BACKUP_ENV_FILE}" ]; then
+    # shellcheck disable=SC1090
+    set -a
+    . "${HERMES_BACKUP_ENV_FILE}"
+    set +a
+  fi
+
+  loadEnvVarFromFile R2_BUCKET
+  loadEnvVarFromFile R2_ENDPOINT
+  loadEnvVarFromFile R2_ACCESS_KEY_ID
+  loadEnvVarFromFile R2_SECRET_ACCESS_KEY
+  loadEnvVarFromFile BACKUP_CRYPT_PASSWORD
+  loadEnvVarFromFile BACKUP_CRYPT_PASSWORD2
+
+  if [ -z "${BACKUP_CRYPT_PASSWORD:-}" ] && [ -n "${RCLONE_CRYPT_PASSWORD:-}" ]; then
+    export BACKUP_CRYPT_PASSWORD="${RCLONE_CRYPT_PASSWORD}"
+  fi
+
+  if [ -z "${BACKUP_CRYPT_PASSWORD2:-}" ] && [ -n "${RCLONE_CRYPT_PASSWORD2:-}" ]; then
+    export BACKUP_CRYPT_PASSWORD2="${RCLONE_CRYPT_PASSWORD2}"
+  fi
+
+  requiredVars=(
+    R2_BUCKET
+    R2_ENDPOINT
+    R2_ACCESS_KEY_ID
+    R2_SECRET_ACCESS_KEY
+    BACKUP_CRYPT_PASSWORD
+    BACKUP_CRYPT_PASSWORD2
+  )
+
+  for varName in "${requiredVars[@]}"; do
+    if [ -z "${!varName:-}" ]; then
+      die "Missing required environment variable: ${varName}"
+    fi
+  done
+}
+
+currentHostName() {
+  hostname -s
+}
+
+timestampNowUtc() {
+  date -u +%Y-%m-%dT%H-%M-%SZ
+}
+
+archiveNameFromTimestamp() {
+  printf '%s%s\n' "$1" "${archiveExtension}"
+}
+
+manifestNameFromArchive() {
+  local archiveName="$1"
+
+  case "${archiveName}" in
+    *"${archiveExtension}")
+      printf '%s%s\n' "${archiveName%${archiveExtension}}" "${manifestSuffix}"
+      ;;
+    *)
+      die "Backup name must end with ${archiveExtension}: ${archiveName}"
+      ;;
+  esac
+}
+
+normaliseArchiveSelection() {
+  local selection="${1:-}"
+
+  if [ -z "${selection}" ]; then
+    die "A backup timestamp or archive name is required."
+  fi
+
+  case "${selection}" in
+    *"${archiveExtension}")
+      printf '%s\n' "${selection}"
+      ;;
+    *"${manifestSuffix}")
+      die "Pass the backup archive name or timestamp, not the manifest name: ${selection}"
+      ;;
+    *)
+      printf '%s%s\n' "${selection}" "${archiveExtension}"
+      ;;
+  esac
+}
+
+remotePrefix() {
+  printf 'hermes-encrypted:%s/backups\n' "$(currentHostName)"
+}
+
+remoteArchivePath() {
+  printf '%s/%s\n' "$(remotePrefix)" "$1"
+}
+
+remoteManifestPath() {
+  printf '%s/%s\n' "$(remotePrefix)" "$(manifestNameFromArchive "$1")"
+}
+
+createRcloneConfig() {
+  local cryptPassword cryptPassword2
+
+  rcloneConfigDir="$(mktemp -d "${workDir}/rclone.XXXXXX")"
+  rcloneConfigPath="${rcloneConfigDir}/rclone.conf"
+
+  cryptPassword="$(printf '%s\n' "${BACKUP_CRYPT_PASSWORD}" | rclone obscure -)"
+  cryptPassword2="$(printf '%s\n' "${BACKUP_CRYPT_PASSWORD2}" | rclone obscure -)"
+
+  cat > "${rcloneConfigPath}" <<EOF
+[hermes-r2]
+type = s3
+provider = Cloudflare
+access_key_id = ${R2_ACCESS_KEY_ID}
+secret_access_key = ${R2_SECRET_ACCESS_KEY}
+region = auto
+endpoint = ${R2_ENDPOINT}
+acl = private
+no_check_bucket = true
+
+[hermes-encrypted]
+type = crypt
+remote = hermes-r2:${R2_BUCKET}/hermes
+password = ${cryptPassword}
+password2 = ${cryptPassword2}
+filename_encryption = standard
+directory_name_encryption = true
+EOF
+}
+
+remoteObjectCount() {
+  rclone lsjson "$1" --config "${rcloneConfigPath}" | jq 'length'
+}
+
+remoteObjectSize() {
+  rclone lsjson "$1" --config "${rcloneConfigPath}" | jq -r 'if length == 1 then .[0].Size else empty end'
+}
+
+listRemoteBackupArchives() {
+  rclone lsf "$(remotePrefix)" --config "${rcloneConfigPath}" --files-only \
+    | grep -E '\.tar\.zst$' \
+    || true
+}
+
+listRemoteBackupManifests() {
+  rclone lsf "$(remotePrefix)" --config "${rcloneConfigPath}" --files-only \
+    | grep -E '\.manifest\.json$' \
+    || true
+}
+
+selectLatestArchiveName() {
+  local manifestName
+
+  manifestName="$(listRemoteBackupManifests | sort | tail -n 1)"
+  if [ -z "${manifestName}" ]; then
+    die "No complete Hermes backups were found under $(remotePrefix)."
+  fi
+
+  printf '%s%s\n' "${manifestName%${manifestSuffix}}" "${archiveExtension}"
+}
+
+downloadBackupPair() {
+  local archiveName="$1"
+  local downloadDir="$2"
+  local archivePath="${downloadDir}/${archiveName}"
+  local manifestPath="${downloadDir}/$(manifestNameFromArchive "${archiveName}")"
+
+  mkdir -p "${downloadDir}"
+
+  rclone copyto \
+    "$(remoteArchivePath "${archiveName}")" \
+    "${archivePath}" \
+    --config "${rcloneConfigPath}"
+
+  rclone copyto \
+    "$(remoteManifestPath "${archiveName}")" \
+    "${manifestPath}" \
+    --config "${rcloneConfigPath}"
+
+  printf '%s\n%s\n' "${archivePath}" "${manifestPath}"
+}
+
+verifyRemoteBackupPair() {
+  local archiveName="$1"
+  local manifestName remoteArchiveSize manifestCount
+
+  manifestName="$(manifestNameFromArchive "${archiveName}")"
+  remoteArchiveSize="$(remoteObjectSize "$(remoteArchivePath "${archiveName}")")"
+  manifestCount="$(remoteObjectCount "$(remoteManifestPath "${archiveName}")")"
+
+  if [ -z "${remoteArchiveSize}" ]; then
+    die "Remote archive verification failed for ${archiveName}."
+  fi
+
+  if [ "${manifestCount}" != "1" ]; then
+    die "Remote manifest verification failed for ${manifestName}."
+  fi
+
+  printf '%s\n' "${remoteArchiveSize}"
+}
+
+verifyBackupArchive() {
+  local archiveName="$1"
+  local archivePath="$2"
+  local manifestPath="$3"
+  local expectedHost="$4"
+  local manifestArchiveName manifestHost manifestSha256 manifestSizeBytes actualSizeBytes actualSha256
+
+  manifestArchiveName="$(jq -r '.archive_name // empty' "${manifestPath}")"
+  manifestHost="$(jq -r '.hostname // empty' "${manifestPath}")"
+  manifestSha256="$(jq -r '.archive_sha256 // empty' "${manifestPath}")"
+  manifestSizeBytes="$(jq -r '.archive_size_bytes // empty' "${manifestPath}")"
+
+  [ -n "${manifestArchiveName}" ] || die "Backup manifest is missing archive_name."
+  [ -n "${manifestHost}" ] || die "Backup manifest is missing hostname."
+  [ -n "${manifestSha256}" ] || die "Backup manifest is missing archive_sha256."
+  [ -n "${manifestSizeBytes}" ] || die "Backup manifest is missing archive_size_bytes."
+
+  if [ "${manifestArchiveName}" != "${archiveName}" ]; then
+    die "Backup manifest archive_name does not match ${archiveName}."
+  fi
+
+  if [ "${manifestHost}" != "${expectedHost}" ]; then
+    die "Backup manifest hostname ${manifestHost} does not match ${expectedHost}."
+  fi
+
+  if ! [[ "${manifestSha256}" =~ ^[0-9a-f]{64}$ ]]; then
+    die "Backup manifest archive_sha256 is not a valid SHA-256 digest."
+  fi
+
+  if ! [[ "${manifestSizeBytes}" =~ ^[0-9]+$ ]]; then
+    die "Backup manifest archive_size_bytes is not an integer."
+  fi
+
+  actualSizeBytes="$(stat -c '%s' "${archivePath}")"
+  actualSha256="$(sha256sum "${archivePath}" | cut -d ' ' -f 1)"
+
+  if [ "${manifestSizeBytes}" != "${actualSizeBytes}" ]; then
+    die "Archive size mismatch for ${archiveName}: manifest=${manifestSizeBytes}, actual=${actualSizeBytes}."
+  fi
+
+  if [ "${manifestSha256}" != "${actualSha256}" ]; then
+    die "Archive SHA-256 mismatch for ${archiveName}."
+  fi
+
+  processBackupArchive verify "${archivePath}"
+}
+
+processBackupArchive() {
+  local mode="$1"
+  local archivePath="$2"
+  local destinationPath="${3:-}"
+
+  if [ "${mode}" = "extract" ] && [ -z "${destinationPath}" ]; then
+    die "Archive extraction requires a destination path."
+  fi
+
+  python3 - "${mode}" "${archivePath}" "${destinationPath}" <<'PY'
+import os
+import pathlib
+import posixpath
+import shutil
+import subprocess
+import sys
+import tarfile
+
+mode = sys.argv[1]
+archive_path = sys.argv[2]
+destination_path = os.path.realpath(sys.argv[3]) if mode == "extract" and sys.argv[3] else None
+found_hermes = False
+deferred_directories = []
+pending_error = None
+proc = subprocess.Popen(["zstd", "-d", "-q", "-c", archive_path], stdout=subprocess.PIPE)
+
+try:
+    assert proc.stdout is not None
+    with tarfile.open(fileobj=proc.stdout, mode="r|") as archive:
+        for member in archive:
+            name = member.name
+            if name in {"", "."}:
+                continue
+
+            normalised = posixpath.normpath(name)
+            parts = [part for part in pathlib.PurePosixPath(normalised).parts if part not in {"", "."}]
+
+            if name.startswith("/") or normalised == ".." or any(part == ".." for part in parts):
+                raise SystemExit(f"Unsafe archive path: {name}")
+
+            if member.issym() or member.islnk():
+                raise SystemExit(f"Refusing archive link entry: {name}")
+
+            if member.ischr() or member.isblk() or member.isfifo():
+                raise SystemExit(f"Refusing special archive entry: {name}")
+
+            if parts and parts[0] == ".hermes":
+                found_hermes = True
+
+            if mode != "extract":
+                continue
+
+            relative_path = os.path.join(*parts) if parts else ""
+            target_path = os.path.realpath(os.path.join(destination_path, relative_path)) if relative_path else destination_path
+
+            if target_path != destination_path and not target_path.startswith(destination_path + os.sep):
+                raise SystemExit(f"Archive entry escapes destination: {name}")
+
+            if member.isdir():
+                os.makedirs(target_path, exist_ok=True)
+                deferred_directories.append((target_path, member.mode & 0o777, member.mtime))
+                continue
+
+            if not member.isfile():
+                raise SystemExit(f"Unsupported archive entry: {name}")
+
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
+            source = archive.extractfile(member)
+            if source is None:
+                raise SystemExit(f"Unable to read archive entry: {name}")
+
+            with source, open(target_path, "wb") as destination:
+                shutil.copyfileobj(source, destination)
+
+            os.chmod(target_path, member.mode & 0o777)
+            os.utime(target_path, (member.mtime, member.mtime), follow_symlinks=False)
+
+    for target_path, mode_bits, mtime in reversed(deferred_directories):
+        os.chmod(target_path, mode_bits)
+        os.utime(target_path, (mtime, mtime), follow_symlinks=False)
+except BaseException as error:
+    pending_error = error
+    raise
+finally:
+    if proc.stdout is not None:
+        proc.stdout.close()
+    exit_code = proc.wait()
+    if exit_code != 0 and pending_error is None:
+        action = "extracting" if mode == "extract" else "reading"
+        raise SystemExit(f"zstd failed while {action} {archive_path}: exit code {exit_code}")
+
+if not found_hermes:
+    raise SystemExit("Archive does not contain the expected .hermes data.")
+PY
+}
+
+prepareRestoreDestination() {
+  local requestedPath="$1"
+  local resolvedPath resolvedParent statePath
+
+  if [ -z "${requestedPath}" ]; then
+    die "A destination path argument is required."
+  fi
+
+  case "${requestedPath}" in
+    /*) ;;
+    *)
+      die "Destination path must be absolute to avoid ambiguous restores: ${requestedPath}"
+      ;;
+  esac
+
+  resolvedPath="$(realpath -m "${requestedPath}")"
+  resolvedParent="$(dirname "${resolvedPath}")"
+  statePath="$(realpath -m "${stateDir}")"
+
+  case "${resolvedPath}" in
+    /|/var|/var/lib)
+      die "Refusing to restore into a dangerous top-level path: ${resolvedPath}"
+      ;;
+  esac
+
+  if [ ! -d "${resolvedParent}" ]; then
+    die "Destination parent directory does not exist: ${resolvedParent}"
+  fi
+
+  case "${resolvedPath}" in
+    "${statePath}"|"${statePath}"/*)
+      die "Refusing to restore into the live Hermes state path: ${resolvedPath}"
+      ;;
+  esac
+
+  case "$(realpath -m "${resolvedParent}")" in
+    "${statePath}"|"${statePath}"/*)
+      die "Refusing to restore beneath the live Hermes state path: ${resolvedParent}"
+      ;;
+  esac
+
+  if [ -L "${requestedPath}" ] || [ -L "${resolvedPath}" ]; then
+    die "Destination path must not be a symbolic link: ${requestedPath}"
+  fi
+
+  if [ -e "${resolvedPath}" ]; then
+    if [ ! -d "${resolvedPath}" ]; then
+      die "Destination exists and is not a directory: ${resolvedPath}"
+    fi
+
+    if [ -n "$(find "${resolvedPath}" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+      die "Destination directory must be empty before restore: ${resolvedPath}"
+    fi
+  else
+    mkdir -p "${resolvedPath}"
+  fi
+
+  printf '%s\n' "${resolvedPath}"
+}
+
+extractBackupArchive() {
+  local archivePath="$1"
+  local destinationPath="$2"
+
+  processBackupArchive extract "${archivePath}" "${destinationPath}"
+}

--- a/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
+++ b/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
@@ -2,65 +2,27 @@ set -euo pipefail
 
 umask 077
 
-readonly stateDir="/var/lib/hermes"
-readonly hermesHome="${stateDir}/.hermes"
-readonly cacheDir="/var/cache/hermes-backup"
-readonly workDir="${cacheDir}/work"
-readonly snapshotDir="${workDir}/snapshot"
-readonly artifactsDir="${workDir}/artifacts"
-readonly rcloneConfigDir="${workDir}/rclone"
-readonly rcloneConfigPath="${rcloneConfigDir}/rclone.conf"
-readonly lockPath="${cacheDir}/hermes-backup.lock"
-readonly sqliteDatabases=(
-  "state.db"
-  "memory_store.db"
-)
+loadBackupEnvironment
+ensureCacheDirectories
+acquireBackupLock
 
-mkdir -p "${cacheDir}" "${snapshotDir}" "${artifactsDir}" "${rcloneConfigDir}"
-exec 9>"${lockPath}"
-flock -n 9 || {
-  echo "Another Hermes backup run is already in progress." >&2
-  exit 1
-}
-
-requiredVars=(
-  R2_BUCKET
-  R2_ENDPOINT
-  R2_ACCESS_KEY_ID
-  R2_SECRET_ACCESS_KEY
-  BACKUP_CRYPT_PASSWORD
-  BACKUP_CRYPT_PASSWORD2
-)
-
-for varName in "${requiredVars[@]}"; do
-  if [ -z "${!varName:-}" ]; then
-    echo "Missing required environment variable: ${varName}" >&2
-    exit 1
-  fi
-done
-
-echo "Starting Hermes backup run."
-
-timestamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
-readonly timestamp
-hostName="$(hostname -s)"
-readonly hostName
-readonly archiveName="${timestamp}.tar.zst"
-readonly manifestName="${timestamp}.manifest.json"
+readonly timestamp="$(timestampNowUtc)"
+readonly hostName="$(currentHostName)"
+readonly archiveName="$(archiveNameFromTimestamp "${timestamp}")"
+readonly manifestName="$(manifestNameFromArchive "${archiveName}")"
 readonly archivePath="${artifactsDir}/${archiveName}"
 readonly manifestPath="${artifactsDir}/${manifestName}"
-readonly remotePrefix="hermes-encrypted:${hostName}/backups"
+readonly remoteBackupPrefix="$(remotePrefix)"
 
 cleanup() {
   local exitCode="$1"
   local artifactPath
 
-  rm -rf "${snapshotDir}" "${rcloneConfigDir}"
+  rm -rf "${snapshotDir}"
+  cleanupRcloneConfig
 
-  for artifactPath in "${archivePath:-}" "${manifestPath:-}"; do
-    if [ -n "${artifactPath}" ]; then
-      rm -f "${artifactPath}"
-    fi
+  for artifactPath in "${archivePath}" "${manifestPath}"; do
+    rm -f "${artifactPath}"
   done
 
   if [ "${exitCode}" -eq 0 ]; then
@@ -74,7 +36,7 @@ backupSqliteDatabase() {
   local targetPath="${snapshotDir}/.hermes/${databaseName}"
 
   if [ ! -f "${sourcePath}" ]; then
-    echo "Skipping missing SQLite database: ${sourcePath}"
+    logPhase "Skipping missing SQLite database: ${sourcePath}"
     return 0
   fi
 
@@ -83,11 +45,13 @@ backupSqliteDatabase() {
 }
 
 trap 'cleanup "$?"' EXIT
+createRcloneConfig
 
+logPhase "Starting Hermes backup for ${hostName}"
+logPhase "Phase: snapshot"
 rm -rf "${snapshotDir}"
 mkdir -p "${snapshotDir}"
 
-echo "Creating filesystem snapshot in ${snapshotDir}."
 rsync -a --delete --numeric-ids \
   --exclude='/.hermes/state.db' \
   --exclude='/.hermes/state.db-wal' \
@@ -97,37 +61,14 @@ rsync -a --delete --numeric-ids \
   --exclude='/.hermes/memory_store.db-shm' \
   "${stateDir}/" "${snapshotDir}/"
 
-echo "Capturing live SQLite backups."
+logPhase "Phase: SQLite capture"
 for databaseName in "${sqliteDatabases[@]}"; do
   backupSqliteDatabase "${databaseName}"
 done
 
-cryptPassword="$(rclone obscure "${BACKUP_CRYPT_PASSWORD}")"
-cryptPassword2="$(rclone obscure "${BACKUP_CRYPT_PASSWORD2}")"
-
-cat > "${rcloneConfigPath}" <<EOF
-[hermes-r2]
-type = s3
-provider = Cloudflare
-access_key_id = ${R2_ACCESS_KEY_ID}
-secret_access_key = ${R2_SECRET_ACCESS_KEY}
-region = auto
-endpoint = ${R2_ENDPOINT}
-acl = private
-no_check_bucket = true
-
-[hermes-encrypted]
-type = crypt
-remote = hermes-r2:${R2_BUCKET}/hermes
-password = ${cryptPassword}
-password2 = ${cryptPassword2}
-filename_encryption = standard
-directory_name_encryption = true
-EOF
-
+logPhase "Phase: archive creation"
 rm -f "${archivePath}" "${manifestPath}"
 
-echo "Creating compressed archive ${archiveName}."
 tar \
   --use-compress-program="zstd -T0 -19" \
   -cf "${archivePath}" \
@@ -151,29 +92,23 @@ jq -n \
     archive_name: $archiveName,
     archive_size_bytes: $sizeBytes,
     archive_sha256: $sha256
-}' > "${manifestPath}"
+  }' > "${manifestPath}"
 
-echo "Uploading archive and manifest to Cloudflare R2."
-rclone copyto "${archivePath}" "${remotePrefix}/${archiveName}" --config "${rcloneConfigPath}"
-rclone copyto "${manifestPath}" "${remotePrefix}/${manifestName}" --config "${rcloneConfigPath}"
+logPhase "Phase: upload"
+rclone copyto "${archivePath}" "$(remoteArchivePath "${archiveName}")" --config "${rcloneConfigPath}"
+rclone copyto "${manifestPath}" "$(remoteManifestPath "${archiveName}")" --config "${rcloneConfigPath}"
 
-echo "Verifying remote objects."
-archiveListing="$(rclone lsjson "${remotePrefix}/${archiveName}" --config "${rcloneConfigPath}")"
-manifestListing="$(rclone lsjson "${remotePrefix}/${manifestName}" --config "${rcloneConfigPath}")"
+logPhase "Phase: verification"
+archiveRemoteSize="$(verifyRemoteBackupPair "${archiveName}")"
 
-archiveRemoteSize="$(printf '%s' "${archiveListing}" | jq -r 'if length == 1 then .[0].Size else empty end')"
-manifestCount="$(printf '%s' "${manifestListing}" | jq 'length')"
-
-if [ -z "${archiveRemoteSize}" ] || [ "${archiveRemoteSize}" != "${archiveSizeBytes}" ]; then
-  echo "Remote archive verification failed for ${archiveName}." >&2
-  exit 1
-fi
-
-if [ "${manifestCount}" != "1" ]; then
-  echo "Remote manifest verification failed for ${manifestName}." >&2
-  exit 1
+if [ "${archiveRemoteSize}" != "${archiveSizeBytes}" ]; then
+  die "Remote archive size mismatch for ${archiveName}: remote=${archiveRemoteSize}, local=${archiveSizeBytes}."
 fi
 
 rm -f "${archivePath}" "${manifestPath}"
 
-echo "Hermes backup uploaded successfully: ${remotePrefix}/${archiveName} (${archiveSizeBytes} bytes, sha256 ${archiveSha256})"
+printf 'Hermes backup uploaded successfully: %s/%s (%s bytes, sha256 %s)\n' \
+  "${remoteBackupPrefix}" \
+  "${archiveName}" \
+  "${archiveSizeBytes}" \
+  "${archiveSha256}"

--- a/nixos/_mixins/server/hermes-backup/hermes-backup-verify-r2.sh
+++ b/nixos/_mixins/server/hermes-backup/hermes-backup-verify-r2.sh
@@ -1,0 +1,44 @@
+set -euo pipefail
+
+umask 077
+
+loadBackupEnvironment
+ensureCacheDirectories
+
+verifyDir=""
+
+cleanup() {
+  if [ -n "${verifyDir}" ]; then
+    rm -rf "${verifyDir}"
+  fi
+  cleanupRcloneConfig
+}
+
+trap cleanup EXIT
+
+createRcloneConfig
+verifyDir="$(mktemp -d "${workDir}/verify.XXXXXX")"
+
+if [ "$#" -gt 1 ]; then
+  die "Usage: hermes-backup-verify-r2 [backup-timestamp-or-archive-name]"
+fi
+
+if [ "$#" -eq 1 ]; then
+  archiveName="$(normaliseArchiveSelection "$1")"
+else
+  archiveName="$(selectLatestArchiveName)"
+fi
+
+manifestName="$(manifestNameFromArchive "${archiveName}")"
+logPhase "Verifying remote artefacts for ${archiveName}"
+remoteArchiveSize="$(verifyRemoteBackupPair "${archiveName}")"
+
+logPhase "Downloading ${archiveName} and ${manifestName}"
+mapfile -t downloadedPaths < <(downloadBackupPair "${archiveName}" "${verifyDir}")
+archivePath="${downloadedPaths[0]}"
+manifestPath="${downloadedPaths[1]}"
+
+logPhase "Validating manifest, archive hash, and archive structure"
+verifyBackupArchive "${archiveName}" "${archivePath}" "${manifestPath}" "$(currentHostName)"
+
+printf 'Hermes backup verification passed: %s (%s bytes)\n' "${archiveName}" "${remoteArchiveSize}"

--- a/nixos/_mixins/server/hermes-backup/hermes-restore-r2.sh
+++ b/nixos/_mixins/server/hermes-backup/hermes-restore-r2.sh
@@ -1,0 +1,43 @@
+set -euo pipefail
+
+umask 077
+
+if [ "$#" -ne 2 ]; then
+  die "Usage: hermes-restore-r2 <backup-timestamp-or-archive-name> <absolute-destination-path>"
+fi
+
+archiveName="$(normaliseArchiveSelection "$1")"
+destinationPath="$(prepareRestoreDestination "$2")"
+
+loadBackupEnvironment
+ensureCacheDirectories
+
+restoreDir=""
+
+cleanup() {
+  if [ -n "${restoreDir}" ]; then
+    rm -rf "${restoreDir}"
+  fi
+  cleanupRcloneConfig
+}
+
+trap cleanup EXIT
+
+createRcloneConfig
+restoreDir="$(mktemp -d "${workDir}/restore.XXXXXX")"
+
+logPhase "Checking remote artefacts for ${archiveName}"
+verifyRemoteBackupPair "${archiveName}" > /dev/null
+
+logPhase "Downloading ${archiveName}"
+mapfile -t downloadedPaths < <(downloadBackupPair "${archiveName}" "${restoreDir}")
+archivePath="${downloadedPaths[0]}"
+manifestPath="${downloadedPaths[1]}"
+
+logPhase "Validating archive before restore"
+verifyBackupArchive "${archiveName}" "${archivePath}" "${manifestPath}" "$(currentHostName)"
+
+logPhase "Extracting ${archiveName} into ${destinationPath}"
+extractBackupArchive "${archivePath}" "${destinationPath}"
+
+printf 'Hermes backup restore completed: %s -> %s\n' "${archiveName}" "${destinationPath}"


### PR DESCRIPTION
## Summary
- add shared Hermes backup helper logic and install verify/restore commands alongside the existing backup command
- verify remote backup artefacts by checking manifest metadata, archive size/hash, and archive structure for the latest complete backup or an explicit backup name
- restore a chosen backup into an explicit destination path with guardrails that refuse ambiguous or dangerous targets

## Test Plan
- `bash -n nixos/_mixins/server/hermes-backup/hermes-backup-common.sh nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh nixos/_mixins/server/hermes-backup/hermes-backup-verify-r2.sh nixos/_mixins/server/hermes-backup/hermes-restore-r2.sh`
- `git diff --check`
- `just eval`

## Notes
- restore uses per-run temporary rclone config directories to avoid cross-run interference
- verify without an argument now chooses the latest complete backup by manifest presence rather than the newest archive upload
