### PR TITLE
fix(hermes): tombstone GitHub notification webhook route

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -255,6 +255,10 @@ is intentionally hybrid. A webhook can reduce latency for configured
 repositories or organisations, but it cannot replace the Notifications REST API
 poller as the source of truth.
 
+The `github-notifications` route is explicitly tombstoned in the Nix config so
+the Hermes config merge step removes the previously deployed static route from
+runtime use.
+
 ## Sanctuary
 
 Traya-owned continuity state now lives under `/var/lib/hermes/workspace/trayas-sanctuary`.

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -566,6 +566,7 @@ in
               host = "127.0.0.1";
               port = 8644;
               secret = "\${WEBHOOK_SECRET}";
+              routes.github-notifications = null;
             };
           };
         };


### PR DESCRIPTION
## Summary

- tombstone the previously deployed `github-notifications` static route with a null route value
- document why the tombstone exists
- keep the generic Hermes webhook gateway intact

## Why

PR #800 removed the route from Nix, but the Hermes activation merge preserves existing runtime config keys. That means omission alone does not delete a route that has already been written into `/var/lib/hermes/.hermes/config.yaml`.

Setting the route to `null` lets the Nix-managed config win during the merge and makes the gateway treat `/webhooks/github-notifications` as unknown.

## Validation

- `nix fmt nixos/_mixins/server/hermes/default.nix nixos/_mixins/server/hermes/README.md`
- `git diff --check`
- `just eval`
- `nix eval --impure --json .#nixosConfigurations.revan.config.services.hermes-agent.settings.platforms.webhook.extra | jq '{has_routes: has("routes"), routes_keys: ((.routes // {}) | keys), github_notifications: .routes."github-notifications"}'`
- simulated the Hermes config merge against the current live config without printing secrets

Targeted route check returns:

```json
{
  "has_routes": true,
  "routes_keys": [
    "github-notifications"
  ],
  "github_notifications": null
}
```
