### PR TITLE
chore(llama-swap): update to 208

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,8 +9,8 @@ let
   llamaCppNpmDepsHash = "sha256-RAFtsbBGBjteCt5yXhrmHL39rIDJMCFBETgzId2eRRk=";
 
   # Pinned here for the freshener workflow.
-  llamaSwapVersion = "205";
-  llamaSwapHash = "sha256-b6AaWAoDeauH7XBUYWjVwLT29aDv6fTkryR1l4eqaPc=";
+  llamaSwapVersion = "208";
+  llamaSwapHash = "sha256-E+BqqQcCLlW/DWvjwC66ClV6yuQ5x7cAMkLPJkS3x5M=";
   llamaSwapVendorHash = "sha256-tOOZgugiVcICYg9HyeTolyAg+YZWtxSJTvAuwfMazHQ=";
   llamaSwapUiNpmDepsHash = "sha256-6D4F58sSBkr7FKKO34gDhnZ9uN/SfsyYn1xJjYsMeq4=";
 in


### PR DESCRIPTION
Automated llama-swap update to version 208.

Release: https://github.com/mostlygeek/llama-swap/releases/tag/v208