### PR TITLE
feat(hermes): enable webhook tunnel

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -145,6 +145,7 @@ Hermes currently draws from several secret sources:
 
 - `secrets/ai.yaml`
 - `secrets/hermes.yaml`
+- `secrets/cloudflare.yaml`
 - `secrets/hermes-auth.json`
 - `secrets/mcp.yaml`
 - `secrets/traya.yaml`
@@ -154,6 +155,9 @@ currently exports:
 
 - `TELEGRAM_BOT_TOKEN`
 - `TELEGRAM_ALLOWED_USERS`
+- `WEBHOOK_ENABLED`
+- `WEBHOOK_PORT`
+- `WEBHOOK_SECRET`
 - `ANTHROPIC_API_KEY`
 - `CONTEXT7_API_KEY`
 - `JINA_API_KEY`
@@ -180,6 +184,9 @@ Operationally:
   `secrets/traya.yaml`
 - `EMAIL_PASSWORD` must be a Fastmail app password, not the regular web login
   password
+- `WEBHOOK_SECRET` must be a dedicated HMAC secret in `secrets/hermes.yaml`
+- `CLOUDFLARE_TUNNEL_TOKEN_HERMES` must be a dedicated Cloudflare Tunnel
+  connector token in `secrets/cloudflare.yaml`
 - live token refresh remains in Hermes state after startup
 
 ## Telegram
@@ -199,6 +206,42 @@ That means the current service expects:
 - a configured Telegram home channel ID
 
 Discord is no longer part of this design.
+
+## Webhooks
+
+The Hermes webhook platform is enabled on localhost:
+
+```nix
+services.hermes-agent.settings.platforms.webhook = {
+  enabled = true;
+  extra = {
+    host = "127.0.0.1";
+    port = 8644;
+    secret = "\${WEBHOOK_SECRET}";
+  };
+};
+```
+
+The public endpoint is exposed through a dedicated remotely-managed Cloudflare
+Tunnel connector, not by opening port `8644` directly. The connector service is
+`cloudflared-hermes` and uses `CLOUDFLARE_TUNNEL_TOKEN_HERMES` from
+`secrets/cloudflare.yaml`.
+
+The LibreChat tunnel configuration is the reusable pattern, but the LibreChat
+tunnel token is not reused. Keep a separate Hermes tunnel token so webhook
+routing and token rotation stay isolated from LibreChat.
+
+In Cloudflare, publish the chosen webhook hostname to:
+
+```text
+http://127.0.0.1:8644
+```
+
+After deployment, the local health check should return OK:
+
+```bash
+curl http://127.0.0.1:8644/health
+```
 
 ## Sanctuary
 

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -10,6 +10,8 @@ let
   aiSopsFile = ../../../../secrets + "/ai.yaml";
   bondSopsFile = ../../../../secrets + "/hermes-bond.yaml";
   hermesSopsFile = ../../../../secrets + "/hermes.yaml";
+  cloudflareSopsFile = ../../../../secrets + "/cloudflare.yaml";
+  hasCloudflareSopsFile = builtins.pathExists cloudflareSopsFile;
   mcpSopsFile = ../../../../secrets + "/mcp.yaml";
   trayaSopsFile = ../../../../secrets + "/traya.yaml";
   claudePackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
@@ -328,6 +330,21 @@ in
         mode = "0400";
       };
 
+      WEBHOOK_SECRET = {
+        sopsFile = hermesSopsFile;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+
+      CLOUDFLARE_TUNNEL_TOKEN_HERMES = lib.mkIf hasCloudflareSopsFile {
+        sopsFile = cloudflareSopsFile;
+        path = "/run/secrets/CLOUDFLARE_TUNNEL_TOKEN_HERMES";
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+
       BOND_MD = {
         sopsFile = bondSopsFile;
         owner = "root";
@@ -417,6 +434,9 @@ in
       content = ''
         TELEGRAM_BOT_TOKEN=${config.sops.placeholder.TELEGRAM_BOT_TOKEN}
         TELEGRAM_ALLOWED_USERS=${config.sops.placeholder.TELEGRAM_ALLOWED_USERS}
+        WEBHOOK_ENABLED=true
+        WEBHOOK_PORT=8644
+        WEBHOOK_SECRET=${config.sops.placeholder.WEBHOOK_SECRET}
         ANTHROPIC_API_KEY=${config.sops.placeholder.ANTHROPIC_API_KEY}
         CONTEXT7_API_KEY=${config.sops.placeholder.CONTEXT7_API_KEY}
         JINA_API_KEY=${config.sops.placeholder.JINA_API_KEY}
@@ -538,6 +558,17 @@ in
       environmentFiles = [ config.sops.templates."hermes-env".path ];
 
       settings = {
+        platforms = {
+          webhook = {
+            enabled = true;
+            extra = {
+              host = "127.0.0.1";
+              port = 8644;
+              secret = "\${WEBHOOK_SECRET}";
+            };
+          };
+        };
+
         model = {
           default = "gpt-5.5";
           provider = "openai-codex";
@@ -721,6 +752,48 @@ in
       "/run/current-system"
       "/run/booted-system"
     ];
+
+    systemd.services.cloudflared-hermes = lib.mkIf hasCloudflareSopsFile {
+      description = "Cloudflare Tunnel connector for Hermes webhooks";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = lib.concatStringsSep " " [
+          (lib.getExe pkgs.cloudflared)
+          "tunnel"
+          "--no-autoupdate"
+          "run"
+          "--token-file"
+          config.sops.secrets.CLOUDFLARE_TUNNEL_TOKEN_HERMES.path
+        ];
+        Restart = lib.mkDefault "always";
+        RestartSec = lib.mkDefault 5;
+        User = lib.mkDefault "root";
+        Group = lib.mkDefault "root";
+
+        # Restrict the connector to outbound access and secret reads.
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+      };
+    };
+
+    # Create a dedicated remotely-managed Hermes tunnel in Cloudflare, then
+    # encrypt its connector token into secrets/cloudflare.yaml as
+    # CLOUDFLARE_TUNNEL_TOKEN_HERMES. Configure the published application in
+    # Cloudflare to route the chosen webhook hostname to http://127.0.0.1:8644.
 
     systemd.tmpfiles.rules = lib.mkAfter [
       "d ${config.services.hermes-agent.stateDir}/.config 2750 ${hermesUser} ${hermesGroup} - -"


### PR DESCRIPTION
## Summary
- Enables the Hermes webhook platform on localhost port 8644 with a SOPS-backed WEBHOOK_SECRET.
- Adds a dedicated cloudflared-hermes systemd service modelled on the LibreChat remotely-managed tunnel pattern.
- Documents the Cloudflare routing and secret requirements for Hermes webhooks.

## Secret and tunnel notes
- The LibreChat tunnel configuration pattern is suitable for reuse.
- The LibreChat tunnel token itself is not reused.
- Hermes expects a new WEBHOOK_SECRET in secrets/hermes.yaml.
- Hermes expects a new CLOUDFLARE_TUNNEL_TOKEN_HERMES in secrets/cloudflare.yaml.
- The Cloudflare published application should route the chosen webhook hostname to http://127.0.0.1:8644.

## Test Plan
- git diff --check
- targeted nix eval for revan Hermes webhook settings, env template, SOPS paths, and cloudflared-hermes ExecStart
- just eval
- nix build --impure --dry-run --no-link .#nixosConfigurations.revan.config.system.build.toplevel
