### PR TITLE
fix(ci): keep llm-agents out of flake lock updater

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           pr-title: "chore: update flake.lock"
+          # Keep llm-agents on a manual cadence. Large Codex bumps regularly blow up
+          # Home and NixOS matrix builds on GitHub-hosted runners.
+          inputs: >-
+            determinate fh home-manager nixpkgs nixpkgs-unstable nix-darwin
+            systems flake-utils rust-overlay flake-parts sidra bzmenu iwmenu
+            pwmenu catppuccin direnv-instant disko kolide-launcher nixos-hardware
+            nix-homebrew nix-index-database nix-vscode-extensions nix-flatpak
+            mac-app-util sops-nix vscode-server nix-packages xdg-override
           # Labels to be set on the PR
           pr-labels: |
             dependencies


### PR DESCRIPTION
## What
- whitelist updater inputs instead of updating every flake input
- leave `llm-agents` on a manual cadence
- document why in the workflow

## Why
CI run `24874301787` for PR #783 updated `llm-agents`, which pulled in a newer Codex build. Across the failing Home and NixOS jobs the runner then lost contact during Codex compilation, for example:
- job `72827578530` fetched `github:numtide/llm-agents.nix/645fe817...`
- the build included `codex-0.124.0.drv`
- the job ended with `Process completed with exit code 143` and `The runner has received a shutdown signal`
- GitHub annotated the failed jobs with `The hosted runner lost communication with the server`

That is not a repo logic failure, it is the updater pulling in a dependency bump that is too heavy for the hosted CI matrix. Keeping `llm-agents` manual stops the recurring breakage without touching normal config evaluation.

## Validation
- `yq '.' .github/workflows/updater.yml >/dev/null`
- `just eval`
- `git diff --check`
