### PR TITLE
fix(ci): pin builder checkouts to the PR head SHA

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -33,6 +33,8 @@ jobs:
       has_orphan_homes: ${{ steps.inventory.outputs.has_orphan_homes }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: wimpysworld/nothing-but-nix@main
         with:
           hatchet-protocol: "holster"
@@ -62,6 +64,8 @@ jobs:
         target: ${{ fromJSON(needs.inventory.outputs.devshells) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: wimpysworld/nothing-but-nix@main
         if: contains(matrix.target.system, 'linux')
         with:
@@ -140,6 +144,8 @@ jobs:
         target: ${{ fromJSON(needs.inventory.outputs.packages) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: wimpysworld/nothing-but-nix@main
         if: contains(matrix.target.system, 'linux')
         with:
@@ -238,6 +244,8 @@ jobs:
         target: ${{ fromJSON(needs.inventory.outputs.nixos) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: wimpysworld/nothing-but-nix@main
         with:
           hatchet-protocol: "holster"
@@ -278,6 +286,8 @@ jobs:
         target: ${{ fromJSON(needs.inventory.outputs.darwin) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: DeterminateSystems/determinate-nix-action@v3
         with:
           extra-conf: |
@@ -308,6 +318,8 @@ jobs:
         target: ${{ fromJSON(needs.inventory.outputs.orphan_homes) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: wimpysworld/nothing-but-nix@main
         with:
           hatchet-protocol: "holster"

--- a/pkgs/fonts/bw-fusiona-font/default.nix
+++ b/pkgs/fonts/bw-fusiona-font/default.nix
@@ -18,8 +18,17 @@ stdenvNoCC.mkDerivation rec {
   };
 
   installPhase = ''
+    fontList=$(mktemp)
+    find . -type f -name '*.otf' -print > "$fontList"
+    if ! [ -s "$fontList" ]; then
+      echo "error: expected at least one .otf file in the source archive" >&2
+      exit 1
+    fi
+
     install -d $out/share/fonts/opentype/${pname}
-    find . -type f -name '*.otf' -exec install -m444 -t $out/share/fonts/opentype/${pname} {} +
+    while IFS= read -r fontFile; do
+      install -m444 "$fontFile" $out/share/fonts/opentype/${pname}/
+    done < "$fontList"
   '';
 
   meta = {

--- a/pkgs/fonts/bw-fusiona-font/default.nix
+++ b/pkgs/fonts/bw-fusiona-font/default.nix
@@ -9,13 +9,17 @@ stdenvNoCC.mkDerivation rec {
   version = "1.000";
 
   src = fetchzip {
-    url = "https://ifonts.xyz/wp-content/ifonts-files/downloads/559747/bw-fusiona-font-family.zip";
-    hash = "sha256-8FNKeTJTumpkGqj1aIvuXdkODPhWg2D0rF6k137/IOI=";
+    # Use the official demo archive directly. The previous third-party mirror
+    # started returning intermittent 403 responses to GitHub Actions runners,
+    # which made the builder workflow flaky.
+    url = "https://brandingwithtype.com/storage/Bw%20Fusiona%20DEMO-4.zip";
+    hash = "sha256-iG63fSKK/O1U88mNMgn1tHB+Zvfk8Z3z4VdOUaj+7qc=";
     stripRoot = false;
   };
 
   installPhase = ''
-    install -m444 -Dt $out/share/fonts/opentype/${pname} *.otf
+    install -d $out/share/fonts/opentype/${pname}
+    find . -type f -name '*.otf' -exec install -m444 -t $out/share/fonts/opentype/${pname} {} +
   '';
 
   meta = {


### PR DESCRIPTION
## Summary
- make every PR-triggered builder job check out the pull request head SHA instead of GitHub's ephemeral merge ref
- keep push builds on `github.sha` unchanged
- avoid late-starting matrix jobs failing checkout after a PR is merged while the workflow is still running

## Root cause
In run https://github.com/wimpysworld/nix-config/actions/runs/24846144059/job/72733967341 the x86_64-linux packages job started after PR #781 had already been merged. `actions/checkout` retried fetching `refs/remotes/pull/781/merge` and GitHub returned HTTP 500 each time, while other queued jobs were subsequently cancelled. The workflow was depending on a PR merge ref that can disappear once the PR closes.

## Validation
- `git diff --check`
- `just eval`