### PR TITLE
feat(hermes): add Hue light control

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -173,6 +173,8 @@ let
   hermesAuthFile = "${hermesHome}/auth.json";
   himalayaConfigDir = "${config.services.hermes-agent.stateDir}/.config/himalaya";
   himalayaConfigPath = "${himalayaConfigDir}/config.toml";
+  openhueConfigDir = "${config.services.hermes-agent.stateDir}/.openhue";
+  openhueConfigPath = "${openhueConfigDir}/config.yaml";
   hermesSshDir = "${config.services.hermes-agent.stateDir}/.ssh";
   hermesGnupgHome = "${config.services.hermes-agent.stateDir}/.gnupg";
   # GPG runtime config for Traya's keyring. Loopback pinentry guards against
@@ -218,6 +220,7 @@ let
     nh
     nix-direnv
     nodejs-slim
+    openhue-cli
     openssh
     poppler-utils
     procps
@@ -332,6 +335,20 @@ in
       };
 
       WEBHOOK_SECRET = {
+        sopsFile = hermesSopsFile;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+
+      HUE_BRIDGE_IP = {
+        sopsFile = hermesSopsFile;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+
+      HUE_BRIDGE_APPLICATION_KEY = {
         sopsFile = hermesSopsFile;
         owner = "root";
         group = "root";
@@ -521,6 +538,16 @@ in
       mode = "0440";
     };
 
+    sops.templates."hermes-openhue-config" = {
+      content = ''
+        bridge: ${config.sops.placeholder.HUE_BRIDGE_IP}
+        key: ${config.sops.placeholder.HUE_BRIDGE_APPLICATION_KEY}
+      '';
+      owner = hermesUser;
+      group = hermesGroup;
+      mode = "0440";
+    };
+
     services.hermes-agent = {
       enable = true;
       addToSystemPackages = true;
@@ -549,6 +576,13 @@ in
         nixos = {
           command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
           args = [ ];
+        };
+        openhue = {
+          command = "${pkgs.openhue-cli}/bin/openhue";
+          args = [ "mcp" ];
+          env = {
+            HOME = config.services.hermes-agent.stateDir;
+          };
         };
         cloudflare = {
           url = "https://docs.mcp.cloudflare.com/mcp";
@@ -804,7 +838,9 @@ in
       "d ${hermesGnupgHome} 0700 ${hermesUser} ${hermesGroup} - -"
       "d ${hermesHome}/skills 2770 ${hermesUser} ${hermesGroup} - -"
       "d ${hermesHome}/skills/traya 2770 ${hermesUser} ${hermesGroup} - -"
+      "d ${openhueConfigDir} 2770 ${hermesUser} ${hermesGroup} - -"
       "L+ ${himalayaConfigPath} - - - - ${config.sops.templates."hermes-himalaya-config".path}"
+      "L+ ${openhueConfigPath} - - - - ${config.sops.templates."hermes-openhue-config".path}"
       "L+ ${hermesSshDir}/id_ed25519 - - - - ${config.sops.secrets.SSH_PRIVATE_KEY.path}"
       "L+ ${hermesSshDir}/id_ed25519.pub - - - - ${config.sops.secrets.SSH_PUBLIC_KEY.path}"
       "L+ ${hermesGnupgHome}/gpg.conf - - - - ${hermesGpgConf}"

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5,6 +5,7 @@ pkgs: {
   davinci-resolve = pkgs.callPackage ./davinci-resolve { };
   davinci-resolve-studio = pkgs.callPackage ./davinci-resolve { studioVariant = true; };
   heynote = pkgs.callPackage ./heynote { };
+  openhue-cli = pkgs.callPackage ./openhue-cli { };
   defold = pkgs.callPackage ./defold { };
   defold-bob = pkgs.callPackage ./defold-bob { };
   defold-gdc = pkgs.callPackage ./defold-gdc { };

--- a/pkgs/openhue-cli/default.nix
+++ b/pkgs/openhue-cli/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openhue-cli";
+  version = "0.23";
+
+  src = fetchurl (
+    let
+      system = stdenv.hostPlatform.system;
+      sources = {
+        x86_64-linux = {
+          name = "openhue_Linux_x86_64.tar.gz";
+          hash = "sha256-eCx4rF1ZRkgO7iwR8LjRDIc6FWtShE5/edKaD+b4AvY=";
+        };
+        aarch64-linux = {
+          name = "openhue_Linux_arm64.tar.gz";
+          hash = "sha256-Xx5dQBqF8yPmj+rxX69bplecZfKMUp1WN/zohd9qhKY=";
+        };
+      };
+      source = sources.${system} or (throw "openhue-cli: unsupported system ${system}");
+    in
+    {
+      url = "https://github.com/openhue/openhue-cli/releases/download/${finalAttrs.version}/${source.name}";
+      inherit (source) hash;
+    }
+  );
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 openhue $out/bin/openhue
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command-line interface for interacting with Philips Hue smart lighting systems";
+    homepage = "https://github.com/openhue/openhue-cli";
+    license = lib.licenses.asl20;
+    mainProgram = "openhue";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## What

- Package OpenHue CLI 0.23 for Linux from the upstream release archives.
- Add `openhue` to the managed Hermes shell package set.
- Register OpenHue's built-in MCP server in the Hermes service config.
- Render OpenHue's bridge config declaratively from SOPS secrets.

## Why

Martin has Hue lights and a Hue bridge on the LAN. OpenHue supports direct bridge control and a built-in MCP server exposing Hue tools to assistants.

## Declarative Hue configuration

This PR expects these entries in `secrets/hermes.yaml`:

```yaml
HUE_BRIDGE_IP: <bridge-ip>
HUE_BRIDGE_APPLICATION_KEY: <bridge-application-key>
```

Nix renders them into:

```text
/var/lib/hermes/.openhue/config.yaml
```

with this OpenHue shape:

```yaml
bridge: <bridge-ip>
key: <bridge-application-key>
```

The OpenHue MCP subprocess also gets `HOME=/var/lib/hermes` so it reads that managed config path consistently.

## Validation

- `nix build .#openhue-cli -L`
- `./result/bin/openhue version`
- `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.mcpServers.openhue.command --raw`
- `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.mcpServers.openhue.args --json`
- `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.mcpServers.openhue.env.HOME --raw`
- `nix eval .#nixosConfigurations.revan.config.sops.templates."hermes-openhue-config".mode --raw`
- `nix eval .#nixosConfigurations.revan.config.systemd.tmpfiles.rules --json`
- `just eval`
- `git diff --check`
