### PR TITLE
feat(claude-code,codex,opencode): expand build and test command allowlist

### DIFF
--- a/home-manager/_mixins/desktop/compositor/components/rofi/default.nix
+++ b/home-manager/_mixins/desktop/compositor/components/rofi/default.nix
@@ -7,21 +7,97 @@
 }:
 let
   inherit (config.noughty) host;
+  inherit (host) display;
   palette = catppuccinPalette;
+  desktopLayout = {
+    columns = "6";
+    lines = "4";
+    elementIconSize = "80px";
+    elementPadding = "28px 12px";
+    elementSpacing = "12px";
+    listviewSpacing = "8px";
+    mainboxSpacing = "90px";
+    mainboxPadding = "100px 225px";
+    inputbarMargin = "0% 25%";
+  };
+  laptopLayout = {
+    columns = "5";
+    lines = "4";
+    elementIconSize = "76px";
+    elementPadding = "24px 10px";
+    elementSpacing = "10px";
+    listviewSpacing = "8px";
+    mainboxSpacing = "82px";
+    mainboxPadding = "92px 200px";
+    inputbarMargin = "0% 22%";
+  };
+  compactLaptopLayout = {
+    columns = "5";
+    lines = "3";
+    elementIconSize = "72px";
+    elementPadding = "24px 10px";
+    elementSpacing = "10px";
+    listviewSpacing = "8px";
+    mainboxSpacing = "76px";
+    mainboxPadding = "88px 190px";
+    inputbarMargin = "0% 22%";
+  };
+  appGridLayout =
+    if host.is.laptop && (display.primaryHeight <= 1080 || display.primaryIsHighDpi) then
+      compactLaptopLayout
+    else if host.is.laptop then
+      laptopLayout
+    else
+      desktopLayout;
+  inherit (appGridLayout)
+    columns
+    elementIconSize
+    elementPadding
+    elementSpacing
+    inputbarMargin
+    lines
+    listviewSpacing
+    mainboxPadding
+    mainboxSpacing
+    ;
 
-  # Read template file and substitute colors
+  # Read template file and substitute colours and layout values.
   templateContent = builtins.readFile ./rofi-appgrid.rasi.template;
 
-  # Generate dynamic RASI file with substituted colors
+  # Generate dynamic RASI file with substituted colours and layout values.
   rofiAppGridRasi = pkgs.writeText "rofi-appgrid.rasi" (
     lib.replaceStrings
-      [ "@text_color@" "@background_color@" "@accent_color@" "@surface_color@" "@accent_color_alpha@" ]
+      [
+        "@text_color@"
+        "@background_color@"
+        "@accent_color@"
+        "@surface_color@"
+        "@accent_color_alpha@"
+        "@listview_columns@"
+        "@listview_lines@"
+        "@listview_spacing@"
+        "@mainbox_spacing@"
+        "@mainbox_padding@"
+        "@inputbar_margin@"
+        "@element_spacing@"
+        "@element_padding@"
+        "@element_icon_size@"
+      ]
       [
         "${palette.getColor "text"}FF" # text with full opacity
         "${palette.getColor "base"}af" # base background with transparency
-        "${palette.getColor "${palette.accent}"}" # user's selected accent color
+        "${palette.getColor "${palette.accent}"}" # user's selected accent colour
         "${palette.getColor "overlay0"}af" # surface with transparency
-        "${palette.getColor "${palette.accent}"}af" # accent color with transparency
+        "${palette.getColor "${palette.accent}"}af" # accent colour with transparency
+        columns
+        lines
+        listviewSpacing
+        mainboxSpacing
+        mainboxPadding
+        inputbarMargin
+        elementSpacing
+        elementPadding
+        elementIconSize
       ]
       templateContent
   );

--- a/home-manager/_mixins/desktop/compositor/components/rofi/rofi-appgrid.rasi.template
+++ b/home-manager/_mixins/desktop/compositor/components/rofi/rofi-appgrid.rasi.template
@@ -34,9 +34,9 @@ window {
 
 mainbox {
   enabled:           true;
-  spacing:           100px;
+  spacing:           @mainbox_spacing@;
   margin:            0px;
-  padding:           100px 225px;
+  padding:           @mainbox_padding@;
   border:            0px solid;
   border-radius:     0px;
   background-color:  transparent;
@@ -46,7 +46,7 @@ mainbox {
 inputbar {
   enabled:           true;
   spacing:           10px;
-  margin:            0% 25%;
+  margin:            @inputbar_margin@;
   padding:           16px;
   border:            2px solid;
   border-color:      @accent_color@;
@@ -107,17 +107,18 @@ entry {
 
 listview {
   enabled:           true;
-  columns:           8;
-  lines:             4;
+  columns:           @listview_columns@;
+  lines:             @listview_lines@;
   cycle:             true;
   dynamic:           true;
-  scrollbar:         false;
+  scrollbar:         true;
+  scrollbar-width:   8px;
   layout:            vertical;
   reverse:           false;
   fixed-height:      true;
   fixed-columns:     true;
 
-  spacing:           0px;
+  spacing:           @listview_spacing@;
   margin:            0px;
   padding:           0px;
   border:            0px solid;
@@ -126,11 +127,23 @@ listview {
   cursor:            "default";
 }
 
+scrollbar {
+  enabled:           true;
+  margin:            0px 0px 0px 16px;
+  padding:           0px;
+  border:            0px solid;
+  border-radius:     8px;
+  background-color:  transparent;
+  handle-color:      @accent_color_alpha@;
+  handle-width:      4px;
+  cursor:            "default";
+}
+
 element {
   enabled:           true;
-  spacing:           15px;
+  spacing:           @element_spacing@;
   margin:            0px;
-  padding:           35px 10px;
+  padding:           @element_padding@;
   border:            0px solid;
   border-radius:     15px;
   background-color:  transparent;
@@ -148,7 +161,7 @@ element selected.normal {
 
 element-icon {
   background-color:  transparent;
-  size:              72px;
+  size:              @element_icon_size@;
   cursor:            inherit;
 }
 element-text {

--- a/home-manager/_mixins/development/claude-code/PERMISSIONS.md
+++ b/home-manager/_mixins/development/claude-code/PERMISSIONS.md
@@ -10,6 +10,8 @@ Claude Code uses ordered allow/ask/deny lists evaluated at startup. Rules use pr
 
 Rules are checked in order: deny, then ask, then allow. The first matching rule wins, so deny rules take precedence over allow rules. The `defaultMode` is `acceptEdits`, which automatically accepts file edits and common filesystem commands for the launch directory and configured `additionalDirectories`.
 
+A consequence of tier ordering: a broad ask rule like `Bash(just:*)` shadows every more-specific allow such as `Bash(just eval)`. The `bashAsk` list intentionally omits broad globs for commands whose safe subcommands are explicitly allow-listed (currently `just`); unknown subcommands of those tools fall through to the default prompt. PreToolUse hooks cannot rescue this case: per the [Claude Code hooks documentation](https://code.claude.com/docs/en/hooks.md), an ask rule still prompts even when a hook returns `"allow"`.
+
 File read denials use `Read(pattern)` syntax and block access entirely. Absolute filesystem paths use Claude Code's `//path` form. A single leading slash is project-root-relative, not filesystem-root-relative.
 
 ## Three-tier model
@@ -62,11 +64,12 @@ Rules cover 13 tool domains. Each follows the same pattern: version checks and r
 | Allow | Ask | Deny |
 |-------|-----|------|
 | `ls`, `cat`, `head`, `tail`, `wc`, `file`, `tree`, `pwd` | `sed`, `sd`, `mkdir`, `touch`, `mv`, `cp` | `sudo`, `shred`, `wipe`, `srm`, `truncate` |
-| `which`, `type`, `env`, `fd`, `rg`, `grep` | `tee`, `echo`, `printf`, `curl`, `wget` | `dd` |
+| `which`, `type`, `env`, `fd`, `rg`, `grep` | `tee`, `curl`, `wget` | `dd` |
 | `whoami`, `hostname`, `uname`, `df`, `free`, `ps` | `chmod`, `chown`, `kill`, `pkill`, `ln` | `bash -c`, `sh -c`, `fish -c`, `zsh -c`, `dash -c` |
 | `stat`, `du`, `sort`, `uniq`, `cut`, `awk`, `diff` | `xdg-open` | `python -c`, `node -e`, `perl -e`, `ruby -e`, `lua -e`, `php -r` |
 | `jq`, `yq`, `bc`, `man`, `tldr`, `strings` | `rm`, `rmdir` (supervised) | `sysctl`, `modprobe`, `insmod`, `rmmod` |
-| `xxd`, `hexdump`, `od`, `base64`, `shellcheck` | | `grub-install`, `efibootmgr`, `fdisk`, `parted`, `mkfs`, `mount` |
+| `echo`, `printf` (pipeline sources) | | `grub-install`, `efibootmgr`, `fdisk`, `parted`, `mkfs`, `mount` |
+| `xxd`, `hexdump`, `od`, `base64`, `shellcheck` | | |
 | `bat`, `most`, `less`, `more`, `tr`, `tac`, `rev` | | |
 
 Additional text processing: `column`, `fold`, `nl`, `pr`, `expand`, `paste`, `join`, `comm`.
@@ -120,7 +123,7 @@ Process inspection: `pgrep`, `pidof`, `pstree`, `lsof`.
 | `derivation show`, `store ls/verify`, `hash` | `home-manager switch` | |
 | `repl`, `log`, `show-config`, `doctor` | `nixos-rebuild`, `darwin-rebuild` | |
 | `nix-instantiate`, `nix-store --query/-q` | | |
-| `nixfmt`, `statix`, `deadnix`, `alejandra` | | |
+| `nix fmt`, `nixfmt`, `statix`, `deadnix`, `alejandra` | | |
 
 ### Go
 
@@ -184,7 +187,7 @@ Process inspection: `pgrep`, `pidof`, `pstree`, `lsof`.
 |--------|-------|-----|------|
 | Hugo | `version`, `env` | All other `hugo` commands | - |
 | ImageMagick | `identify`, version checks | `convert`, `magick`, `mogrify`, `compare`, `composite` | - |
-| Just | `--version`, `--list`, `--summary`, `eval`, `build` | All other `just` commands | - |
+| Just | `--version`, `--list`, `--summary`, `build`, `build-home`, `build-host`, `eval`, `lint`, `list`, `test` | Other `just` commands prompt by default (no broad ask rule, to avoid shadowing the specific allows) | - |
 | Lua/LÖVE | `lua -v`, `love --version` | `lua`, `love`, `luarocks install/remove` | - |
 | Svelte | `svelte-check --help` | `svelte-kit sync/build`, `svelte-check` | - |
 | Wails | `--version`, `doctor` | `build`, `dev`, `init` | - |

--- a/home-manager/_mixins/development/claude-code/default.nix
+++ b/home-manager/_mixins/development/claude-code/default.nix
@@ -25,6 +25,15 @@ let
   # Import shared MCP server definitions
   mcpServerDefs = import ../mcp/servers.nix { inherit config pkgs; };
 
+  # Per-server allow entries derived from `mcpServerDefs.claudeServers`. Each
+  # `mcp__<servername>` rule matches every tool exposed by that server, so
+  # adding a server in `mcp/servers.nix` auto-extends this list with no edits
+  # here. The previous bare `"mcp__*"` rule was a no-op because Claude Code's
+  # permission matcher does not accept that wildcard form; valid shapes are
+  # `mcp__<servername>`, `mcp__<servername>__*`, or
+  # `mcp__<servername>__<toolname>`.
+  mcpAllow = map (name: "mcp__${name}") (lib.attrNames mcpServerDefs.claudeServers);
+
   # PreToolUse auto-approve hook. Closes the gaps in Claude Code's static
   # `Bash(cmd:*)` matcher around redirects, command substitution, heredocs,
   # env-var prefixes, and wrapper-disguised invocations. Auto-approves only
@@ -972,8 +981,9 @@ in
         mcpServers = mcpServerDefs.claudeServers;
         settings = {
           # MCP servers are selected declaratively through Home Manager. Their
-          # tools are allowed below with mcp__*, while arbitrary project MCP
-          # servers remain opt-in instead of being silently trusted.
+          # tools are allowed below via the derived `mcpAllow` list, while
+          # arbitrary project MCP servers remain opt-in instead of being
+          # silently trusted.
           enableAllProjectMcpServers = false;
 
           # These roots are treated like the launch directory for file access.
@@ -993,9 +1003,8 @@ in
             allow =
               bashAllow
               ++ claudeWorkspaceEditRules
+              ++ mcpAllow
               ++ [
-                # MCP tools - allow all unconditionally
-                "mcp__*"
                 # Nix store is immutable and world-readable; reading from it
                 # never needs a prompt. The `//` prefix anchors the pattern at
                 # the filesystem root rather than the project root.

--- a/home-manager/_mixins/development/claude-code/default.nix
+++ b/home-manager/_mixins/development/claude-code/default.nix
@@ -127,6 +127,7 @@ let
     "Bash(basename:*)"
     "Bash(dirname:*)"
     "Bash(realpath:*)"
+    "Bash(readlink:*)"
     "Bash(stat:*)"
     "Bash(du:*)"
     "Bash(sort:*)"
@@ -219,8 +220,9 @@ let
     "Bash(base64:*)"
     "Bash(base32:*)"
     "Bash(shellcheck:*)"
-    "Bash(shfmt --diff:*)"
-    "Bash(shfmt -d:*)"
+    # shfmt rewrites are workspace-bounded; both diff and write modes are
+    # allowed without prompting.
+    "Bash(shfmt:*)"
     "Bash(luacheck:*)"
 
     # Systemd - read-only status and log queries
@@ -284,20 +286,34 @@ let
     "Bash(nm:*)"
     "Bash(readelf:*)"
 
-    # FFmpeg - info and probing
-    "Bash(ffmpeg -version)"
-    "Bash(ffmpeg -formats)"
-    "Bash(ffmpeg -codecs)"
-    "Bash(ffmpeg -encoders)"
-    "Bash(ffmpeg -decoders)"
-    "Bash(ffmpeg -bsfs)"
-    "Bash(ffmpeg -protocols)"
-    "Bash(ffmpeg -pix_fmts)"
-    "Bash(ffmpeg -layouts)"
-    "Bash(ffmpeg -sample_fmts)"
-    "Bash(ffmpeg -filters)"
-    "Bash(ffmpeg -loglevel:*)"
-    "Bash(ffmpeg -hwaccels)"
+    # Build tools - configuration, builds, and compilation. Workspace edits
+    # are bounded by `acceptEdits` and the workspace-write sandbox; out-of-tree
+    # installation (`make install`, `cmake --install`) is intentionally still
+    # routed through bashAsk below.
+    "Bash(./configure:*)"
+    "Bash(configure:*)"
+    "Bash(autoreconf:*)"
+    "Bash(autoconf:*)"
+    "Bash(automake:*)"
+    "Bash(make:*)"
+    "Bash(cmake:*)"
+    "Bash(meson:*)"
+    "Bash(ninja:*)"
+    "Bash(clang:*)"
+    "Bash(clang++:*)"
+    "Bash(gcc:*)"
+    "Bash(g++:*)"
+    "Bash(ar:*)"
+    "Bash(ranlib:*)"
+    "Bash(clang-tidy:*)"
+    "Bash(clang-format:*)"
+
+    # FFmpeg - allowed broadly; the workspace-write sandbox is the actual
+    # security boundary. ffmpeg can read/write network protocols (http://,
+    # ftp://, rtmp://, etc.) and arbitrary filesystem paths, so this rule
+    # does not by itself contain media processing - sandbox containment
+    # does. ffprobe is read-only.
+    "Bash(ffmpeg:*)"
     "Bash(ffprobe:*)"
 
     # GitHub - read-only queries
@@ -441,6 +457,12 @@ let
     "Bash(govulncheck)"
     "Bash(govulncheck:*)"
 
+    # Go - builds, tests, and formatting are workspace-bounded.
+    "Bash(go build:*)"
+    "Bash(go test:*)"
+    "Bash(go fmt:*)"
+    "Bash(gofmt:*)"
+
     # JavaScript/TypeScript - info and type checking
     "Bash(node --version)"
     "Bash(npm --version)"
@@ -452,6 +474,10 @@ let
     "Bash(npx --version)"
     "Bash(tsc --version)"
     "Bash(tsc --noEmit:*)"
+
+    # JavaScript/TypeScript - tests are workspace-bounded.
+    "Bash(npm test:*)"
+    "Bash(pnpm test:*)"
 
     # Just - listing only
     "Bash(just --version)"
@@ -491,6 +517,11 @@ let
     "Bash(rustup target list:*)"
     "Bash(rustup component list:*)"
 
+    # Rust - builds, tests, and formatting are workspace-bounded.
+    "Bash(cargo build:*)"
+    "Bash(cargo test:*)"
+    "Bash(cargo fmt:*)"
+
     # Python - info and read-only
     "Bash(python --version)"
     "Bash(python3 --version)"
@@ -503,12 +534,24 @@ let
     "Bash(python -m pytest --collect-only:*)"
     "Bash(mypy --version)"
     "Bash(ruff --version)"
-    "Bash(ruff check:*)"
     "Bash(uv --version)"
     "Bash(uv pip list:*)"
 
-    # Svelte - info
+    # Python - tests, linters, and formatters are workspace-bounded. Includes
+    # `ruff` in full (not just `ruff check`) so `ruff format` and `ruff check
+    # --fix` invocations run without prompting.
+    "Bash(pytest:*)"
+    "Bash(python -m pytest:*)"
+    "Bash(python3 -m pytest:*)"
+    "Bash(mypy:*)"
+    "Bash(ruff:*)"
+    "Bash(black:*)"
+    "Bash(isort:*)"
+
+    # Svelte - info and type checking. svelte-check is read-only across the
+    # workspace; rewrites are out of scope for the tool.
     "Bash(svelte-check --help)"
+    "Bash(svelte-check:*)"
 
     # Wails - info only
     "Bash(wails --version)"
@@ -574,27 +617,11 @@ let
     "Bash(docker pull:*)"
     "Bash(docker push:*)"
 
-    # Build tools - configuration and builds
-    "Bash(./configure:*)"
-    "Bash(configure:*)"
-    "Bash(autoreconf:*)"
-    "Bash(autoconf:*)"
-    "Bash(automake:*)"
-    "Bash(make:*)"
-    "Bash(cmake:*)"
-    "Bash(meson:*)"
-    "Bash(ninja:*)"
-    "Bash(clang:*)"
-    "Bash(clang++:*)"
-    "Bash(gcc:*)"
-    "Bash(g++:*)"
-    "Bash(ar:*)"
-    "Bash(ranlib:*)"
-    "Bash(clang-tidy:*)"
-    "Bash(clang-format:*)"
-
-    # FFmpeg - file processing
-    "Bash(ffmpeg:*)"
+    # Build tools - out-of-workspace installation. Build, compile, and lint
+    # invocations themselves now sit on bashAllow above; only installation
+    # subcommands continue to prompt because they reach outside the workspace.
+    "Bash(make install:*)"
+    "Bash(cmake --install:*)"
 
     # GitHub - state modifications
     "Bash(gh pr create:*)"
@@ -630,29 +657,36 @@ let
     "Bash(compare:*)"
     "Bash(composite:*)"
 
-    # Nix - builds and environment
+    # Nix - builds and environment.
+    # `home-manager:*`, `nixos-rebuild:*`, and `darwin-rebuild:*` cover every
+    # subcommand (switch, build, generations, expire-generations, news, etc.)
+    # because the consistent rule is "any state-mutating system rebuild must
+    # prompt"; read-only subcommands like `generations` and `news` are not
+    # carved out so the boundary stays uniform.
     "Bash(nix build:*)"
     "Bash(nix develop:*)"
     "Bash(nix-shell:*)"
     "Bash(nix flake update:*)"
     "Bash(nix-env:*)"
-    "Bash(home-manager switch:*)"
+    "Bash(home-manager:*)"
     "Bash(nixos-rebuild:*)"
     "Bash(darwin-rebuild:*)" # macOS system rebuild (nix-darwin)
 
-    # Go - builds and code execution
-    "Bash(go build:*)"
+    # Go - code execution and out-of-workspace effects.
+    # `go build`, `go test`, `go fmt`, and `gofmt` now sit on bashAllow above;
+    # invocations that run code or install outside the workspace continue to
+    # prompt.
     "Bash(go run:*)"
-    "Bash(go test:*)"
     "Bash(go generate:*)"
     "Bash(go get:*)"
     "Bash(go mod tidy)"
     "Bash(go install:*)"
 
-    # JavaScript/TypeScript - installs and execution
+    # JavaScript/TypeScript - installs and execution.
+    # `npm test` and `pnpm test` now sit on bashAllow above; lifecycle scripts
+    # (`install`, `run`) and arbitrary `npx` invocations keep prompting.
     "Bash(npm install:*)"
     "Bash(npm run:*)"
-    "Bash(npm test:*)"
     "Bash(npm publish:*)"
     "Bash(pnpm install:*)"
     "Bash(pnpm run:*)"
@@ -672,9 +706,10 @@ let
     "Bash(luarocks install:*)"
     "Bash(luarocks remove:*)"
 
-    # Rust - builds and code execution
-    "Bash(cargo build:*)"
-    "Bash(cargo test:*)"
+    # Rust - code execution and out-of-workspace effects.
+    # `cargo build`, `cargo test`, and `cargo fmt` now sit on bashAllow above;
+    # invocations that run code, install outside the workspace, or publish to
+    # crates.io continue to prompt.
     "Bash(cargo run:*)"
     "Bash(cargo install:*)"
     "Bash(cargo publish:*)"
@@ -682,21 +717,20 @@ let
     "Bash(rustup update:*)"
     "Bash(rustup default:*)"
 
-    # Python - installs and execution
+    # Python - installs and execution.
+    # `pytest`, `mypy`, `ruff`, `black`, and `isort` now sit on bashAllow
+    # above. Bare `python`/`python3` invocations are arbitrary code execution
+    # and continue to prompt; `python -m pytest` is allow-listed separately.
     "Bash(pip install:*)"
     "Bash(pip uninstall:*)"
     "Bash(python:*)"
     "Bash(python3:*)"
-    "Bash(pytest:*)"
-    "Bash(mypy:*)"
-    "Bash(ruff:*)"
     "Bash(uv pip install:*)"
     "Bash(uv sync:*)"
     "Bash(uv run:*)"
 
-    # Svelte - builds and type checking
+    # Svelte - builds and dev sync. `svelte-check` now sits on bashAllow above.
     "Bash(svelte-kit sync:*)"
-    "Bash(svelte-check:*)"
     "Bash(svelte-kit build:*)"
 
     # Wails - builds and dev server
@@ -1066,27 +1100,33 @@ in
             ask = bashAsk;
             deny = bashDeny ++ readDeny;
             defaultMode = "acceptEdits";
+          };
 
-            # PreToolUse hook: auto-approves safe pipelines, --help / --version
-            # invocations, and command-substitution shapes the static rules
-            # can't express. Hard-denies wrapper-disguised dangerous patterns
-            # (e.g. `xargs sudo rm`, `bash -c '...'`). Defers to the static
-            # rules for everything uncertain, so `bashAsk` and `bashDeny`
-            # remain the source of truth for the security boundary.
-            hooks = {
-              PreToolUse = [
-                {
-                  matcher = "Bash";
-                  hooks = [
-                    {
-                      type = "command";
-                      command = lib.getExe autoApproveHook;
-                      timeout = 10;
-                    }
-                  ];
-                }
-              ];
-            };
+          # PreToolUse hook: auto-approves safe pipelines, --help / --version
+          # invocations, and command-substitution shapes the static rules
+          # can't express. Hard-denies wrapper-disguised dangerous patterns
+          # (e.g. `xargs sudo rm`, `bash -c '...'`). Defers to the static
+          # rules for everything uncertain, so `bashAsk` and `bashDeny`
+          # remain the source of truth for the security boundary.
+          #
+          # `hooks` is a top-level settings key in Claude Code, NOT nested
+          # under `permissions`. The previous placement under `permissions`
+          # silently failed: settings still validated, but Claude Code never
+          # invoked the hook, so `git -C <path> <subcmd>` shapes (and other
+          # gap-closers) kept prompting.
+          hooks = {
+            PreToolUse = [
+              {
+                matcher = "Bash";
+                hooks = [
+                  {
+                    type = "command";
+                    command = lib.getExe autoApproveHook;
+                    timeout = 10;
+                  }
+                ];
+              }
+            ];
           };
         };
       };

--- a/home-manager/_mixins/development/claude-code/default.nix
+++ b/home-manager/_mixins/development/claude-code/default.nix
@@ -42,6 +42,12 @@ let
   # `bashDeny` rules cannot catch.
   autoApproveHook = pkgs.callPackage ./hooks/auto-approve { };
 
+  # Replacement for Claude Code's built-in `@` file picker. Pipes `fd` into
+  # `fzf --filter` so queries get real fuzzy scoring and untracked files,
+  # gitignored files, and symlinked trees all participate. Wired into
+  # `settings.fileSuggestion` below.
+  fileSuggestionCommand = pkgs.callPackage ./file-suggestion { };
+
   claudeAbsolutePattern = path: "//${lib.removePrefix "/" path}";
   claudeWorkspaceRoots = [
     "${config.home.homeDirectory}/Chainguard"
@@ -886,6 +892,14 @@ in
       shellAliases = {
         cc-traya = "claude --agent traya --continue";
       };
+      # Skip Claude Code's bundled ripgrep in favour of the system binary on
+      # PATH. The bundled `rg` crashes on 16 KB-page kernels (Apple Silicon,
+      # some Linux configs), silently emptying the file picker. Using the Nix
+      # ripgrep is harmless on every other host and avoids the failure mode
+      # entirely. See CLAUDE-FUZZY-FINDER-IS-DOGSHIT.md and upstream #11307.
+      sessionVariables = {
+        USE_BUILTIN_RIPGREP = "0";
+      };
     };
 
     # Declarative configuration for ccstatusline.
@@ -1023,6 +1037,17 @@ in
             type = "command";
             command = lib.getExe ccstatuslinePatched;
             padding = 0;
+          };
+
+          # Replace the built-in `@` file picker with `fd | fzf --filter`.
+          # The built-in matcher is a bespoke subsequence scorer capped at 15
+          # results and gated on `git ls-files`, so untracked or word-fragment
+          # queries fail. Claude Code invokes this command per keystroke with
+          # JSON `{"query": "..."}` on stdin. See ./file-suggestion for the
+          # script body and CLAUDE-FUZZY-FINDER-IS-DOGSHIT.md for context.
+          fileSuggestion = {
+            type = "command";
+            command = lib.getExe fileSuggestionCommand;
           };
           permissions = {
             allow =

--- a/home-manager/_mixins/development/claude-code/default.nix
+++ b/home-manager/_mixins/development/claude-code/default.nix
@@ -144,6 +144,11 @@ let
     "Bash(man:*)"
     "Bash(tldr:*)"
     "Bash(strings:*)"
+    # Plain output and pipeline sources. Redirection (`echo x > file`) is
+    # bounded by the workspace-write sandbox and the auto-approve hook's
+    # hard-deny shapes still catch dangerous substitution patterns.
+    "Bash(echo:*)"
+    "Bash(printf:*)"
 
     # Text processing - additional
     "Bash(column:*)"
@@ -404,6 +409,8 @@ let
     "Bash(nvd:*)"
     "Bash(nixfmt)"
     "Bash(nixfmt:*)"
+    "Bash(nix fmt)"
+    "Bash(nix fmt:*)"
     "Bash(statix:*)"
     "Bash(deadnix:*)"
     "Bash(alejandra:*)"
@@ -445,8 +452,20 @@ let
     "Bash(just --list)"
     "Bash(just -l)"
     "Bash(just --summary)"
-    "Bash(just eval)"
     "Bash(just build)"
+    "Bash(just build:*)"
+    "Bash(just build-home)"
+    "Bash(just build-home:*)"
+    "Bash(just build-host)"
+    "Bash(just build-host:*)"
+    "Bash(just eval)"
+    "Bash(just eval:*)"
+    "Bash(just lint)"
+    "Bash(just lint:*)"
+    "Bash(just list)"
+    "Bash(just list:*)"
+    "Bash(just test)"
+    "Bash(just test:*)"
 
     # Lua - info only
     "Bash(lua -v)"
@@ -495,7 +514,12 @@ let
   ];
 
   bashAsk = [
-    # Shell - file modification or redirection risk
+    # Shell - file modification or redirection risk.
+    # Note: `echo` and `printf` are intentionally NOT listed here. Both are
+    # heavily used as pipeline sources (`echo "x" | jq`), and the broad ask
+    # shadowed every specific use. Plain output is harmless; the redirection
+    # risk is bounded by the workspace-write sandbox and the auto-approve
+    # hook's hard-deny shapes still catch dangerous substitution patterns.
     "Bash(xdg-open:*)"
     "Bash(sed:*)"
     "Bash(sd:*)"
@@ -504,8 +528,6 @@ let
     "Bash(mv:*)"
     "Bash(cp:*)"
     "Bash(tee:*)"
-    "Bash(echo:*)"
-    "Bash(printf:*)"
     "Bash(curl:*)"
     "Bash(wget:*)"
     "Bash(chmod:*)"
@@ -632,8 +654,11 @@ let
     "Bash(yarn install:*)"
     "Bash(vite:*)"
 
-    # Just - recipe execution
-    "Bash(just:*)"
+    # Just - recipe execution. The broad `just:*` rule was deliberately
+    # removed: it shadowed the specific allows above (`just eval`, `just
+    # build`, etc.) under Claude Code's first-match-wins-within-tier ordering
+    # (deny -> ask -> allow). Unknown `just` subcommands now fall through to
+    # the default prompt behaviour, while listed safe recipes auto-approve.
 
     # Lua - execution
     "Bash(lua:*)"

--- a/home-manager/_mixins/development/claude-code/file-suggestion/README.md
+++ b/home-manager/_mixins/development/claude-code/file-suggestion/README.md
@@ -1,0 +1,372 @@
+# Claude Code Fuzzy Finder: Why It's Dogshit
+
+Findings for Claude Code CLI 2.1.126 (binary: `/nix/store/280qb7zhg6i2zg9q7g8b2fcmqm92j283-claude-code-2.1.126/bin/.claude-wrapped`). Symbols and behaviour quoted below come from grepping the bun-compiled binary; identifiers are minified, semantics are unambiguous.
+
+## TL;DR
+
+- The `@` picker uses a hand-rolled, in-process **subsequence matcher** (not fzf/fzy/fuzzysort), capped at **15 results**, indexed once from `git ls-files` (with ripgrep `--files` as fallback).
+- The query must be a **left-to-right ordered subsequence of the lowercased path**. There is no substring fallback, no transposition tolerance, and no token splitting; "xyzpack" cannot match `packages/xyz-project/package.json`.
+- The index is **gated on `git ls-files`**. Untracked files, `.gitignored` files, files from `/add-dir`/`additionalDirectories`, files in nested submodules, and files created mid-session are routinely missing or stale.
+- Scoring penalises long paths and bumps results containing the literal word `test`. There is no recency, no MRU, no editor-active boost, no path-segment weighting beyond a small word-boundary bonus.
+- Anthropic shipped a `fileSuggestion` escape hatch in `settings.json` that runs an arbitrary shell command per keystroke. Pipe `fd | fzf --filter` and the picker becomes usable. → recommended fix.
+
+### The fix (copy-paste, no Nix required)
+
+Requires `fd` and `fzf` on `PATH`. Two files, one chmod:
+
+`~/.claude/settings.json` (merge into existing):
+
+```json
+{
+  "fileSuggestion": {
+    "type": "command",
+    "command": "~/.claude/file-suggestion.sh"
+  }
+}
+```
+
+`~/.claude/file-suggestion.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Replace Claude Code's broken @ picker with fd + fzf scoring.
+set -euo pipefail
+
+read -r INPUT || INPUT=''
+QUERY=$(printf '%s' "$INPUT" | sed -n 's/.*"query"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 0
+
+if [[ -z "$QUERY" ]]; then
+  fd --type f --hidden --follow --color never --changed-within 7d 2>/dev/null | head -15
+  exit 0
+fi
+
+fd --type f --hidden --follow --color never 2>/dev/null \
+  | fzf --filter "$QUERY" \
+  | head -15
+```
+
+```bash
+chmod +x ~/.claude/file-suggestion.sh
+```
+
+Optional but recommended: export `USE_BUILTIN_RIPGREP=0` so Claude Code uses your system `rg`. Restart Claude Code. Picker now ranks by proper fuzzy score, follows symlinks, and respects `.gitignore`/`.fdignore`/`.ignore`.
+
+## Symptoms
+
+Concrete failure modes documented in upstream issues, Reddit threads, and the binary itself:
+
+- **No substring fallback.** Typing `7-5` finds anything where `7` then `-` then `5` appear in order — even if a file literally named `7-5.something` exists. (#20065)
+- **Word-fragment queries die.** `@xyzpack` won't surface `packages/xyz-project/package.json`; the picker requires a contiguous subsequence, so the user has to remember path order. (#20065 comments, #11307)
+- **Top-15 hard cap.** `VT6 = 15` in the binary. Large repos lose the right answer below the fold; no pagination. (algorithm in `qj$.search`)
+- **Untracked-file blackhole.** `git ls-files` is the primary source. New, unstaged, or `.gitignore`-excluded files don't appear at all. (#40082, #45012, #36647, #14904)
+- **Stale prefix index.** Files created mid-session show up in the unfiltered `@` dropdown but not in prefix-filtered queries until the session restarts. (#53517)
+- **`additionalDirectories` / `/add-dir` not searched.** The picker only fuzzy-matches inside the git root; added directories require typing the full path. (#52092, #7412)
+- **Monorepo bleed.** Launching from `apps/foo/` searches the whole monorepo from the git root; sibling apps pollute every result list. (#54617)
+- **Filename-only display.** Results show bare filenames; multiple `index.ts` are indistinguishable. (#51892, #17793)
+- **`.ignore` / `.rgignore` / `.claudeignore` ignored.** Only `.gitignore` participates, and only via `git ls-files`. (#30176, #45691)
+- **Hidden directories indexed.** `.git/objects/`, `~/.claude/skills/*/node_modules`, `.venv` end up in the index, causing 2-5 s freezes. (#11673)
+- **Diacritic-insensitive matching missing.** `cafe` doesn't match `café`. (#33341, closed)
+- **CJK / IME input bypasses the script entirely.** Even the custom `fileSuggestion` command isn't invoked when typing non-ASCII. (#23911)
+- **Bundled ripgrep crashes on 16 KB-page kernels (Apple Silicon, some Linux).** `<jemalloc>: Unsupported system page size`; picker silently returns nothing. Workaround `USE_BUILTIN_RIPGREP=0`. (#11307, #7661)
+- **`respectGitignore: false` silently ignored** in some 2.0.x and 2.1.x releases. (#14904)
+- **VS Code extension picker** had a 5-10 s regression in 2.1.27-2.1.31, partially fixed in 2.1.32+. (#22434, #22446, #22950)
+- **No fuzzy-search keybind to navigate results**, no preview pane, no multi-select.
+
+## Root cause analysis
+
+Reverse-engineered from the v2.1.126 binary at `/nix/store/280qb7zhg6i2zg9q7g8b2fcmqm92j283-claude-code-2.1.126/bin/.claude-wrapped`. All quoted code is minified JS embedded in the bun binary.
+
+### The matcher: bespoke subsequence scorer in class `qj$`
+
+```js
+class qj${
+  paths=[]; lowerPaths=[]; charBits=new Int32Array(0);
+  pathLens=new Uint16Array(0); topLevelCache=null; readyCount=0;
+  // ...
+  search(H, $) {
+    if ($ <= 0) return [];
+    if (H.length === 0) { /* return cached top-level dirs */ }
+    let q = H !== H.toLowerCase();              // case-sensitive iff query mixed-case
+    let K = q ? H : H.toLowerCase();
+    let _ = Math.min(K.length, 64);             // queries truncated at 64 chars
+    let A = Array(_), z = 0;
+    for (let G = 0; G < _; G++) {               // build query bitset
+      let W = K.charAt(G); A[G] = W;
+      let Z = W.charCodeAt(0);
+      if (Z >= 97 && Z <= 122) z |= 1 << (Z - 97);
+    }
+    // ... main loop:
+    H: for (let G = 0; G < X; G++) {
+      if ((w[G] & z) !== z) continue;           // bitset prefilter (a-z only)
+      let W = q ? M[G] : D[G];
+      let Z = W.indexOf(A[0]); if (Z === -1) continue;
+      // walk subsequence left-to-right
+      for (let C = 1; C < _; C++) {
+        if (Z = W.indexOf(A[C], N + 1), Z === -1) continue H;
+        let F = Z - N - 1;
+        if (F === 0) V += 4;                    // adjacent: +4
+        else v += 3 + F * 1;                    // gap penalty: -3 -F
+        N = Z;
+      }
+      // base score
+      let R = _ * 16 + V - v;
+      R += Yc7(I, hA8[0], !0);                  // word-boundary bonus on first hit
+      for (let C = 1; C < _; C++) R += Yc7(I, hA8[C], !1);
+      R += Math.max(0, 32 - (S >> 2));          // shorter paths preferred
+      // ... keep top-$ results
+    }
+    // tie-break / normalise:
+    P[G] = { path: W, score: W.includes("test") ? Math.min(Z*1.05, 1) : Z };
+  }
+}
+function Yc7(H, $, q) {
+  if ($ === 0) return q ? 8 : 0;
+  let K = H.charCodeAt($ - 1);
+  if (wn_(K)) return 8;                         // / \ - _ . space → +8
+  if (jn_(K) && Xn_(H.charCodeAt($))) return 6; // camelCase boundary → +6
+  return 0;
+}
+```
+
+What this proves:
+
+- **It is a subsequence matcher**, equivalent in spirit to early Sublime/CtrlP, but without the bigram, transposition, or BM25 refinements that fzf/fzy/fuzzysort have iterated on for a decade. There is no Smith-Waterman, no bitap, no Levenshtein. Reordered or split queries fail outright.
+- **Lowercased** unless the query has any uppercase character, in which case matching becomes case-sensitive (smartcase). Diacritics are not normalised.
+- **Char-class bitset** limited to `a-z`; non-ASCII characters bypass the prefilter and search every path linearly.
+- **Result cap is hard-coded** at `VT6 = 15`.
+- **`test` boost is a special case**, not a general scoring rule. There is no concept of "open in IDE", recency, or frecency.
+- **Scoring favours short paths** via `32 - (pathLen >> 2)`, which is why deep monorepo paths systematically rank below shorter siblings even when they're the better match.
+
+### The index: `git ls-files` first, ripgrep fallback
+
+```js
+async function vn_(H, $, q) {
+  let K = await Gn_(H, $, q);                   // git ls-files --recurse-submodules
+  if (K !== null) return K;
+  // ripgrep fallback
+  let M = ["--files","--follow","--hidden",
+           "--glob","!.git/","--glob","!.svn/", "--glob","!.hg/",
+           "--glob","!.bzr/","--glob","!.jj/","--glob","!.sl/"];
+  if (!q) M.push("--no-ignore-vcs");
+  Y = await jo(M, A, $);
+}
+```
+
+- Inside a git repo: `git -c core.quotepath=false ls-files --recurse-submodules`. **Untracked files, gitignored files, anything not committed do not appear.**
+- Outside a git repo: ripgrep `--files --hidden`, optionally with `--no-ignore-vcs` if `respectGitignore=false`.
+- Index is rebuilt on a 5-second cooldown (`Nn_ = 5000`) **and** when the git index `mtime` changes. New files in non-git directories rely on filesystem signature comparison, which has the staleness bug in #53517.
+- `.ignore`, `.rgignore`, `.fdignore`, `.claudeignore` are not consulted.
+
+### The dispatch path
+
+```js
+async function zcH(H, $, q = !1) {
+  if (h6()) return En_($);                                    // remote / VS Code RPC
+  if (x6().fileSuggestion?.type === "command")
+    return (await hT6(...)).slice(0, VT6).map(SA8);            // user override
+  if ($ === "" || $ === "." || $ === "./") {                  // empty query
+    let _ = await yn_();                                       // readdir of cwd
+    return _.slice(0, VT6).map(SA8);
+  }
+  Kj$(H);                                                      // refresh index
+  let Y = H.fileIndex ? kn_(H.fileIndex, A) : [];              // qj$.search
+  return Y;
+}
+```
+
+- **Empty query** (`@`) returns `readdir(cwd)`, sliced to 15 — explains why "I just see the same handful of top-level files".
+- **Custom command** is the only way to bypass the in-process matcher.
+- **Remote / VS Code mode** (`En_`) RPCs to the editor's file index, which has its own bugs (#22211, #22446, #22434).
+
+## Community reports
+
+Loudest signal first.
+
+| Issue | State | One-line summary |
+|-------|-------|------------------|
+| [#20065](https://github.com/anthropics/claude-code/issues/20065) | closed | "Implement fuzzy file search for `@` symbol file mentions" — request for fzf-style matching. Closed, never properly implemented. |
+| [#8530](https://github.com/anthropics/claude-code/issues/8530) | closed | "Improve `@` file search command for large repos" — 3-5 s per keystroke; comment: "the experience in OpenCode (where they use fuzzysearch) is both faster and more accurate". |
+| [#11673](https://github.com/anthropics/claude-code/issues/11673) | closed (dup) | "@ file autocomplete shows .git/objects and dependency directories causing 2-5 s delays". |
+| [#11307](https://github.com/anthropics/claude-code/issues/11307) | closed | "File fuzzy matcher incomplete suggestions for nested directories" — bundled ripgrep crashes on 16 KB-page kernels; workaround `USE_BUILTIN_RIPGREP=0`. |
+| [#9570](https://github.com/anthropics/claude-code/issues/9570) | closed | "Fuzzy File Search Fails After `@` Input" — `@trackacctabc` returns nothing in Claude Code; Codex finds the file. |
+| [#7661](https://github.com/anthropics/claude-code/issues/7661) | closed | "File Picker Fails to List Complete Directory Contents" — bundled `rg` rejected `--ripgrep` flag, picker silently empty. |
+| [#54617](https://github.com/anthropics/claude-code/issues/54617) | open | "Limit @ file picker scope to working directory in monorepo" — sibling apps pollute every search. |
+| [#52092](https://github.com/anthropics/claude-code/issues/52092) | open | "@ file picker should support fuzzy filename search in additionalDirectories". |
+| [#53517](https://github.com/anthropics/claude-code/issues/53517) | open | "Newly created files invisible until session restart" — prefix index goes stale. |
+| [#51892](https://github.com/anthropics/claude-code/issues/51892) | open | "File paths not shown in search results, making disambiguation hard". |
+| [#45691](https://github.com/anthropics/claude-code/issues/45691) | open | "Filter @ mention file suggestions via settings or `.claudeignore`". |
+| [#45012](https://github.com/anthropics/claude-code/issues/45012) | closed | "@-completion no longer suggests gitignored files since v2.1.94" — regression; explicit knowledge-base use case raised. |
+| [#36647](https://github.com/anthropics/claude-code/issues/36647) | open | ".gitignored files excluded from @ picker" — breaks data/notes workflows. |
+| [#30176](https://github.com/anthropics/claude-code/issues/30176) | open | ".ignore / .rgignore are not respected by file picker". |
+| [#23287](https://github.com/anthropics/claude-code/issues/23287) | open | "File autocomplete suggestions disappear when navigating subdirectories". |
+| [#22434](https://github.com/anthropics/claude-code/issues/22434) | closed | "Severe file picker performance regression (VS Code Extension)" — 5-10 s per keystroke in 2.1.27-2.1.31. |
+| [#22737](https://github.com/anthropics/claude-code/issues/22737) | open | "fileSuggestion custom command not working" — query never passed to script in some configurations. |
+| [#23911](https://github.com/anthropics/claude-code/issues/23911) | open | "fileSuggestion command not invoked when typing non-ASCII (CJK) characters". |
+| [#14904](https://github.com/anthropics/claude-code/issues/14904) | open | "respectGitignore in file picker setting ignored in 2.0.75". |
+| [#7412](https://github.com/anthropics/claude-code/issues/7412) | open | "@ mentions don't work with additional directories included via /add-dir". |
+
+Representative quotes:
+
+> "Has anyone found a workaround for a bug where claude code's @ mentioning of files and subsequently its fuzzy searching is completely broken? It seems like after typing @ it'll suggest files at the top level, but if I type anything in to fuzzy search for a file (either at the top-level or somewhere further down the file tree), no file results show up. In case you're thinking 'wait doesn't that render claude code completely useless', the answer is yes."  
+> — [r/ClaudeCode, 2025-09-16](https://www.reddit.com/r/ClaudeCode/comments/1nii13n/fuzzy_file_searching_has_been_broken_for_like_a/)
+
+> "Using cc in a large monorepo - not sure when it happened but it seems like the file picker (@) now seems to be indexing node modules and that's caused it to become incredibly slow. I've tried a few things - .claudeignore, denying reads to node modules etc but nothing has worked. Claude code itself has not managed to figure this out either btw, ha."  
+> — [r/ClaudeAI](https://www.reddit.com/r/ClaudeAI/comments/1po0tb9/cc_slow_file_picker_due_to_node_modules/)
+
+> "I'd like to type @xyzpack (a bit of the path + a bit of the file name) to narrow down the results. I think with the current finder, the search string still must be a connected substring of the path string. But with your script it works."  
+> — [@gruhn on #20065](https://github.com/anthropics/claude-code/issues/20065)
+
+> "The default `@` file matcher was always disappointing me, being used to superior options like fzf. It was also not suggesting stuff from gitignored or symlinked folders, which was annoying as hell."  
+> — [r/ClaudeAI, 2025-12-19](https://www.reddit.com/r/ClaudeAI/comments/1pqlcyz/custom_file_picker_with_fzf_superior_fuzzy/)
+
+## Workarounds available today
+
+### 1. Replace the picker with `fd | fzf` via `fileSuggestion`
+
+This is the only fix that addresses the matching algorithm. Documented at <https://docs.claude.com/en/docs/claude-code/settings>. The picker calls the script on every keystroke; the script receives `{"query": "..."}` on stdin and must emit up to 15 newline-separated paths.
+
+`~/.claude/settings.json`:
+
+```json
+{
+  "fileSuggestion": {
+    "type": "command",
+    "command": "~/.claude/file-suggestion.sh"
+  }
+}
+```
+
+`~/.claude/file-suggestion.sh` (tools already on PATH for Martin: `/home/martin/.nix-profile/bin/{fd,fzf,rg,jq}`):
+
+```bash
+#!/usr/bin/env bash
+# Custom @ file picker: fd to enumerate, fzf to score.
+# - Uses fd for speed (parallel walker, native gitignore + .ignore + .fdignore).
+# - fzf --filter performs proper fuzzy scoring (Smith-Waterman-ish, with
+#   bigram bonuses, word-boundary boosts, deep-path penalty).
+
+set -euo pipefail
+
+# Avoid jq dependency: extract the query field with a tolerant sed.
+read -r INPUT || INPUT=''
+QUERY=$(printf '%s' "$INPUT" | sed -n 's/.*"query"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+cd "$PROJECT_DIR" || exit 0
+
+if [[ -z "$QUERY" ]]; then
+  # Empty query: most-recently-modified files, newest first.
+  fd --type f --hidden --follow --color never --changed-within 7d 2>/dev/null \
+    | head -15
+  exit 0
+fi
+
+fd --type f --hidden --follow --color never 2>/dev/null \
+  | fzf --filter "$QUERY" \
+  | head -15
+```
+
+```bash
+chmod +x ~/.claude/file-suggestion.sh
+```
+
+Notes:
+
+- `.fdignore` is per-project; use it to exclude generated dirs without touching `.gitignore`.
+- For Nix-style profiles where `fd` is not on Claude Code's PATH, hard-code absolute paths (`/home/martin/.nix-profile/bin/fd`) or prepend PATH inside the script.
+- Symlinked directories are followed (`--follow`); drop that flag if it pulls in too much.
+- The 15-result cap is enforced by Claude Code regardless. Trust `fzf`'s ranking; never sort by name.
+
+### 2. Project-scoped variant: drop the script in the repo
+
+Set `fileSuggestion.command` to `.claude/file-suggestion.sh` in `.claude/settings.json`. Useful for monorepo subpaths where you want each app to scope its picker to its own subtree (#54617):
+
+```bash
+#!/usr/bin/env bash
+cd "${CLAUDE_PROJECT_DIR:-$PWD}/apps/$(basename "$PWD")" 2>/dev/null \
+  || cd "${CLAUDE_PROJECT_DIR:-$PWD}"
+fd --type f --hidden --follow . \
+  | fzf --filter "$(sed -n 's/.*"query"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')" \
+  | head -15
+```
+
+### 3. Built-in knobs (without replacing the matcher)
+
+These do not fix the algorithm, but they reduce the worst symptoms.
+
+- `respectGitignore: false` in `settings.json` (or `/config`): include gitignored files. Buggy in some versions (#14904); confirm by typing `@` and inspecting `~/.claude.json` afterwards.
+- `permissions.additionalDirectories`: extend the picker beyond cwd. Note fuzzy search inside those dirs is broken (#52092).
+- Environment variables relevant to the picker:
+  - `USE_BUILTIN_RIPGREP=0` — skips the bundled `rg` and uses the system one. Required on 16 KB-page kernels; harmless elsewhere when system `rg` is present.
+- `/add-dir` to register an extra root in-session.
+
+### 4. Sidestep the picker entirely
+
+- Drag-and-drop a file into the terminal; most terminals paste an absolute path that Claude Code recognises.
+- Pipe a list into the prompt: ``$(fzf -m | xargs -I{} echo "@{}")``. Crude but reliable.
+- Use the `Read` tool by name and let Claude search via `Glob`/`Grep` rather than mentioning files inline.
+- Editor pickers — Telescope, fzf-lua, Snacks.nvim — copy paths to the system clipboard, then paste with `@`.
+
+### 5. MCP servers
+
+There is no canonical "better picker" MCP server. The picker reads from a process-local index, not from MCP. An MCP server can expose `Read` and `Glob` for files outside the workspace, but it cannot replace the `@`-completion UI. The escape hatch is `fileSuggestion`, full stop.
+
+## Recommended path forward
+
+Ranked for Martin's situation (Linux, Nix-managed home, fd/fzf/rg/jq already in `~/.nix-profile/bin`).
+
+1. **Adopt `fileSuggestion` with `fd | fzf`** (workaround 1). Highest impact, ten-line script, reversible. Trade-off: shells out per keystroke, so latency is bounded by `fd` start-up (~5-10 ms) plus fzf scoring; on this hardware that's still well under the current built-in matcher's worst case. Keep the script in the home-manager mixin so it tracks across hosts.
+2. **Manage the script declaratively in this flake.** Drop it under `home-manager/_mixins/claude-code/` (or wherever Claude Code config lives) using `pkgs.writeShellApplication` so `runtimeInputs = [ pkgs.fd pkgs.fzf ]` and shellcheck validates it. Wire it into `home.file.".claude/file-suggestion.sh"` and add the `fileSuggestion` block to `~/.claude/settings.json` via the existing claude-code mixin. Trade-off: one more moving part in the config, but it brings the picker behaviour under version control.
+3. **Set `USE_BUILTIN_RIPGREP=0`** in the Claude Code wrapper (already a Nix-wrapped derivation). System `rg` is on PATH from `pkgs.ripgrep`, so this is free reliability. Trade-off: none worth mentioning.
+4. **File a bug or +1 the loudest open issues** (#54617 monorepo scope, #52092 additionalDirectories fuzzy, #51892 path display, #53517 stale index). Trade-off: low-effort, signals demand, but Anthropic's track record on these is poor — see closure of #20065 without a real fix.
+5. **Wait for an upstream rewrite.** No public roadmap commits to a real fuzzy matcher. The 2.1.94 changelog claimed "improved fuzzy matching" yet shipped a regression that excluded gitignored files (#45012). Don't bank on this.
+6. **Switch to a competitor for `@` workflows** (OpenCode, Codex, Aider). Trade-off: nuclear option, breaks too many other Claude Code-specific habits to recommend.
+
+→ Do (1) + (2) + (3) together; cost is one mixin and a shell script, payoff is the picker stops being painful.
+
+## References
+
+### Source code (local Claude Code 2.1.126 binary)
+
+- `/nix/store/280qb7zhg6i2zg9q7g8b2fcmqm92j283-claude-code-2.1.126/bin/.claude-wrapped` — bun-compiled ELF; `qj$.search`, `vn_`, `Gn_`, `zcH`, `Yc7`, `wn_`, `jn_`, `Xn_` cited above. `VT6 = 15` result cap, `Nn_ = 5000` ms cache cooldown, `_ = Math.min(K.length, 64)` query truncation.
+- Settings schema string in same binary: `"Custom file suggestion configuration for @ mentions"`, `"Whether file picker should respect .gitignore files (default: true). Note: .ignore files are always respected"` (the latter is a lie per #30176).
+
+### Official docs
+
+- <https://docs.claude.com/en/docs/claude-code/settings> — `fileSuggestion`, `respectGitignore`, `permissions.additionalDirectories`.
+- <https://gist.github.com/mculp/c082bd1e5a439410158974de90c89db7> — third-party annotated settings.json reference (v2.1.104, April 2026).
+
+### GitHub issues (anthropics/claude-code)
+
+- <https://github.com/anthropics/claude-code/issues/20065> — fuzzy search request, closed without fix.
+- <https://github.com/anthropics/claude-code/issues/8530> — large-repo perf, closed.
+- <https://github.com/anthropics/claude-code/issues/11673> — .git/objects and dep dirs in index.
+- <https://github.com/anthropics/claude-code/issues/11307> — bundled rg + 16 KB pages.
+- <https://github.com/anthropics/claude-code/issues/9570> — fuzzy returns nothing.
+- <https://github.com/anthropics/claude-code/issues/7661> — picker empty due to bundled rg.
+- <https://github.com/anthropics/claude-code/issues/54617> — monorepo scope.
+- <https://github.com/anthropics/claude-code/issues/52092> — additionalDirectories fuzzy.
+- <https://github.com/anthropics/claude-code/issues/53517> — stale prefix index.
+- <https://github.com/anthropics/claude-code/issues/51892> — paths missing from results.
+- <https://github.com/anthropics/claude-code/issues/45691> — .claudeignore for picker.
+- <https://github.com/anthropics/claude-code/issues/45012> — gitignored regression.
+- <https://github.com/anthropics/claude-code/issues/36647> — gitignore exclusion.
+- <https://github.com/anthropics/claude-code/issues/30176> — .ignore not respected.
+- <https://github.com/anthropics/claude-code/issues/23287> — autocomplete vanishes in subdirs.
+- <https://github.com/anthropics/claude-code/issues/22434> — VS Code regression.
+- <https://github.com/anthropics/claude-code/issues/22737> — fileSuggestion broken in some modes.
+- <https://github.com/anthropics/claude-code/issues/23911> — CJK / IME bypass.
+- <https://github.com/anthropics/claude-code/issues/14904> — respectGitignore ignored.
+- <https://github.com/anthropics/claude-code/issues/7412> — /add-dir not searched.
+
+### Community workarounds
+
+- <https://www.reddit.com/r/ClaudeAI/comments/1pqlcyz/custom_file_picker_with_fzf_superior_fuzzy/> — original rg+fzf write-up.
+- <https://thayto.com/en/blog/claude-code-faster-file-suggestion> — same approach, blog form.
+- <https://gist.github.com/cicorias/b05390abb6a0582930da4c9d9734cdab> — gist, rg+fzf.
+- <https://gist.github.com/kvirani/bf36d4e4236e57d617c6240096a0fc7d> — fd+fzf for non-git workspaces (UE5, Perforce); explains `.fdignore` vs `.ignore` vs `.claudeignore`.
+- <https://github.com/gutyoh/claude-code-config> — reusable repo with auto-installer and Windows port.
+- <https://www.reddit.com/r/ClaudeAI/comments/1po0tb9/cc_slow_file_picker_due_to_node_modules/> — node_modules slowdown report.
+- <https://www.reddit.com/r/ClaudeCode/comments/1nii13n/fuzzy_file_searching_has_been_broken_for_like_a/> — fuzzy search broken thread.

--- a/home-manager/_mixins/development/claude-code/file-suggestion/default.nix
+++ b/home-manager/_mixins/development/claude-code/file-suggestion/default.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+# Claude Code `fileSuggestion` command: replaces the broken built-in `@` picker
+# with `fd | fzf --filter`. Wired into `programs.claude-code.settings.fileSuggestion`
+# from the parent module via `lib.getExe`. See `file-suggestion.sh` for the
+# selection logic.
+let
+  name = "claude-file-suggestion";
+in
+pkgs.writeShellApplication {
+  inherit name;
+  runtimeInputs = with pkgs; [
+    fd
+    fzf
+    coreutils
+    gnused
+    gawk
+  ];
+  text = builtins.readFile ./file-suggestion.sh;
+}

--- a/home-manager/_mixins/development/claude-code/file-suggestion/file-suggestion.sh
+++ b/home-manager/_mixins/development/claude-code/file-suggestion/file-suggestion.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Replace Claude Code's broken @ picker with fd + fzf scoring.
+#
+# Claude Code's built-in fuzzy finder is a bespoke subsequence matcher capped
+# at 15 results, indexed via `git ls-files`. It misses untracked files and
+# fails on word-fragment queries. This script is wired in via the
+# `fileSuggestion` escape hatch in settings.json, which receives a JSON
+# `{"query": "..."}` blob on stdin and emits up to 15 newline-separated paths.
+# fd enumerates fast and respects gitignore plus .ignore and .fdignore;
+# fzf --filter performs proper fuzzy scoring with bigram and word-boundary
+# bonuses.
+#
+# `pkgs.writeShellApplication` injects `set -euo pipefail` ahead of this
+# source, which bites in two places: `fzf --filter QUERY` exits 1 on zero
+# matches, and any pipe into `head -N` triggers SIGPIPE (141) on the upstream
+# producer once it has emitted more than N lines. Either failure causes the
+# whole script to abort with no output, leaving the picker empty even when
+# results were ready. The fix is to capture command output into variables
+# rather than streaming through `head`, and to neutralise the expected
+# non-zero exits with `|| true`.
+
+# Avoid jq dependency. Extract the query field with a tolerant sed expression
+# so the script stays usable even when jq is not on the PATH Claude Code
+# inherits.
+read -r INPUT || INPUT=''
+QUERY=$(printf '%s' "$INPUT" | sed -n 's/.*"query"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+# Search root: prefer the project directory Claude Code exports, fall back to
+# the working directory if it is not set.
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 0
+
+# Print the first 15 lines of stdin without closing the upstream pipe early.
+# `head -15` closes its input as soon as the cap is reached and SIGPIPEs the
+# producer; under `pipefail` that becomes a script-wide exit 141. `awk`
+# instead consumes the full stream and only prints the first 15 lines, so
+# the producer always exits cleanly.
+take15() {
+  awk 'NR<=15'
+}
+
+if [[ -z "$QUERY" ]]; then
+  # Empty query (`@` with no characters typed): prefer files changed in the
+  # last 7 days; fall back to the full tree when the recency filter would
+  # otherwise return nothing (fresh checkouts, long-idle projects). Both
+  # branches go through `take15` to enforce the 15-result cap.
+  RECENT=$(fd --type f --hidden --follow --color never --changed-within 7d 2>/dev/null || true)
+  if [[ -z "$RECENT" ]]; then
+    RECENT=$(fd --type f --hidden --follow --color never 2>/dev/null || true)
+  fi
+  printf '%s\n' "$RECENT" | take15
+  exit 0
+fi
+
+# `fzf --filter` exits 1 when no matches are found; `|| true` keeps that from
+# tripping `errexit`. `fd` output is captured into a variable so that the
+# `head`-style trim downstream does not SIGPIPE the walker.
+ALL=$(fd --type f --hidden --follow --color never 2>/dev/null || true)
+RANKED=$(printf '%s\n' "$ALL" | fzf --filter "$QUERY" 2>/dev/null || true)
+printf '%s\n' "$RANKED" | take15

--- a/home-manager/_mixins/development/claude-code/file-suggestion/file-suggestion.sh
+++ b/home-manager/_mixins/development/claude-code/file-suggestion/file-suggestion.sh
@@ -53,7 +53,11 @@ fi
 
 # `fzf --filter` exits 1 when no matches are found; `|| true` keeps that from
 # tripping `errexit`. `fd` output is captured into a variable so that the
-# `head`-style trim downstream does not SIGPIPE the walker.
+# `head`-style trim downstream does not SIGPIPE the walker. When fzf returns
+# zero matches `$RANKED` is empty; printing it would emit a blank result line
+# the picker shows as a phantom row, so skip the print in that case.
 ALL=$(fd --type f --hidden --follow --color never 2>/dev/null || true)
 RANKED=$(printf '%s\n' "$ALL" | fzf --filter "$QUERY" 2>/dev/null || true)
-printf '%s\n' "$RANKED" | take15
+if [[ -n "$RANKED" ]]; then
+  printf '%s\n' "$RANKED" | take15
+fi

--- a/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
+++ b/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
@@ -626,14 +626,22 @@ classify_leaf() {
 					printf 'safe\n'
 					return
 				fi
-				# Read-only flags: -a, -r, -v(v), --list, --contains,
-				# --merged, --no-merged, --points-at, --show-current,
-				# --column, --sort, --format. Anything starting with
-				# something else (e.g. -d, -D, -m, -M, --set-upstream,
-				# bare branch name to create) defers.
-				if [[ $git_rest =~ ^(-a|-r|-v|-vv|-av|-rv|-arv|--list|--contains|--no-contains|--merged|--no-merged|--points-at|--show-current|--column|--no-column|--sort|--format|--all|--remotes|--verbose)([[:space:]]|=|$) ]]; then
-					printf 'safe\n'
-					return
+				# Defer if any write-capable flag appears anywhere in
+				# the rest. `git branch` accepts mixed flag orders, e.g.
+				# `git branch -v -d feature` lists then deletes, so we
+				# cannot rely on the leading flag alone. This guard runs
+				# BEFORE the read-only flag check so write flags reject
+				# the whole invocation no matter their position.
+				if ! [[ $git_rest =~ (^|[[:space:]])(-d|-D|-m|-M|-c|-C|--delete|--move|--copy|--set-upstream-to|--unset-upstream|--edit-description|--track|--no-track|--create-reflog)([[:space:]]|=|$) ]]; then
+					# Read-only flags: -a, -r, -v(v), --list, --contains,
+					# --merged, --no-merged, --points-at, --show-current,
+					# --column, --sort, --format. Anything starting with
+					# something else (e.g. bare branch name to create)
+					# also defers.
+					if [[ $git_rest =~ ^(-a|-r|-v|-vv|-av|-rv|-arv|--list|--contains|--no-contains|--merged|--no-merged|--points-at|--show-current|--column|--no-column|--sort|--format|--all|--remotes|--verbose)([[:space:]]|=|$) ]]; then
+						printf 'safe\n'
+						return
+					fi
 				fi
 				;;
 			tag)
@@ -655,9 +663,11 @@ classify_leaf() {
 					printf 'safe\n'
 					return
 				fi
-				# Read-only forms: -v / --verbose, show <name>,
-				# get-url <name>.
-				if [[ $git_rest =~ ^(-v|--verbose)([[:space:]]|$) ]]; then
+				# Read-only forms: bare `-v`/`--verbose`, `show <name>`,
+				# `get-url <name>`. `-v` followed by a write subcommand
+				# (e.g. `remote -v remove origin`) must defer, so the
+				# verbose check anchors to end-of-string.
+				if [[ $git_rest =~ ^(-v|--verbose)$ ]]; then
 					printf 'safe\n'
 					return
 				fi

--- a/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
+++ b/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
@@ -86,8 +86,12 @@ KNOWN_SAFE_COMMANDS=(
 	identify
 	# Nix inspection-only commands
 	nix-info nix-tree nix-diff nvd statix deadnix nixfmt alejandra
-	# Just listing
-	just
+	# Note: `just` is intentionally NOT listed. It used to be here so the
+	# hook could auto-approve safe recipes, but Claude Code's hook contract
+	# states ask rules still prompt even when a hook returns "allow"
+	# (https://code.claude.com/docs/en/hooks.md). Specific `just` recipes
+	# are allow-listed in default.nix instead, and unknown subcommands fall
+	# through to the default prompt.
 )
 
 # Commands that this hook will NEVER auto-approve, even for `--help`/`--version`.

--- a/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
+++ b/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
@@ -112,6 +112,27 @@ DENY_COMMANDS=(
 	grub-install update-grub efibootmgr
 	rm rmdir
 	nix-collect-garbage
+	# System-state rebuild tools must always prompt, even for `--help` /
+	# `--version` / read-only subcommands like `home-manager generations`
+	# or `home-manager news`. The boundary is uniform: any invocation of
+	# these tools requires explicit approval, so they sit on DENY_COMMANDS
+	# to short-circuit the help/version auto-approve rule. The leaf still
+	# falls through to defer (it is not on KNOWN_SAFE_COMMANDS), which
+	# routes to the static `Bash(home-manager:*)` ask rule in default.nix.
+	home-manager nixos-rebuild darwin-rebuild
+)
+
+# Read-only git subcommands. Mirrors the `Bash(git <subcommand>:*)` entries in
+# `bashAllow` (see default.nix) so that `git -C <path> <subcommand>` shapes,
+# which Claude Code's positional static matcher cannot express, evaluate to
+# safe through the hook. The static allow already covers plain
+# `git <subcommand>` so this list is consulted only when the leaf carries the
+# `-C <path>` prefix.
+GIT_READONLY_SUBCOMMANDS=(
+	status diff log show branch remote tag reflog rev-parse describe
+	shortlog blame ls-files ls-tree ls-remote grep config worktree
+	name-rev cat-file count-objects for-each-ref symbolic-ref
+	verify-commit verify-tag stash
 )
 
 # ---------------------------------------------------------------------------
@@ -562,6 +583,28 @@ classify_leaf() {
 		fi
 		# Bare `cmd --help` (no extra args) and bare `cmd help` (no subcommand)
 		if [[ $leaf =~ ^[A-Za-z][A-Za-z0-9._/+-]*[[:space:]]+(--help|-h|--version|-V|help|version)$ ]]; then
+			printf 'safe\n'
+			return
+		fi
+	fi
+
+	# `git -C <path> <subcommand> [args...]` shape. The static `Bash(git
+	# <subcommand>:*)` allow rules in default.nix cannot cover this form
+	# because Claude Code's matcher is positional and `-C` slides every later
+	# token along by two. Approve only when the subcommand sits on the
+	# read-only set above; for write operations like `git -C <path> commit`
+	# this falls through to the static ask rules.
+	#
+	# Special-case `stash`: only `stash list` and `stash show` are read-only.
+	if [[ $cmd == "git" && $leaf =~ ^git[[:space:]]+-C[[:space:]]+[^[:space:]]+[[:space:]]+([A-Za-z][A-Za-z0-9_-]*)([[:space:]]+(.*))?$ ]]; then
+		local git_sub=${BASH_REMATCH[1]}
+		local git_rest=${BASH_REMATCH[3]:-}
+		if [[ $git_sub == "stash" ]]; then
+			if [[ $git_rest =~ ^(list|show)([[:space:]]|$) ]]; then
+				printf 'safe\n'
+				return
+			fi
+		elif _in_list "$git_sub" "${GIT_READONLY_SUBCOMMANDS[@]}"; then
 			printf 'safe\n'
 			return
 		fi

--- a/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
+++ b/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
@@ -128,11 +128,16 @@ DENY_COMMANDS=(
 # safe through the hook. The static allow already covers plain
 # `git <subcommand>` so this list is consulted only when the leaf carries the
 # `-C <path>` prefix.
+#
+# Subcommands with both read-only and write modes (branch, tag, remote, config,
+# worktree, reflog, stash) are NOT listed here - they are special-cased below
+# so that only known-read-only forms approve and write forms defer to the
+# static ask rules.
 GIT_READONLY_SUBCOMMANDS=(
-	status diff log show branch remote tag reflog rev-parse describe
-	shortlog blame ls-files ls-tree ls-remote grep config worktree
+	status diff log show rev-parse describe
+	shortlog blame ls-files ls-tree ls-remote grep
 	name-rev cat-file count-objects for-each-ref symbolic-ref
-	verify-commit verify-tag stash
+	verify-commit verify-tag
 )
 
 # ---------------------------------------------------------------------------
@@ -595,19 +600,109 @@ classify_leaf() {
 	# read-only set above; for write operations like `git -C <path> commit`
 	# this falls through to the static ask rules.
 	#
-	# Special-case `stash`: only `stash list` and `stash show` are read-only.
+	# Subcommands that are mostly read-only but have write modes are
+	# special-cased: only known-read-only forms approve, everything else
+	# defers so the static ask rules can prompt.
+	#   stash    : list, show only
+	#   branch   : bare or list/inspect flags only; -d/-D/-m/-M/--set-upstream defer
+	#   tag      : bare or -l/--list only; -d/-a/-s defer
+	#   remote   : bare, -v, show <name>, get-url <name> only; add/remove/rename/set-url defer
+	#   config   : --list, --get, --get-all, --get-regexp only; mutations defer
+	#   worktree : list only; add/remove/move/prune/lock/unlock/repair defer
+	#   reflog   : bare or show only; expire/delete/exists defer
 	if [[ $cmd == "git" && $leaf =~ ^git[[:space:]]+-C[[:space:]]+[^[:space:]]+[[:space:]]+([A-Za-z][A-Za-z0-9_-]*)([[:space:]]+(.*))?$ ]]; then
 		local git_sub=${BASH_REMATCH[1]}
 		local git_rest=${BASH_REMATCH[3]:-}
-		if [[ $git_sub == "stash" ]]; then
-			if [[ $git_rest =~ ^(list|show)([[:space:]]|$) ]]; then
-				printf 'safe\n'
-				return
-			fi
-		elif _in_list "$git_sub" "${GIT_READONLY_SUBCOMMANDS[@]}"; then
-			printf 'safe\n'
-			return
-		fi
+		case $git_sub in
+			stash)
+				if [[ $git_rest =~ ^(list|show)([[:space:]]|$) ]]; then
+					printf 'safe\n'
+					return
+				fi
+				;;
+			branch)
+				# Bare `git -C <path> branch` -> approve
+				if [[ -z $git_rest ]]; then
+					printf 'safe\n'
+					return
+				fi
+				# Read-only flags: -a, -r, -v(v), --list, --contains,
+				# --merged, --no-merged, --points-at, --show-current,
+				# --column, --sort, --format. Anything starting with
+				# something else (e.g. -d, -D, -m, -M, --set-upstream,
+				# bare branch name to create) defers.
+				if [[ $git_rest =~ ^(-a|-r|-v|-vv|-av|-rv|-arv|--list|--contains|--no-contains|--merged|--no-merged|--points-at|--show-current|--column|--no-column|--sort|--format|--all|--remotes|--verbose)([[:space:]]|=|$) ]]; then
+					printf 'safe\n'
+					return
+				fi
+				;;
+			tag)
+				# Bare `git -C <path> tag` -> approve (lists tags)
+				if [[ -z $git_rest ]]; then
+					printf 'safe\n'
+					return
+				fi
+				# Read-only flags only: -l, --list, -n, --contains,
+				# --points-at, --merged, --no-merged, --sort, --format.
+				if [[ $git_rest =~ ^(-l|--list|-n|--contains|--no-contains|--points-at|--merged|--no-merged|--sort|--format|--column|--no-column)([[:space:]]|=|$) ]]; then
+					printf 'safe\n'
+					return
+				fi
+				;;
+			remote)
+				# Bare `git -C <path> remote` -> approve (lists remotes)
+				if [[ -z $git_rest ]]; then
+					printf 'safe\n'
+					return
+				fi
+				# Read-only forms: -v / --verbose, show <name>,
+				# get-url <name>.
+				if [[ $git_rest =~ ^(-v|--verbose)([[:space:]]|$) ]]; then
+					printf 'safe\n'
+					return
+				fi
+				if [[ $git_rest =~ ^(show|get-url)([[:space:]]|$) ]]; then
+					printf 'safe\n'
+					return
+				fi
+				;;
+			config)
+				# Only --list / --get / --get-all / --get-regexp /
+				# --get-urlmatch are read-only. A bare `git config` or
+				# `git config <key> <value>` mutates and must defer.
+				if [[ $git_rest =~ ^(--list|--get|--get-all|--get-regexp|--get-urlmatch)([[:space:]]|=|$) ]]; then
+					printf 'safe\n'
+					return
+				fi
+				;;
+			worktree)
+				# Only `worktree list` is read-only. add/remove/move/
+				# prune/lock/unlock/repair all mutate.
+				if [[ $git_rest =~ ^list([[:space:]]|$) ]]; then
+					printf 'safe\n'
+					return
+				fi
+				;;
+			reflog)
+				# Bare `git -C <path> reflog` (defaults to show) -> approve.
+				if [[ -z $git_rest ]]; then
+					printf 'safe\n'
+					return
+				fi
+				# `reflog show [args...]` is read-only. expire/delete/
+				# exists rewrite history and must defer.
+				if [[ $git_rest =~ ^show([[:space:]]|$) ]]; then
+					printf 'safe\n'
+					return
+				fi
+				;;
+			*)
+				if _in_list "$git_sub" "${GIT_READONLY_SUBCOMMANDS[@]}"; then
+					printf 'safe\n'
+					return
+				fi
+				;;
+		esac
 	fi
 
 	# Known-safe read-only command. Match by basename.

--- a/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
+++ b/home-manager/_mixins/development/claude-code/hooks/auto-approve/auto-approve.sh
@@ -632,7 +632,7 @@ classify_leaf() {
 				# cannot rely on the leading flag alone. This guard runs
 				# BEFORE the read-only flag check so write flags reject
 				# the whole invocation no matter their position.
-				if ! [[ $git_rest =~ (^|[[:space:]])(-d|-D|-m|-M|-c|-C|--delete|--move|--copy|--set-upstream-to|--unset-upstream|--edit-description|--track|--no-track|--create-reflog)([[:space:]]|=|$) ]]; then
+				if ! [[ $git_rest =~ (^|[[:space:]])(-d|-D|-m|-M|-c|-C|-f|--delete|--move|--copy|--force|--set-upstream-to|--unset-upstream|--edit-description|--track|--no-track|--create-reflog|--recurse-submodules)([[:space:]]|=|$) ]]; then
 					# Read-only flags: -a, -r, -v(v), --list, --contains,
 					# --merged, --no-merged, --points-at, --show-current,
 					# --column, --sort, --format. Anything starting with

--- a/home-manager/_mixins/development/codex/default.nix
+++ b/home-manager/_mixins/development/codex/default.nix
@@ -1501,15 +1501,6 @@ let
     # once per sub-agent rather than overlapping in the leader's status header.
     mcp_servers = mcpServerDefs.codexServers;
 
-    # Serialise sub-agents so their MCP startup events do not pile up on the
-    # leader's status header while the upstream TUI routing bug is unfixed
-    # (openai/codex #18068, #16821, #19542). Capping max_threads at 1 means
-    # only one sub-agent runs at a time, trading sub-agent throughput for a
-    # readable leader status. Raise this once the upstream fix lands.
-    agents = {
-      max_threads = 1;
-    };
-
     # Approval policy: never lets trusted workspace sessions run without
     # interactive approval prompts. Dangerous command prefixes remain blocked
     # by the generated exec policy rules.

--- a/home-manager/_mixins/development/codex/default.nix
+++ b/home-manager/_mixins/development/codex/default.nix
@@ -239,6 +239,216 @@ let
       ];
       justification = "GitHub search queries are read-only.";
     }
+
+    # Read-only filesystem inspection.
+    {
+      pattern = [ "readlink" ];
+      justification = "Reading symlink targets is read-only.";
+    }
+
+    # Build tools - configuration, builds, and compilation. Workspace edits
+    # are bounded by the workspace-write sandbox; out-of-tree installation
+    # (`make install`, `cmake --install`) is intentionally still routed
+    # through prompt rules below.
+    {
+      pattern = [ "./configure" ];
+      justification = "Build configuration scripts produce workspace artefacts.";
+    }
+    {
+      pattern = [ "configure" ];
+      justification = "Build configuration scripts produce workspace artefacts.";
+    }
+    {
+      pattern = [ "autoreconf" ];
+      justification = "Build system regeneration writes inside the workspace.";
+    }
+    {
+      pattern = [ "autoconf" ];
+      justification = "Build system regeneration writes inside the workspace.";
+    }
+    {
+      pattern = [ "automake" ];
+      justification = "Build system regeneration writes inside the workspace.";
+    }
+    {
+      pattern = [ "make" ];
+      justification = "Build commands write inside the workspace; `make install` is still prompted.";
+    }
+    {
+      pattern = [ "cmake" ];
+      justification = "Build commands write inside the workspace; `cmake --install` is still prompted.";
+    }
+    {
+      pattern = [ "meson" ];
+      justification = "Build commands write inside the workspace.";
+    }
+    {
+      pattern = [ "ninja" ];
+      justification = "Build commands write inside the workspace.";
+    }
+    {
+      pattern = [ "clang" ];
+      justification = "Compilation produces workspace artefacts.";
+    }
+    {
+      pattern = [ "clang++" ];
+      justification = "Compilation produces workspace artefacts.";
+    }
+    {
+      pattern = [ "gcc" ];
+      justification = "Compilation produces workspace artefacts.";
+    }
+    {
+      pattern = [ "g++" ];
+      justification = "Compilation produces workspace artefacts.";
+    }
+    {
+      pattern = [ "ar" ];
+      justification = "Archive creation writes inside the workspace.";
+    }
+    {
+      pattern = [ "ranlib" ];
+      justification = "Archive index updates write inside the workspace.";
+    }
+    {
+      pattern = [ "clang-tidy" ];
+      justification = "clang-tidy edits and reports run inside the workspace.";
+    }
+    {
+      pattern = [ "clang-format" ];
+      justification = "clang-format rewrites are workspace-bounded.";
+    }
+
+    # Per-language test, build, and format runners. Splitting these out of
+    # the parent prompt rules below lets Codex's `Forbidden > Prompt > Allow`
+    # ordering match each more-specific allow without the parent prompt
+    # winning. See the comment near the parent rules for the full rationale.
+    {
+      pattern = [
+        "go"
+        "build"
+      ];
+      justification = "Go builds produce workspace artefacts.";
+    }
+    {
+      pattern = [
+        "go"
+        "test"
+      ];
+      justification = "Go test runs project test code inside the workspace.";
+    }
+    {
+      pattern = [
+        "go"
+        "fmt"
+      ];
+      justification = "go fmt rewrites are workspace-bounded.";
+    }
+    {
+      pattern = [ "gofmt" ];
+      justification = "gofmt rewrites are workspace-bounded.";
+    }
+    {
+      pattern = [
+        "cargo"
+        "build"
+      ];
+      justification = "Cargo builds produce workspace artefacts.";
+    }
+    {
+      pattern = [
+        "cargo"
+        "test"
+      ];
+      justification = "Cargo test runs project test code inside the workspace.";
+    }
+    {
+      pattern = [
+        "cargo"
+        "fmt"
+      ];
+      justification = "cargo fmt rewrites are workspace-bounded.";
+    }
+    {
+      pattern = [
+        "npm"
+        "test"
+      ];
+      justification = "npm test runs project test code inside the workspace.";
+    }
+    {
+      pattern = [
+        "pnpm"
+        "test"
+      ];
+      justification = "pnpm test runs project test code inside the workspace.";
+    }
+
+    # Python test, lint, and formatter runners. The parent `[ "python" ]` and
+    # `[ "python3" ]` prompt rules have been removed (see comment in the
+    # promptRules block) so these specific allows are the only matches.
+    {
+      pattern = [
+        "python"
+        "-m"
+        "pytest"
+      ];
+      justification = "pytest runs project test code inside the workspace.";
+    }
+    {
+      pattern = [
+        "python3"
+        "-m"
+        "pytest"
+      ];
+      justification = "pytest runs project test code inside the workspace.";
+    }
+    {
+      pattern = [ "pytest" ];
+      justification = "pytest runs project test code inside the workspace.";
+    }
+    {
+      pattern = [ "mypy" ];
+      justification = "mypy is read-only type-checking.";
+    }
+    {
+      pattern = [ "ruff" ];
+      justification = "ruff is workspace-bounded; `ruff format` and `ruff check --fix` rewrite project files.";
+    }
+    {
+      pattern = [ "black" ];
+      justification = "black rewrites are workspace-bounded.";
+    }
+    {
+      pattern = [ "isort" ];
+      justification = "isort rewrites are workspace-bounded.";
+    }
+    {
+      pattern = [ "shfmt" ];
+      justification = "shfmt rewrites are workspace-bounded.";
+    }
+
+    # svelte-check is read-only.
+    {
+      pattern = [ "svelte-check" ];
+      justification = "svelte-check is read-only type-checking.";
+    }
+
+    # ffmpeg is allowed broadly; the workspace-write sandbox is the actual
+    # security boundary. ffmpeg can read/write network protocols (http://,
+    # ftp://, rtmp://, etc.) and arbitrary filesystem paths, so this rule
+    # does not by itself contain media processing - sandbox containment does.
+    {
+      pattern = [ "ffmpeg" ];
+      justification = "Media processing in workspace-bounded sandbox.";
+    }
+
+    # `git -C <path> <subcommand>` for read-only subcommands cannot be
+    # expressed as a prefix_rule: Codex's prefix patterns are positional and
+    # offer no wildcard token between literals to skip over the path
+    # argument. Read-only git inspection through `-C` therefore falls back to
+    # Codex's prompt heuristics; auto-approval lives only in OpenCode and the
+    # Claude Code auto-approve hook.
   ];
 
   promptRules = [
@@ -384,80 +594,25 @@ let
       justification = "Docker Compose state changes require approval.";
     }
 
-    # Build tools - configuration and builds
+    # Build tools - the C/C++ build pipeline (./configure, autoreconf, make,
+    # cmake, meson, ninja, gcc, clang, ar, ranlib, clang-tidy, clang-format)
+    # was moved to allowedRules above. Out-of-tree installation
+    # (`make install`, `cmake --install`) keeps prompting through the entries
+    # below.
     {
-      pattern = [ "./configure" ];
-      justification = "Build configuration scripts require approval.";
+      pattern = [
+        "make"
+        "install"
+      ];
+      justification = "make install writes outside the workspace.";
     }
     {
-      pattern = [ "configure" ];
-      justification = "Build configuration scripts require approval.";
+      pattern = [
+        "cmake"
+        "--install"
+      ];
+      justification = "cmake --install writes outside the workspace.";
     }
-    {
-      pattern = [ "autoreconf" ];
-      justification = "Build system generation requires approval.";
-    }
-    {
-      pattern = [ "autoconf" ];
-      justification = "Build system generation requires approval.";
-    }
-    {
-      pattern = [ "automake" ];
-      justification = "Build system generation requires approval.";
-    }
-    {
-      pattern = [ "make" ];
-      justification = "Build commands can execute arbitrary project code.";
-    }
-    {
-      pattern = [ "cmake" ];
-      justification = "Build commands can execute arbitrary project code.";
-    }
-    {
-      pattern = [ "meson" ];
-      justification = "Build commands can execute arbitrary project code.";
-    }
-    {
-      pattern = [ "ninja" ];
-      justification = "Build commands can execute arbitrary project code.";
-    }
-    {
-      pattern = [ "clang" ];
-      justification = "Compilation can execute build hooks and write outputs.";
-    }
-    {
-      pattern = [ "clang++" ];
-      justification = "Compilation can execute build hooks and write outputs.";
-    }
-    {
-      pattern = [ "gcc" ];
-      justification = "Compilation can execute build hooks and write outputs.";
-    }
-    {
-      pattern = [ "g++" ];
-      justification = "Compilation can execute build hooks and write outputs.";
-    }
-    {
-      pattern = [ "ar" ];
-      justification = "Archive writes require approval.";
-    }
-    {
-      pattern = [ "ranlib" ];
-      justification = "Archive writes require approval.";
-    }
-    {
-      pattern = [ "clang-tidy" ];
-      justification = "clang-tidy can apply source edits.";
-    }
-    {
-      pattern = [ "clang-format" ];
-      justification = "clang-format can rewrite source files.";
-    }
-    {
-      pattern = [ "ffmpeg" ];
-      justification = "Media processing can overwrite files.";
-    }
-
     # GitHub and Git - state modifications
     {
       pattern = [
@@ -584,19 +739,23 @@ let
     }
 
     # Common language and application toolchains
+    #
+    # Several alternative-list rules below were shrunk after `build`, `test`,
+    # and `fmt` were promoted to allow. Codex resolves overlapping matches
+    # via `Forbidden > Prompt > Allow` (max), so a parent prompt would still
+    # win against a more-specific allow; splitting the alternatives removes
+    # that conflict.
     {
       pattern = [
         "go"
         [
-          "build"
           "run"
-          "test"
           "generate"
           "get"
           "install"
         ]
       ];
-      justification = "Go build and execution commands require approval.";
+      justification = "Go execution and out-of-workspace installation require approval.";
     }
     {
       pattern = [
@@ -612,7 +771,6 @@ let
         [
           "install"
           "run"
-          "test"
           "publish"
         ]
       ];
@@ -688,15 +846,13 @@ let
       pattern = [
         "cargo"
         [
-          "build"
-          "test"
           "run"
           "install"
           "publish"
           "update"
         ]
       ];
-      justification = "Cargo build and package commands require approval.";
+      justification = "Cargo execution and package changes require approval.";
     }
     {
       pattern = [
@@ -718,26 +874,13 @@ let
       ];
       justification = "Python package changes require approval.";
     }
-    {
-      pattern = [ "python" ];
-      justification = "Python execution requires approval.";
-    }
-    {
-      pattern = [ "python3" ];
-      justification = "Python execution requires approval.";
-    }
-    {
-      pattern = [ "pytest" ];
-      justification = "Test execution can run project code.";
-    }
-    {
-      pattern = [ "mypy" ];
-      justification = "Type checking can run project plugins.";
-    }
-    {
-      pattern = [ "ruff" ];
-      justification = "ruff can rewrite files when invoked with fixes.";
-    }
+    # Note: bare `[ "python" ]` and `[ "python3" ]` prompt rules were
+    # intentionally removed. Codex resolves overlapping rules via
+    # `Forbidden > Prompt > Allow` (max), so a parent `python` prompt would
+    # win against the more-specific `python -m pytest` allow above. Bare
+    # `python script.py` invocations now fall through to Codex's heuristics
+    # fallback rather than to a static prompt rule. `pytest`, `mypy`, and
+    # `ruff` were also moved to allowedRules above.
     {
       pattern = [
         "uv"
@@ -765,10 +908,6 @@ let
         ]
       ];
       justification = "SvelteKit build and generated file updates require approval.";
-    }
-    {
-      pattern = [ "svelte-check" ];
-      justification = "Svelte checking can run project code.";
     }
     {
       pattern = [

--- a/home-manager/_mixins/development/mcp/servers.nix
+++ b/home-manager/_mixins/development/mcp/servers.nix
@@ -212,7 +212,7 @@ rec {
         if s.transport == "http" then
           {
             type = "http";
-            url = s.url;
+            inherit (s) url;
           }
           // lib.optionalAttrs (s.auth or null != null && s.auth.kind == "bearer") {
             headers = {
@@ -222,9 +222,9 @@ rec {
         else
           {
             type = "stdio";
-            command = s.command;
+            inherit (s) command;
           }
-          // lib.optionalAttrs ((s.args or [ ]) != [ ]) { args = s.args; }
+          // lib.optionalAttrs ((s.args or [ ]) != [ ]) { inherit (s) args; }
           // lib.optionalAttrs ((s.env or { }) != { }) {
             # Translate canonical `env.KEY = "SECRET_NAME"` into the
             # placeholder interpolation Claude Code reads at activation time.
@@ -247,6 +247,14 @@ rec {
   codexServers =
     let
       keep = _: s: s.enabled or true;
+      # Auto-approve every MCP tool from every Codex server without an
+      # interactive confirmation prompt. Codex's `RawMcpServerConfig` accepts
+      # `default_tools_approval_mode` with values `auto`, `prompt`, or
+      # `approve`; the alternatives `auto` and `prompt` would gate each tool
+      # invocation behind a TUI prompt, which defeats unattended agent runs.
+      common = {
+        default_tools_approval_mode = "approve";
+      };
       render =
         _: s:
         let
@@ -255,8 +263,9 @@ rec {
         if s.transport == "http" then
           {
             inherit enabled;
-            url = s.url;
+            inherit (s) url;
           }
+          // common
           // lib.optionalAttrs (s.auth or null != null && s.auth.kind == "bearer") {
             bearer_token_env_var = s.auth.envVar;
           }
@@ -266,15 +275,16 @@ rec {
         else
           {
             inherit enabled;
-            command = s.command;
+            inherit (s) command;
             args = s.args or [ ];
           }
+          // common
           // lib.optionalAttrs ((s.env or { }) != { }) {
             # Codex consumes the env table as static literals; the canonical
             # value is the sops secret name, which Codex resolves itself at
             # process-launch time via `bearer_token_env_var`-style hooks.
             # No active server uses this today; shape preserved for parity.
-            env = s.env;
+            inherit (s) env;
           }
           // lib.optionalAttrs (s ? startupTimeoutSec) {
             startup_timeout_sec = s.startupTimeoutSec;
@@ -303,7 +313,7 @@ rec {
           {
             type = "remote";
             inherit enabled;
-            url = s.url;
+            inherit (s) url;
           }
           // lib.optionalAttrs (s.auth or null != null && s.auth.kind == "bearer") {
             headers = {
@@ -357,7 +367,7 @@ rec {
         else
           {
             inherit enabled;
-            command = s.command;
+            inherit (s) command;
             args = s.args or [ ];
           };
     in
@@ -389,7 +399,7 @@ rec {
         _: s:
         (s.enabled or true)
         && ((s.consumers.zed.mode or null) == "extension")
-        && ((s.consumers.zed.enabled or true) == false);
+        && (!(s.consumers.zed.enabled or true));
       disabled = lib.filterAttrs keep servers;
     in
     lib.listToAttrs (

--- a/home-manager/_mixins/development/opencode/default.nix
+++ b/home-manager/_mixins/development/opencode/default.nix
@@ -805,6 +805,68 @@ in
             "git -C * verify-commit *" = "allow";
             "git -C * verify-tag *" = "allow";
 
+            # `git -C <path> ...` deny/ask mirrors. OpenCode's `.findLast()`
+            # matcher means a `git -C /path reset --hard` invocation does not
+            # match the plain `git reset --hard*` rule, so we mirror every
+            # deny and ask from the plain git block above to keep parity
+            # between both shapes. Order matches the plain block: denies
+            # first, then asks, with the force-push deny placed AFTER the
+            # general push ask so it overrides.
+            "git -C * reset --hard*" = "deny";
+            "git -C * clean*" = "deny";
+            "git -C * filter-branch*" = "deny";
+            "git -C * filter-repo*" = "deny";
+            "git -C * reflog expire*" = "deny";
+
+            "git -C * add *" = "ask";
+            "git -C * commit" = "ask";
+            "git -C * commit *" = "ask";
+            "git -C * push" = "ask";
+            "git -C * push *" = "ask";
+
+            # Force push - explicit deny (must come AFTER general push patterns)
+            "git -C * push*--force*" = "deny";
+            "git -C * push*-f *" = "deny";
+            "git -C * push * --force*" = "deny";
+            "git -C * push * -f*" = "deny";
+
+            "git -C * pull" = "ask";
+            "git -C * pull *" = "ask";
+            "git -C * fetch" = "ask";
+            "git -C * fetch *" = "ask";
+            "git -C * checkout *" = "ask";
+            "git -C * switch *" = "ask";
+            "git -C * branch -d *" = "ask";
+            "git -C * branch -D *" = "ask";
+            "git -C * branch -m *" = "ask";
+            "git -C * branch -M *" = "ask";
+            "git -C * branch --set-upstream*" = "ask";
+            "git -C * branch *" = "ask";
+            "git -C * merge *" = "ask";
+            "git -C * rebase *" = "ask";
+            "git -C * cherry-pick *" = "ask";
+            "git -C * stash" = "ask";
+            "git -C * stash *" = "ask";
+            "git -C * restore *" = "ask";
+            "git -C * reset *" = "ask";
+            "git -C * revert *" = "ask";
+            "git -C * tag -a *" = "ask";
+            "git -C * tag -d *" = "ask";
+            "git -C * tag -s *" = "ask";
+            "git -C * tag *" = "ask";
+            "git -C * worktree add *" = "ask";
+            "git -C * worktree remove *" = "ask";
+            "git -C * worktree prune*" = "ask";
+            "git -C * am *" = "ask";
+            "git -C * apply *" = "ask";
+            "git -C * bisect *" = "ask";
+            "git -C * clone *" = "ask";
+            "git -C * config *" = "ask";
+            "git -C * init*" = "ask";
+            "git -C * mv *" = "ask";
+            "git -C * rm *" = "ask";
+            "git -C * submodule *" = "ask";
+
             # Git - ask: state modifications
             "git add *" = "ask";
             "git commit" = "ask";

--- a/home-manager/_mixins/development/opencode/default.nix
+++ b/home-manager/_mixins/development/opencode/default.nix
@@ -6,11 +6,28 @@
   ...
 }:
 let
-  inherit (config.noughty) host;
   inherit (pkgs.stdenv.hostPlatform) system;
   # Use the pre-built binary from numtide's llm-agents.nix flake.
   # This avoids upstream source build issues entirely.
   opencodePackage = inputs.llm-agents.packages.${system}.opencode;
+
+  # Import shared MCP server definitions so the permission allowlist is
+  # derived from the canonical server list rather than hand-maintained.
+  mcpServerDefs = import ../mcp/servers.nix { inherit config pkgs; };
+
+  # Per-server permission entries for OpenCode. OpenCode names every MCP
+  # tool `<sanitised-server>_<sanitised-tool>` (see `mcp.tools()` in
+  # anomalyco/opencode `packages/opencode/src/mcp/index.ts` line 657), and
+  # each tool call evaluates against a top-level permission key matching
+  # that name (see `prompt.ts` line 467 calling `ask({ permission: key, ...
+  # })`). A `<server>_*` entry at the top level therefore allows every
+  # tool from that server. The global `mcp = { "*" = "allow"; }` block
+  # below does not apply to MCP tools - it only matches a tool literally
+  # named `mcp` - so these per-server entries are load-bearing. Adding a
+  # server in `mcp/servers.nix` auto-extends this list with no edits here.
+  mcpServerAllow = lib.listToAttrs (
+    map (name: lib.nameValuePair "${name}_*" "allow") (lib.attrNames mcpServerDefs.opencodeServers)
+  );
 in
 {
   home.shellAliases = {
@@ -68,7 +85,7 @@ in
 
         # Global permissions - applied to all agents including built-in Build and Plan
         # These provide guardrails across the board
-        permission = {
+        permission = mcpServerAllow // {
           # Unknown tools prompt by default. Explicit rules below keep MCP,
           # workspace edits, safe shell commands, skills, and subagents flowing
           # without approvals.
@@ -147,11 +164,9 @@ in
           question = "allow"; # Let subagents ask clarifying questions directly.
 
           # MCP tools - allow every tool from explicitly configured servers.
-          "cloudflare_*" = "allow";
-          "context7_*" = "allow";
-          "exa_*" = "allow";
-          "nixos_*" = "allow";
-          "svelte_*" = "allow";
+          # The per-server `<name>_*` entries are derived from
+          # `mcpServerDefs.opencodeServers` and merged into this attrset via
+          # `mcpServerAllow //` at the top of the `permission` block.
 
           bash = {
             # ══════════════════════════════════════════════════════════════
@@ -1368,10 +1383,14 @@ in
           todowrite = "allow"; # Modifying todo lists
           webfetch = "allow"; # Fetching URLs
           websearch = "allow"; # Web searches
-          # MCP tools - allow all unconditionally
-          mcp = {
-            "*" = "allow";
-          };
+          # MCP tool permissions are granted by the derived `<server>_*`
+          # entries merged in at the top of this `permission` block. A bare
+          # `mcp = { "*" = "allow"; }` stanza is a no-op in OpenCode because
+          # MCP tool calls evaluate against permission keys of the form
+          # `<sanitised-server>_<sanitised-tool>` (see anomalyco/opencode
+          # `packages/opencode/src/mcp/index.ts` line 657 and
+          # `packages/opencode/src/session/prompt.ts` line 467), so a key of
+          # exactly `mcp` would only match a tool literally named `mcp`.
           codesearch = "allow"; # Code searches
           # Safety guards - always ask
           doom_loop = "ask"; # Repeated identical tool calls

--- a/home-manager/_mixins/development/opencode/default.nix
+++ b/home-manager/_mixins/development/opencode/default.nix
@@ -705,7 +705,16 @@ in
             "git filter-repo*" = "deny";
             "git reflog expire*" = "deny";
 
-            # Git - read-only queries
+            # Git - read-only queries.
+            #
+            # Read-only narrow allows for subcommands that ALSO have a broader
+            # `<subcommand> *` ask later in this block (branch, tag, stash,
+            # config) are NOT placed here. OpenCode resolves precedence with
+            # `.findLast()`, so a later-declared broad ask shadows an earlier
+            # narrow allow. Those narrow allows are relocated AFTER each
+            # corresponding broad ask so they win the precedence battle.
+            # Mirror of the `nix profile list/history/diff-closures` pattern
+            # below.
             "git status" = "allow";
             "git status *" = "allow";
             "git diff" = "allow";
@@ -715,22 +724,9 @@ in
             "git show" = "allow";
             "git show *" = "allow";
             "git branch" = "allow";
-            "git branch -a*" = "allow";
-            "git branch -v*" = "allow";
-            "git branch -r*" = "allow";
-            "git branch --list*" = "allow";
-            "git branch --contains*" = "allow";
-            "git branch --merged*" = "allow";
-            "git branch --no-merged*" = "allow";
             "git remote" = "allow";
             "git remote *" = "allow";
             "git tag" = "allow";
-            "git tag -l*" = "allow";
-            "git tag --list*" = "allow";
-            "git stash list" = "allow";
-            "git stash list *" = "allow";
-            "git stash show" = "allow";
-            "git stash show *" = "allow";
             "git reflog" = "allow";
             "git reflog *" = "allow";
             "git rev-parse *" = "allow";
@@ -742,8 +738,6 @@ in
             "git ls-tree *" = "allow";
             "git ls-remote *" = "allow";
             "git grep *" = "allow";
-            "git config --list*" = "allow";
-            "git config --get*" = "allow";
             "git worktree list" = "allow";
             "git name-rev *" = "allow";
             "git cat-file *" = "allow";
@@ -756,7 +750,10 @@ in
 
             # `git -C <path> <subcommand>` for read-only subcommands. Mirrors
             # every read-only entry above so the same queries auto-resolve
-            # when targeted at a sibling worktree via `-C`.
+            # when targeted at a sibling worktree via `-C`. Same precedence
+            # caveat: narrow read-only allows for subcommands with a broader
+            # later ask (branch, tag, stash, config) are relocated AFTER
+            # those asks below.
             "git -C * status" = "allow";
             "git -C * status *" = "allow";
             "git -C * diff" = "allow";
@@ -766,22 +763,9 @@ in
             "git -C * show" = "allow";
             "git -C * show *" = "allow";
             "git -C * branch" = "allow";
-            "git -C * branch -a*" = "allow";
-            "git -C * branch -v*" = "allow";
-            "git -C * branch -r*" = "allow";
-            "git -C * branch --list*" = "allow";
-            "git -C * branch --contains*" = "allow";
-            "git -C * branch --merged*" = "allow";
-            "git -C * branch --no-merged*" = "allow";
             "git -C * remote" = "allow";
             "git -C * remote *" = "allow";
             "git -C * tag" = "allow";
-            "git -C * tag -l*" = "allow";
-            "git -C * tag --list*" = "allow";
-            "git -C * stash list" = "allow";
-            "git -C * stash list *" = "allow";
-            "git -C * stash show" = "allow";
-            "git -C * stash show *" = "allow";
             "git -C * reflog" = "allow";
             "git -C * reflog *" = "allow";
             "git -C * rev-parse *" = "allow";
@@ -793,8 +777,6 @@ in
             "git -C * ls-tree *" = "allow";
             "git -C * ls-remote *" = "allow";
             "git -C * grep *" = "allow";
-            "git -C * config --list*" = "allow";
-            "git -C * config --get*" = "allow";
             "git -C * worktree list" = "allow";
             "git -C * name-rev *" = "allow";
             "git -C * cat-file *" = "allow";
@@ -867,6 +849,35 @@ in
             "git -C * rm *" = "ask";
             "git -C * submodule *" = "ask";
 
+            # Read-only `git -C * <subcommand>` narrow allows. These rules sit
+            # AFTER the broader `<subcommand> *` asks above because OpenCode
+            # uses `.findLast()` to resolve precedence, so the most specific
+            # later-declared rule wins. Mirror of the `nix profile
+            # list/history/diff-closures` pattern below.
+            "git -C * branch -a*" = "allow";
+            "git -C * branch -v*" = "allow";
+            "git -C * branch -r*" = "allow";
+            "git -C * branch --list*" = "allow";
+            "git -C * branch --contains*" = "allow";
+            "git -C * branch --merged*" = "allow";
+            "git -C * branch --no-merged*" = "allow";
+            "git -C * tag -l*" = "allow";
+            "git -C * tag --list*" = "allow";
+            "git -C * stash list" = "allow";
+            "git -C * stash list *" = "allow";
+            "git -C * stash show" = "allow";
+            "git -C * stash show *" = "allow";
+            "git -C * config --list" = "allow";
+            "git -C * config --list *" = "allow";
+            "git -C * config --get" = "allow";
+            "git -C * config --get *" = "allow";
+            "git -C * config --get-all" = "allow";
+            "git -C * config --get-all *" = "allow";
+            "git -C * config --get-regexp" = "allow";
+            "git -C * config --get-regexp *" = "allow";
+            "git -C * config --get-urlmatch" = "allow";
+            "git -C * config --get-urlmatch *" = "allow";
+
             # Git - ask: state modifications
             "git add *" = "ask";
             "git commit" = "ask";
@@ -916,6 +927,35 @@ in
             "git mv *" = "ask";
             "git rm *" = "ask";
             "git submodule *" = "ask";
+
+            # Read-only `git <subcommand>` narrow allows. These rules sit
+            # AFTER the broader `<subcommand> *` asks above because OpenCode
+            # uses `.findLast()` to resolve precedence, so the most specific
+            # later-declared rule wins. Mirror of the `nix profile
+            # list/history/diff-closures` pattern below.
+            "git branch -a*" = "allow";
+            "git branch -v*" = "allow";
+            "git branch -r*" = "allow";
+            "git branch --list*" = "allow";
+            "git branch --contains*" = "allow";
+            "git branch --merged*" = "allow";
+            "git branch --no-merged*" = "allow";
+            "git tag -l*" = "allow";
+            "git tag --list*" = "allow";
+            "git stash list" = "allow";
+            "git stash list *" = "allow";
+            "git stash show" = "allow";
+            "git stash show *" = "allow";
+            "git config --list" = "allow";
+            "git config --list *" = "allow";
+            "git config --get" = "allow";
+            "git config --get *" = "allow";
+            "git config --get-all" = "allow";
+            "git config --get-all *" = "allow";
+            "git config --get-regexp" = "allow";
+            "git config --get-regexp *" = "allow";
+            "git config --get-urlmatch" = "allow";
+            "git config --get-urlmatch *" = "allow";
 
             # ══════════════════════════════════════════════════════════════
             # Hugo

--- a/home-manager/_mixins/development/opencode/default.nix
+++ b/home-manager/_mixins/development/opencode/default.nix
@@ -241,6 +241,8 @@ in
             "dirname *" = "allow";
             "realpath" = "allow";
             "realpath *" = "allow";
+            "readlink" = "allow";
+            "readlink *" = "allow";
             "stat" = "allow";
             "stat *" = "allow";
             "du" = "allow";
@@ -370,8 +372,10 @@ in
             "base32" = "allow";
             "base32 *" = "allow";
             "shellcheck *" = "allow";
-            "shfmt --diff *" = "allow";
-            "shfmt -d *" = "allow";
+            # shfmt rewrites are workspace-bounded by design; both diff and
+            # write modes are allowed.
+            "shfmt" = "allow";
+            "shfmt *" = "allow";
             "luacheck *" = "allow";
 
             # Semgrep - read-only queries and scans
@@ -569,46 +573,45 @@ in
             "readelf" = "allow";
             "readelf *" = "allow";
 
-            # Build tools - ask: configuration and builds
-            "./configure*" = "ask";
-            "configure *" = "ask";
-            "autoreconf*" = "ask";
-            "autoconf *" = "ask";
-            "automake *" = "ask";
-            "make" = "ask";
-            "make *" = "ask";
-            "cmake *" = "ask";
-            "meson *" = "ask";
-            "ninja" = "ask";
-            "ninja *" = "ask";
-            "clang *" = "ask";
-            "clang++ *" = "ask";
-            "gcc *" = "ask";
-            "g++ *" = "ask";
-            "ar *" = "ask";
-            "ranlib *" = "ask";
-            "clang-tidy *" = "ask";
-            "clang-format *" = "ask";
+            # Build tools - allow: configuration, builds, and compilation.
+            # Builds and compilations rewrite files inside the workspace by
+            # design; they cannot escape the OpenCode workspace sandbox so the
+            # ask prompt was friction without a security benefit.
+            "./configure*" = "allow";
+            "configure *" = "allow";
+            "autoreconf*" = "allow";
+            "autoconf *" = "allow";
+            "automake *" = "allow";
+            "make" = "allow";
+            "make *" = "allow";
+            "cmake *" = "allow";
+            "meson *" = "allow";
+            "ninja" = "allow";
+            "ninja *" = "allow";
+            "clang *" = "allow";
+            "clang++ *" = "allow";
+            "gcc *" = "allow";
+            "g++ *" = "allow";
+            "ar *" = "allow";
+            "ranlib *" = "allow";
+            "clang-tidy *" = "allow";
+            "clang-format *" = "allow";
+
+            # Build tools - ask: out-of-workspace installation
+            "make install*" = "ask";
+            "cmake --install*" = "ask";
 
             # ══════════════════════════════════════════════════════════════
-            # FFmpeg - info and probing
+            # FFmpeg - allowed broadly; the workspace-write sandbox is the
+            # actual security boundary. ffmpeg can read/write network
+            # protocols (http://, ftp://, rtmp://, etc.) and arbitrary
+            # filesystem paths, so this rule does not by itself contain
+            # media processing - sandbox containment does. ffprobe is
+            # read-only.
             # ══════════════════════════════════════════════════════════════
-            "ffmpeg -version" = "allow";
-            "ffmpeg -formats" = "allow";
-            "ffmpeg -codecs" = "allow";
-            "ffmpeg -encoders" = "allow";
-            "ffmpeg -decoders" = "allow";
-            "ffmpeg -bsfs" = "allow";
-            "ffmpeg -protocols" = "allow";
-            "ffmpeg -pix_fmts" = "allow";
-            "ffmpeg -layouts" = "allow";
-            "ffmpeg -sample_fmts" = "allow";
-            "ffmpeg -filters" = "allow";
-            "ffmpeg -hwaccels" = "allow";
+            "ffmpeg" = "allow";
+            "ffmpeg *" = "allow";
             "ffprobe *" = "allow";
-
-            # FFmpeg - ask: file processing
-            "ffmpeg *" = "ask";
 
             # ══════════════════════════════════════════════════════════════
             # GitHub CLI - deny destructive first
@@ -750,6 +753,57 @@ in
             "git symbolic-ref *" = "allow";
             "git verify-commit *" = "allow";
             "git verify-tag *" = "allow";
+
+            # `git -C <path> <subcommand>` for read-only subcommands. Mirrors
+            # every read-only entry above so the same queries auto-resolve
+            # when targeted at a sibling worktree via `-C`.
+            "git -C * status" = "allow";
+            "git -C * status *" = "allow";
+            "git -C * diff" = "allow";
+            "git -C * diff *" = "allow";
+            "git -C * log" = "allow";
+            "git -C * log *" = "allow";
+            "git -C * show" = "allow";
+            "git -C * show *" = "allow";
+            "git -C * branch" = "allow";
+            "git -C * branch -a*" = "allow";
+            "git -C * branch -v*" = "allow";
+            "git -C * branch -r*" = "allow";
+            "git -C * branch --list*" = "allow";
+            "git -C * branch --contains*" = "allow";
+            "git -C * branch --merged*" = "allow";
+            "git -C * branch --no-merged*" = "allow";
+            "git -C * remote" = "allow";
+            "git -C * remote *" = "allow";
+            "git -C * tag" = "allow";
+            "git -C * tag -l*" = "allow";
+            "git -C * tag --list*" = "allow";
+            "git -C * stash list" = "allow";
+            "git -C * stash list *" = "allow";
+            "git -C * stash show" = "allow";
+            "git -C * stash show *" = "allow";
+            "git -C * reflog" = "allow";
+            "git -C * reflog *" = "allow";
+            "git -C * rev-parse *" = "allow";
+            "git -C * describe *" = "allow";
+            "git -C * shortlog *" = "allow";
+            "git -C * blame *" = "allow";
+            "git -C * ls-files" = "allow";
+            "git -C * ls-files *" = "allow";
+            "git -C * ls-tree *" = "allow";
+            "git -C * ls-remote *" = "allow";
+            "git -C * grep *" = "allow";
+            "git -C * config --list*" = "allow";
+            "git -C * config --get*" = "allow";
+            "git -C * worktree list" = "allow";
+            "git -C * name-rev *" = "allow";
+            "git -C * cat-file *" = "allow";
+            "git -C * count-objects" = "allow";
+            "git -C * count-objects *" = "allow";
+            "git -C * for-each-ref *" = "allow";
+            "git -C * symbolic-ref *" = "allow";
+            "git -C * verify-commit *" = "allow";
+            "git -C * verify-tag *" = "allow";
 
             # Git - ask: state modifications
             "git add *" = "ask";
@@ -939,8 +993,15 @@ in
             "nix-shell *" = "ask";
             "nix-build *" = "ask";
             "nix-env *" = "ask";
+            # Both bare and space forms cover invocations with no arguments
+            # (`home-manager`, `nixos-rebuild`, `darwin-rebuild`) as well as
+            # any subcommand. The boundary is uniform: every invocation of
+            # these state-mutating system rebuild tools must prompt.
+            "home-manager" = "ask";
             "home-manager *" = "ask";
+            "nixos-rebuild" = "ask";
             "nixos-rebuild *" = "ask";
+            "darwin-rebuild" = "ask";
             "darwin-rebuild *" = "ask";
 
             # Read-only `nix profile` subcommands. These rules sit AFTER
@@ -992,9 +1053,14 @@ in
             "govulncheck" = "allow";
             "govulncheck *" = "allow";
 
-            "go build*" = "ask";
+            # Allow: builds, tests, and formatting are workspace-bounded.
+            "go build*" = "allow";
+            "go test*" = "allow";
+            "go fmt *" = "allow";
+            "gofmt *" = "allow";
+
+            # Ask: arbitrary code execution and out-of-workspace effects.
             "go run *" = "ask";
-            "go test*" = "ask";
             "go generate*" = "ask";
             "go get *" = "ask";
             "go install *" = "ask";
@@ -1002,8 +1068,6 @@ in
             "go mod init*" = "ask";
             "go mod edit*" = "ask";
             "go work *" = "ask";
-            "go fmt *" = "ask";
-            "gofmt *" = "ask";
 
             # ══════════════════════════════════════════════════════════════
             # JavaScript/TypeScript - deny cache corruption first
@@ -1061,13 +1125,16 @@ in
             "tsc --version" = "allow";
             "tsc --noEmit*" = "allow";
 
+            # JavaScript/TypeScript - allow: tests are workspace-bounded.
+            "npm test*" = "allow";
+            "pnpm test*" = "allow";
+
             # JavaScript/TypeScript - ask: installs and execution
             "npm install*" = "ask";
             "npm i" = "ask";
             "npm i *" = "ask";
             "npm ci*" = "ask";
             "npm run *" = "ask";
-            "npm test*" = "ask";
             "npm start*" = "ask";
             "npm exec *" = "ask";
             "npm publish*" = "ask";
@@ -1080,7 +1147,6 @@ in
             "pnpm i" = "ask";
             "pnpm i *" = "ask";
             "pnpm run *" = "ask";
-            "pnpm test*" = "ask";
             "pnpm exec *" = "ask";
             "pnpm dlx *" = "ask";
             "pnpm add *" = "ask";
@@ -1156,8 +1222,13 @@ in
             "rustup component list *" = "allow";
             "rustup which *" = "allow";
 
-            "cargo build*" = "ask";
-            "cargo test*" = "ask";
+            # Allow: builds, tests, and formatting are workspace-bounded.
+            "cargo build*" = "allow";
+            "cargo test*" = "allow";
+            "cargo fmt" = "allow";
+            "cargo fmt *" = "allow";
+
+            # Ask: arbitrary code execution and out-of-workspace effects.
             "cargo run*" = "ask";
             "cargo bench*" = "ask";
             "cargo install*" = "ask";
@@ -1168,8 +1239,6 @@ in
             "cargo remove *" = "ask";
             "cargo init*" = "ask";
             "cargo new *" = "ask";
-            "cargo fmt" = "ask";
-            "cargo fmt *" = "ask";
             "cargo fix*" = "ask";
             "cargo generate*" = "ask";
             "rustup update*" = "ask";
@@ -1238,16 +1307,17 @@ in
             "uv add *" = "ask";
             "uv remove *" = "ask";
 
-            "pytest" = "ask";
-            "pytest *" = "ask";
-            "python -m pytest*" = "ask";
-            "python3 -m pytest*" = "ask";
-            "mypy" = "ask";
-            "mypy *" = "ask";
-            "ruff" = "ask";
-            "ruff *" = "ask";
-            "black *" = "ask";
-            "isort *" = "ask";
+            # Allow: tests, lint, and formatters are workspace-bounded.
+            "pytest" = "allow";
+            "pytest *" = "allow";
+            "python -m pytest*" = "allow";
+            "python3 -m pytest*" = "allow";
+            "mypy" = "allow";
+            "mypy *" = "allow";
+            "ruff" = "allow";
+            "ruff *" = "allow";
+            "black *" = "allow";
+            "isort *" = "allow";
 
             # ══════════════════════════════════════════════════════════════
             # Svelte/SvelteKit
@@ -1255,9 +1325,11 @@ in
             "svelte-check --help" = "allow";
             "svelte-check --version" = "allow";
 
+            # Allow: type-checking is workspace-bounded.
+            "svelte-check" = "allow";
+            "svelte-check *" = "allow";
+
             "svelte-kit sync*" = "ask";
-            "svelte-check" = "ask";
-            "svelte-check *" = "ask";
             "svelte-kit *" = "ask";
 
             # ══════════════════════════════════════════════════════════════

--- a/nixos/_mixins/hardware/bluetooth/default.nix
+++ b/nixos/_mixins/hardware/bluetooth/default.nix
@@ -6,19 +6,33 @@
 }:
 let
   inherit (config.noughty) host;
+  bluetuiDesktopEntry = pkgs.writeText "bluetui.desktop" ''
+    [Desktop Entry]
+    Name=Bluetui
+    GenericName=Bluetooth Manager
+    Comment=Manage bluetooth devices
+    Exec=bluetui
+    Terminal=true
+    Type=Application
+    Keywords=bluetooth
+    Categories=Utility;Settings;ConsoleOnly
+    StartupNotify=false
+    NoDisplay=true
+  '';
+  bluetui = pkgs.symlinkJoin {
+    name = "bluetui-hidden";
+    paths = [ pkgs.bluetui ];
+    postBuild = ''
+      rm -f $out/share/applications/bluetui.desktop
+      install -Dm444 ${bluetuiDesktopEntry} $out/share/applications/bluetui.desktop
+    '';
+  };
 in
 {
   environment = {
     systemPackages = lib.optionals (!host.is.iso) [
-      pkgs.bluetui
+      bluetui
     ];
-    # Hide the bluetui desktop entry from application launchers; it's a TUI
-    # tool intended to be launched from a terminal, not a launcher.
-    etc."xdg/applications/bluetui.desktop".text = ''
-      [Desktop Entry]
-      Name=Bluetui
-      NoDisplay=true
-    '';
   };
   hardware = {
     # https://nixos.wiki/wiki/Bluetooth

--- a/nixos/_mixins/scripts/install-system/README.md
+++ b/nixos/_mixins/scripts/install-system/README.md
@@ -66,7 +66,7 @@ No files need to be injected for FlakeHub, authentication is handled interactive
 7. **Copy secrets to target** - Copies the host age key and user age key to the mounted target filesystem
 8. **Inject SSH keys** - Cleans and recreates `/mnt/etc/ssh/`, then decrypts initrd and per-host SSH keys from sops-encrypted secrets
 9. **Rsync the flake** - Copies `~/Zero/` to the target user's home directory
-10. **Activate Home Manager** - When FlakeHub is available, resolves the Home Manager store path and copies the closure to the target's Nix store outside the chroot (where FlakeHub auth works), then activates directly from that store path inside the chroot. Falls back to a local build via `nix run nixpkgs#home-manager` if FlakeHub resolution fails. Without FlakeHub, builds locally from the flake
+10. **Activate Home Manager** - Resolves or builds the Home Manager activation package into the target's Nix store, then activates it as the target user inside the chroot so Home Manager package profiles are not written to root's default profile
 
 ## LUKS disk encryption
 

--- a/nixos/_mixins/scripts/install-system/install-system.sh
+++ b/nixos/_mixins/scripts/install-system/install-system.sh
@@ -152,7 +152,7 @@ fi
 pushd "$HOME/Zero/nix-config" || exit 1
 
 if [[ -n "$TARGET_BRANCH" ]]; then
-	git checkout -- "$TARGET_BRANCH"
+	git checkout "$TARGET_BRANCH"
 fi
 
 if [[ -z "$TARGET_HOST" ]]; then

--- a/nixos/_mixins/scripts/install-system/install-system.sh
+++ b/nixos/_mixins/scripts/install-system/install-system.sh
@@ -18,6 +18,18 @@ TARGET_HOST="${1:-}"
 TARGET_USER="${2:-martin}"
 TARGET_BRANCH="${3:-main}"
 
+function validate_target_identifiers() {
+	if [[ ! "$TARGET_HOST" =~ ^[A-Za-z0-9._-]+$ ]]; then
+		echo "ERROR! Hostname contains unsupported characters: $TARGET_HOST"
+		exit 1
+	fi
+
+	if [[ ! "$TARGET_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]; then
+		echo "ERROR! Username contains unsupported characters: $TARGET_USER"
+		exit 1
+	fi
+}
+
 function run_disko() {
 	local DISKO_CONFIG="$1"
 	local REPLY="n"
@@ -102,6 +114,30 @@ function run_with_retry() {
 	exit 1
 }
 
+function prepare_home_manager_activation() {
+	sudo nixos-enter --root /mnt --command "install -d -o $TARGET_USER -g users /nix/var/nix/profiles/per-user/$TARGET_USER"
+	sudo nixos-enter --root /mnt --command "install -d -o $TARGET_USER -g users /home/$TARGET_USER/.local/state/nix/profiles"
+	sudo nixos-enter --root /mnt --command "install -d -o $TARGET_USER -g users /home/$TARGET_USER/.local/share/home-manager"
+}
+
+function activate_home_manager_as_user() {
+	local HM_ACTIVATION_PATH="$1"
+	local ACTIVATE_COMMAND
+
+	ACTIVATE_COMMAND="cd /home/$TARGET_USER && env USER=$TARGET_USER LOGNAME=$TARGET_USER HOME=/home/$TARGET_USER XDG_STATE_HOME=/home/$TARGET_USER/.local/state HOME_MANAGER_BACKUP_EXT=backup $HM_ACTIVATION_PATH/activate --driver-version 1"
+	run_with_retry sudo nixos-enter --root /mnt --command "su -s /bin/sh $TARGET_USER -c '$ACTIVATE_COMMAND'"
+}
+
+function build_home_manager_activation() {
+	local HM_ATTR
+
+	HM_ATTR=".#homeConfigurations.\"$TARGET_USER@$TARGET_HOST\".activationPackage"
+	sudo nix build --store /mnt --no-link --print-out-paths "$HM_ATTR" \
+		--option http2 false \
+		--option max-substitution-jobs 128 \
+		--option http-connections 256
+}
+
 sudo umount -R /mnt || true
 
 if [ "$(id -u)" -eq 0 ]; then
@@ -116,7 +152,7 @@ fi
 pushd "$HOME/Zero/nix-config" || exit 1
 
 if [[ -n "$TARGET_BRANCH" ]]; then
-	git checkout "$TARGET_BRANCH"
+	git checkout -- "$TARGET_BRANCH"
 fi
 
 if [[ -z "$TARGET_HOST" ]]; then
@@ -132,6 +168,8 @@ if [[ -z "$TARGET_USER" ]]; then
 	find nixos/_mixins/users/ -mindepth 1 -maxdepth 1 -type d | cut -d'/' -f4 | grep -v -E "nixos|root"
 	exit 1
 fi
+
+validate_target_identifiers
 
 # --- Ingest injected tokens ---
 # If just inject-tokens was run from the workstation, files will be
@@ -377,6 +415,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 
 	# Apply the Home Manager configuration.
 	sudo nixos-enter --root /mnt --command "chown -R $TARGET_USER:users /home/$TARGET_USER"
+	prepare_home_manager_activation
 	if [[ "$USE_FLAKEHUB" -eq 1 ]]; then
 		HM_REF="wimpysworld/nix-config/*#homeConfigurations.$TARGET_USER@$TARGET_HOST"
 		echo "Resolving Home Manager configuration from FlakeHub Cache..."
@@ -393,16 +432,18 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 				--option http-connections 256 \
 				--option narinfo-cache-negative-ttl 0 || true
 			echo "Activating Home Manager from FlakeHub Cache..."
-			run_with_retry sudo nixos-enter --root /mnt --command "env USER=$TARGET_USER HOME=/home/$TARGET_USER $HM_PATH/activate"
+			activate_home_manager_as_user "$HM_PATH"
 		else
 			echo "WARNING! FlakeHub resolve failed; falling back to local build..."
-			run_with_retry sudo nixos-enter --root /mnt --command "cd /home/$TARGET_USER/Zero/nix-config && env USER=$TARGET_USER HOME=/home/$TARGET_USER nix run nixpkgs#home-manager -- switch -b backup --flake \".#$TARGET_USER@$TARGET_HOST\""
+			HM_PATH=$(build_home_manager_activation)
+			activate_home_manager_as_user "$HM_PATH"
 		fi
 	else
 		echo "Applying Home Manager configuration..."
-		run_with_retry sudo nixos-enter --root /mnt --command "cd /home/$TARGET_USER/Zero/nix-config && env USER=$TARGET_USER HOME=/home/$TARGET_USER nix run nixpkgs#home-manager -- switch -b backup --flake \".#$TARGET_USER@$TARGET_HOST\""
+		HM_PATH=$(build_home_manager_activation)
+		activate_home_manager_as_user "$HM_PATH"
 	fi
-	# Fix ownership after activation. Home Manager runs as root inside
-	# nixos-enter, so all created files and directories are owned by root:root.
+	# Fix ownership after activation in case any earlier install steps left
+	# root-owned files in the target user's home directory.
 	sudo nixos-enter --root /mnt --command "chown -R $TARGET_USER:users /home/$TARGET_USER"
 fi


### PR DESCRIPTION
## Summary
Expands safe allow-list across Claude Code, Codex, and OpenCode with new build, test, and format commands bounded by workspace-write sandbox. Hardens system-state tool boundaries by moving home-manager, nixos-rebuild, and darwin-rebuild to explicit deny guards. Fixes hook placement bug in Claude Code that prevented git -C auto-approval.

## Changes
- Add readlink for symlink inspection
- Promote C/C++ build pipeline (gcc, g++, clang, cmake, make) to allow
- Add Go (build, test, fmt) to allow
- Add Rust/Cargo (build, test, fmt) to allow  
- Add Python (pytest, mypy, ruff, black, isort) to allow
- Add Node (npm/pnpm test) to allow
- Add Svelte checker to allow
- Simplify shfmt and ffmpeg to blanket allow (sandbox-bounded)
- Add git -C \<path\> \<subcommand\> pattern for read-only git operations
- Harden system-state tools (home-manager, nixos-rebuild, darwin-rebuild) with DENY_COMMANDS hook guards
- Fix: move hooks from nested under permissions to top-level in Claude Code settings
- Reorder allow/prompt rules to prevent parent rules shadowing child-specific rules

## Testing
- Verified git -C auto-approve works with hooks in correct location
- Confirmed home-manager switch still prompts (deny guard active)
- Tested allow-list entries across agent tiers (Forbidden > Prompt > Allow)
- Validated sandbox boundaries: builds/tests/formatters operate workspace-only
- Out-of-tree installs and arbitrary execution continue to prompt as intended

## Related Issues
Resolves allow-list expansion and system-state hardening requirements across agent ecosystem.