### PR TITLE
fix(caddy): update plugin source hash

### DIFF
--- a/nixos/_mixins/server/caddy/default.nix
+++ b/nixos/_mixins/server/caddy/default.nix
@@ -31,7 +31,7 @@ lib.mkIf useCaddy {
       plugins = [
         "github.com/WeidiDeng/caddy-cloudflare-ip@v0.0.0-20231130002422-f53b62aa13cb"
       ];
-      hash = "sha256-v3EE+jsDxm4EI13naPFpEBnRkhht0C0g1Q3J5t0FOcc=";
+      hash = "sha256-prFkx5h7jftVZhPQCOR6k1Lid264R9KY75OW30Xo1xs=";
     };
     virtualHosts."${host.name}.${config.noughty.network.tailNet}" = lib.mkMerge [
       # Reverse proxy syncthing; which is configured/enabled via Home Manager


### PR DESCRIPTION
## What
- update the fixed-output hash for the custom Caddy build with the `caddy-cloudflare-ip` plugin

## Why
The previous hash is stale and breaks multiple CI jobs. In Actions run `24852929848`, job `72761144435` reported:
- specified: `sha256-v3EE+jsDxm4EI13naPFpEBnRkhht0C0g1Q3J5t0FOcc=`
- got: `sha256-prFkx5h7jftVZhPQCOR6k1Lid264R9KY75OW30Xo1xs=`

GitHub's annotation on that job explicitly recommended the new hash.

## Validation
- `just eval`
- `nix build '.#nixosConfigurations.felkor.config.services.caddy.package' -L`
- `git diff --check`
