### PR TITLE
fix(hermes): switch memory provider back to holographic

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -368,12 +368,6 @@ in
         mode = "0400";
       };
 
-      HONCHO_API_KEY = {
-        sopsFile = hermesSopsFile;
-        owner = "root";
-        group = "root";
-        mode = "0400";
-      };
 
       EMAIL_ADDRESS = {
         sopsFile = trayaSopsFile;
@@ -458,47 +452,6 @@ in
       mode = "0644";
     };
 
-    sops.templates."hermes-honcho" = {
-      content = builtins.toJSON {
-        apiKey = config.sops.placeholder.HONCHO_API_KEY;
-        baseUrl = "https://api.honcho.dev";
-        workspace = "darth.cc";
-        peerName = "martin";
-        hosts = {
-          hermes = {
-            enabled = true;
-            aiPeer = "traya";
-            workspace = "Hermes";
-            peerName = "martin";
-            recallMode = "hybrid";
-            writeFrequency = "async";
-            sessionStrategy = "per-directory";
-            dialecticReasoningLevel = "low";
-            dialecticDynamic = true;
-            dialecticCadence = 3;
-            dialecticDepth = 1;
-            contextCadence = 1;
-            contextTokens = 1200;
-            dialecticMaxChars = 600;
-            messageMaxChars = 25000;
-            saveMessages = true;
-            observation = {
-              user = {
-                observeMe = true;
-                observeOthers = true;
-              };
-              ai = {
-                observeMe = true;
-                observeOthers = true;
-              };
-            };
-          };
-        };
-      };
-      owner = hermesUser;
-      group = hermesGroup;
-      mode = "0440";
-    };
 
     sops.templates."hermes-gitconfig" = {
       content = ''
@@ -704,7 +657,7 @@ in
         memory = {
           memory_enabled = true;
           user_profile_enabled = true;
-          provider = "honcho";
+          provider = "holographic";
         };
 
         # Full autonomous operation: skip all approval prompts for commands
@@ -751,7 +704,6 @@ in
         config.sops.templates."hermes-gitconfig".path
       }"
       "L+ ${hermesHome}/SOUL.md - - - - ${config.sops.templates."hermes-soul".path}"
-      "L+ ${hermesHome}/honcho.json - - - - ${config.sops.templates."hermes-honcho".path}"
     ];
 
     system.activationScripts.hermes-agent-skills-permissions =


### PR DESCRIPTION
## Summary
- switch the Hermes memory provider on `revan` back to `holographic`
- remove the Honcho secret, rendered config template, and tmpfiles symlink
- leave the rest of the Hermes service wiring unchanged

## Validation
- `just eval`
- `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.settings.memory.provider --raw`
- `git diff --check`
