### PR TITLE
fix(revan): move librechat off local mongodb

### DIFF
--- a/nixos/_mixins/server/librechat/default.nix
+++ b/nixos/_mixins/server/librechat/default.nix
@@ -6,6 +6,7 @@
   ...
 }:
 let
+  cfg = config.services.librechat;
   cloudflareSopsFile = ../../../../secrets + "/cloudflare.yaml";
   hasCloudflareSopsFile = builtins.pathExists cloudflareSopsFile;
   librechatProvisionUsers = pkgs.writeShellApplication {
@@ -15,11 +16,16 @@ let
     # JavaScript, not shell expressions; disable shellcheck accordingly.
     checkPhase = "";
     text = ''
-      mongoUri="mongodb://127.0.0.1:27017/librechat"
-
+      : "''${MONGO_URI_FILE:?}"
       : "''${HASH_MARTIN:?}"
       : "''${HASH_LOUISE:?}"
       : "''${HASH_AGATHA:?}"
+
+      readSecret() {
+        tr -d '\n' < "$1"
+      }
+
+      mongoUri=$(readSecret "$MONGO_URI_FILE")
 
       upsertUser() {
         local email="$1"
@@ -29,7 +35,7 @@ let
         local hashFile="$5"
         local passwordHash
 
-        passwordHash="$(<"$hashFile")"
+        passwordHash=$(readSecret "$hashFile")
 
         EMAIL="$email" \
         NAME="$name" \
@@ -145,6 +151,14 @@ in
       mode = "0400";
     };
 
+    sops.secrets.MONGO_URI = {
+      sopsFile = ../../../../secrets/librechat.yaml;
+      path = "/run/secrets/MONGO_URI";
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
     # Create the LibreChat tunnel in Cloudflare first, then encrypt the
     # tunnel token from the dashboard install connector flow into
     # secrets/cloudflare.yaml as CLOUDFLARE_TUNNEL_TOKEN_LIBRECHAT before
@@ -159,7 +173,7 @@ in
 
     services.librechat = {
       enable = true;
-      enableLocalDB = lib.mkDefault true;
+      enableLocalDB = lib.mkDefault false;
       package = lib.mkDefault pkgs.unstable.librechat;
       openFirewall = lib.mkDefault true;
       meilisearch.enable = lib.mkDefault true;
@@ -177,6 +191,7 @@ in
         CREDS_KEY = config.sops.secrets.CREDS_KEY.path;
         JWT_REFRESH_SECRET = config.sops.secrets.JWT_REFRESH_SECRET.path;
         JWT_SECRET = config.sops.secrets.JWT_SECRET.path;
+        MONGO_URI = config.sops.secrets.MONGO_URI.path;
       };
       settings = lib.mkDefault {
         version = "1.3.6";
@@ -193,12 +208,13 @@ in
     systemd.services.librechat-provision-users = {
       description = "Provision initial LibreChat user accounts.";
       wantedBy = [ "multi-user.target" ];
-      after = [ "mongodb.service" ];
-      wants = [ "mongodb.service" ];
+      after = lib.optionals cfg.enableLocalDB [ "mongodb.service" ] ++ [ "network-online.target" ];
+      wants = lib.optionals cfg.enableLocalDB [ "mongodb.service" ] ++ [ "network-online.target" ];
       environment = {
         HASH_MARTIN = config.sops.secrets.USER_PW_MARTIN.path;
         HASH_LOUISE = config.sops.secrets.USER_PW_LOUISE.path;
         HASH_AGATHA = config.sops.secrets.USER_PW_AGATHA.path;
+        MONGO_URI_FILE = config.sops.secrets.MONGO_URI.path;
       };
       serviceConfig = {
         Type = "oneshot";

--- a/nixos/_mixins/server/librechat/module.nix
+++ b/nixos/_mixins/server/librechat/module.nix
@@ -193,7 +193,7 @@ in
     assertions = [
       {
         assertion = cfg.env ? MONGO_URI || cfg.credentials ? MONGO_URI;
-        message = "MongoDB is not configured, either set `services.librechat.enableLocalDB = true` or provide your own MongoDB instance by setting `services.librechat.env.MONGO_URI` or `services.credentials.MONGO_URI`.";
+        message = "MongoDB is not configured, either set `services.librechat.enableLocalDB = true` or provide your own MongoDB instance by setting `services.librechat.env.MONGO_URI` or `services.librechat.credentials.MONGO_URI`.";
       }
       {
         assertion =


### PR DESCRIPTION
## What
- stop `revan` from enabling the local MongoDB service for LibreChat by default
- wire LibreChat and the provisioning oneshot to read `MONGO_URI` from a sops secret
- keep the user provisioning unit working against an external MongoDB instance
- fix the local LibreChat module assertion text to reference `services.librechat.credentials.MONGO_URI`

## Why
GitHub CI was pulling MongoDB into the `revan` closure, and the uncached MongoDB build is the part that burns time. LibreChat itself is cached, so the sanest fix is to move `revan` off the local MongoDB service entirely while preserving account provisioning.

## Validation
- `nix eval --impure --json .#nixosConfigurations.revan.config.services.librechat.enableLocalDB`
- `nix eval --impure --json .#nixosConfigurations.revan.config.services.mongodb.enable`
- `nix eval --impure --json .#nixosConfigurations.revan.config.systemd.services.librechat-provision-users.after`
- `nix build --impure --dry-run --no-link .#nixosConfigurations.revan.config.system.build.toplevel 2>&1 | grep -E 'derivations will be built|paths will be fetched|mongodb|mongosh|librechat'`

## Follow-up
- add the real `MONGO_URI` value under `MONGO_URI` in `secrets/librechat.yaml` before deploying
