### PR TITLE
fix(revan): keep local librechat mongodb on mongodb-ce

### DIFF
--- a/nixos/_mixins/server/librechat/default.nix
+++ b/nixos/_mixins/server/librechat/default.nix
@@ -6,7 +6,6 @@
   ...
 }:
 let
-  cfg = config.services.librechat;
   cloudflareSopsFile = ../../../../secrets + "/cloudflare.yaml";
   hasCloudflareSopsFile = builtins.pathExists cloudflareSopsFile;
   librechatProvisionUsers = pkgs.writeShellApplication {
@@ -16,16 +15,11 @@ let
     # JavaScript, not shell expressions; disable shellcheck accordingly.
     checkPhase = "";
     text = ''
-      : "''${MONGO_URI_FILE:?}"
+      mongoUri="mongodb://127.0.0.1:27017/librechat"
+
       : "''${HASH_MARTIN:?}"
       : "''${HASH_LOUISE:?}"
       : "''${HASH_AGATHA:?}"
-
-      readSecret() {
-        tr -d '\n' < "$1"
-      }
-
-      mongoUri=$(readSecret "$MONGO_URI_FILE")
 
       upsertUser() {
         local email="$1"
@@ -35,7 +29,7 @@ let
         local hashFile="$5"
         local passwordHash
 
-        passwordHash=$(readSecret "$hashFile")
+        passwordHash="$(<"$hashFile")"
 
         EMAIL="$email" \
         NAME="$name" \
@@ -151,14 +145,6 @@ in
       mode = "0400";
     };
 
-    sops.secrets.MONGO_URI = {
-      sopsFile = ../../../../secrets/librechat.yaml;
-      path = "/run/secrets/MONGO_URI";
-      owner = "root";
-      group = "root";
-      mode = "0400";
-    };
-
     # Create the LibreChat tunnel in Cloudflare first, then encrypt the
     # tunnel token from the dashboard install connector flow into
     # secrets/cloudflare.yaml as CLOUDFLARE_TUNNEL_TOKEN_LIBRECHAT before
@@ -173,7 +159,7 @@ in
 
     services.librechat = {
       enable = true;
-      enableLocalDB = lib.mkDefault false;
+      enableLocalDB = lib.mkDefault true;
       package = lib.mkDefault pkgs.unstable.librechat;
       openFirewall = lib.mkDefault true;
       meilisearch.enable = lib.mkDefault true;
@@ -191,7 +177,6 @@ in
         CREDS_KEY = config.sops.secrets.CREDS_KEY.path;
         JWT_REFRESH_SECRET = config.sops.secrets.JWT_REFRESH_SECRET.path;
         JWT_SECRET = config.sops.secrets.JWT_SECRET.path;
-        MONGO_URI = config.sops.secrets.MONGO_URI.path;
       };
       settings = lib.mkDefault {
         version = "1.3.6";
@@ -204,17 +189,17 @@ in
     };
 
     services.meilisearch.masterKeyFile = lib.mkDefault config.sops.secrets.MEILI_MASTER_KEY.path;
+    services.mongodb.package = lib.mkDefault pkgs.mongodb-ce;
 
     systemd.services.librechat-provision-users = {
       description = "Provision initial LibreChat user accounts.";
       wantedBy = [ "multi-user.target" ];
-      after = lib.optionals cfg.enableLocalDB [ "mongodb.service" ] ++ [ "network-online.target" ];
-      wants = lib.optionals cfg.enableLocalDB [ "mongodb.service" ] ++ [ "network-online.target" ];
+      after = [ "mongodb.service" ];
+      wants = [ "mongodb.service" ];
       environment = {
         HASH_MARTIN = config.sops.secrets.USER_PW_MARTIN.path;
         HASH_LOUISE = config.sops.secrets.USER_PW_LOUISE.path;
         HASH_AGATHA = config.sops.secrets.USER_PW_AGATHA.path;
-        MONGO_URI_FILE = config.sops.secrets.MONGO_URI.path;
       };
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
## What
- restore LibreChat on `revan` to the original local MongoDB topology
- remove the external `MONGO_URI` secret wiring introduced in #791
- keep the local MongoDB service, but source it from `pkgs.mongodb-ce` instead of the source-built `pkgs.mongodb`

## Why
The real CI problem is the local MongoDB package line, not `pkgs.unstable.librechat`.

`revan` was pulling in `mongodb-7.0.31` from `pkgs.mongodb`, and that package is not substitutable from the official cache, so GitHub Actions ends up doing the massive source build.

Using `mongodb-ce` keeps Mongo local on `revan` while switching to the upstream binary-packaged line instead of the heavyweight source build.

## Validation
- `nix eval --impure --json .#nixosConfigurations.revan.config.services.librechat.enableLocalDB`
- `nix eval --impure --json .#nixosConfigurations.revan.config.services.mongodb.enable`
- `nix eval --impure --raw .#nixosConfigurations.revan.config.services.mongodb.package.name`
- `nix eval --impure --json .#nixosConfigurations.revan.config.systemd.services.librechat-provision-users.after`
- `nix eval --impure --raw .#nixosConfigurations.revan.config.services.librechat.env.MONGO_URI`
- `nix build --impure --dry-run --no-link .#nixosConfigurations.revan.config.system.build.toplevel 2>&1 | grep -E 'derivations will be built|paths will be fetched|mongodb|mongosh|librechat|tgz'`

## Notes
The dry run now shows `mongodb-ce-8.2.3` plus the fixed-output `mongodb-linux-x86_64-ubuntu2404-8.2.3.tgz` fetch path instead of the uncached `mongodb-7.0.31` source-build line.
