### PR TITLE
chore(llama-cpp): update to 8953

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -4,8 +4,8 @@ let
   unstablePkgsPath = inputs.nixpkgs-unstable.outPath + "/pkgs/by-name";
 
   # Pinned here for the freshener workflow.
-  llamaCppVersion = "8895";
-  llamaCppHash = "sha256-yIgVbJvIRzdSB7oigBGqPGSzT5rpnKWeSzVA9I3xzM4=";
+  llamaCppVersion = "8953";
+  llamaCppHash = "sha256-FwQnfyojKbbBYhJ2wHMVMgb2XHyiZ69qvsKWtyS/oNo=";
   llamaCppNpmDepsHash = "sha256-RAFtsbBGBjteCt5yXhrmHL39rIDJMCFBETgzId2eRRk=";
 
   # Pinned here for the freshener workflow.


### PR DESCRIPTION
Automated llama.cpp update to build 8953.

Tags: https://github.com/ggml-org/llama.cpp/tags