### PR TITLE
fix(hermes-backup): exclude current-entrypoint from archives

### DIFF
--- a/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
+++ b/nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh
@@ -55,6 +55,7 @@ rm -rf "${snapshotDir}"
 mkdir -p "${snapshotDir}"
 
 rsync -a --delete --numeric-ids \
+	--exclude='/current-entrypoint' \
 	--exclude='/.hermes/state.db' \
 	--exclude='/.hermes/state.db-wal' \
 	--exclude='/.hermes/state.db-shm' \


### PR DESCRIPTION
## Summary
- exclude `/var/lib/hermes/current-entrypoint` from Hermes backup archives
- keep archive verification strict by avoiding symlinks in the backup payload
- fix verification failures seen when `hermes-backup-verify-r2` hits the `./current-entrypoint` symlink

## Test Plan
- [x] `git diff --check`
- [x] `bash -n nixos/_mixins/server/hermes-backup/hermes-backup-r2.sh`
- [x] `nix eval .#nixosConfigurations.revan.config.environment.systemPackages --apply 'pkgs: builtins.any (pkg: (pkg.pname or pkg.name or "") == "hermes-backup-r2") pkgs' --json`
- [x] `just eval`

## Context
The verifier correctly rejects archive symlink entries. The backup builder was still preserving `current-entrypoint`, which points into `/nix/store`, so freshly uploaded archives could fail structural verification even though the upload itself succeeded.
