### PR TITLE
feat(hermes): enable local Piper TTS

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -16,6 +16,7 @@ The current deployment is:
 - **Primary model**: `gpt-5.5` via the `openai-codex` provider
 - **Fallback model**: `claude-opus-4-7` via the `anthropic` provider
 - **Memory provider**: Holographic
+- **Default TTS**: local Piper using `en_GB-vctk-medium`, speaker `p276`/`11`
 - **Web dashboard**: `https://revan.<tailnet>/` through Caddy/Tailscale
 - **Deployment mode**: native NixOS service, not podman container mode
 
@@ -84,6 +85,45 @@ services.hermes-agent.settings = {
 
 This means the live default is `gpt-5.5` through `openai-codex`, with
 Anthropic held as fallback.
+
+## Local Piper TTS
+
+Hermes 0.12.0 supports local TTS providers. This deployment uses Piper by
+default through a command provider so Hermes can select the VCTK multi-speaker
+voice explicitly.
+
+The shell exposes `piper` through `services.hermes-agent.extraPackages`, and
+the managed Hermes wrapper prepends the same package set to `PATH` for manual
+host-side `hermes` invocations.
+
+The voice assets are fixed-output Nix fetches from
+`rhasspy/piper-voices` at revision
+`7a6c333ec560f0e688371adc2fbb7bbe105028c6`:
+
+- model: `en/en_GB/vctk/medium/en_GB-vctk-medium.onnx`
+- config: `en/en_GB/vctk/medium/en_GB-vctk-medium.onnx.json`
+- speaker: `p276`
+- speaker id: `11`
+
+The config shape is:
+
+```nix
+tts = {
+  provider = "piper-vctk-p276";
+  providers.piper-vctk-p276 = {
+    type = "command";
+    command = "piper --model <voice-dir>/en_GB-vctk-medium.onnx --speaker 11 --output-file {output_path} --input-file {input_path}";
+    output_format = "wav";
+    voice_compatible = true;
+    model = "en_GB-vctk-medium";
+    voice = "p276";
+  };
+};
+```
+
+The model and JSON config are symlinked into one Nix store directory before
+use. Piper resolves `<model>.json` next to the ONNX model at runtime, so the
+two fetched files must remain adjacent.
 
 The remote qwen endpoints remain available as named custom providers:
 

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -25,6 +25,20 @@ let
   hermesHome = "${config.services.hermes-agent.stateDir}/.hermes";
   hermesDashboardHost = "127.0.0.1";
   hermesDashboardPort = 9119;
+  piperVoiceRevision = "7a6c333ec560f0e688371adc2fbb7bbe105028c6";
+  piperVctkMediumModel = pkgs.fetchurl {
+    url = "https://huggingface.co/rhasspy/piper-voices/resolve/${piperVoiceRevision}/en/en_GB/vctk/medium/en_GB-vctk-medium.onnx";
+    hash = "sha256-Tp/IWrkAk4Uxn8a65/VVd/ii1+53/ZFZpVAOtlMfQeY=";
+  };
+  piperVctkMediumConfig = pkgs.fetchurl {
+    url = "https://huggingface.co/rhasspy/piper-voices/resolve/${piperVoiceRevision}/en/en_GB/vctk/medium/en_GB-vctk-medium.onnx.json";
+    hash = "sha256-f4XmOR7Q9/RuSr0ZNFkpoWvpMaDJlFCG+WaS3OIIf6g=";
+  };
+  piperVctkMediumVoice = pkgs.runCommand "piper-en_GB-vctk-medium-voice" { } ''
+    mkdir -p "$out"
+    ln -s ${piperVctkMediumModel} "$out/en_GB-vctk-medium.onnx"
+    ln -s ${piperVctkMediumConfig} "$out/en_GB-vctk-medium.onnx.json"
+  '';
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the
   # service account and the interactive host user intentionally share one
@@ -230,6 +244,7 @@ let
     openhue-cli
     openssh
     poppler-utils
+    piper-tts
     procps
     python3
     python3Packages.tinytuya
@@ -752,9 +767,20 @@ in
         ];
 
         tts = {
-          provider = "edge";
-          edge = {
-            voice = "en-GB-SoniaNeural";
+          provider = "piper-vctk-p276";
+          providers.piper-vctk-p276 = {
+            type = "command";
+            command = "${pkgs.piper-tts}/bin/piper --model ${piperVctkMediumVoice}/en_GB-vctk-medium.onnx --speaker 11 --output-file {output_path} --input-file {input_path}";
+            output_format = "wav";
+            voice_compatible = true;
+            timeout = 120;
+            model = "en_GB-vctk-medium";
+            voice = "p276";
+          };
+          piper = {
+            voice = "${piperVctkMediumVoice}/en_GB-vctk-medium.onnx";
+            voices_dir = "${hermesHome}/cache/piper-voices";
+            use_cuda = false;
           };
         };
 


### PR DESCRIPTION
## Summary

- switch Hermes TTS from Edge to a local Piper command provider
- add `piper-tts` to the managed Hermes shell/package set
- fetch the `en_GB-vctk-medium` Piper model and config from a pinned `rhasspy/piper-voices` commit
- select VCTK speaker `p276`, speaker id `11`, as Traya's default voice
- document the local Piper wiring and the adjacent `.onnx`/`.onnx.json` requirement

## Validation

- `nix eval --impure --raw --expr 'let flake = builtins.getFlake "path:/var/lib/hermes/workspace/nix-config-piper"; in flake.nixosConfigurations.revan.config.services.hermes-agent.settings.tts.provider'`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake "path:/var/lib/hermes/workspace/nix-config-piper"; in flake.nixosConfigurations.revan.config.services.hermes-agent.settings.tts.providers.piper-vctk-p276'`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake "path:/var/lib/hermes/workspace/nix-config-piper"; in builtins.elem "piper-tts" (map (p: p.pname or p.name or "") flake.nixosConfigurations.revan.config.services.hermes-agent.extraPackages)'`
- built a real Piper synthesis fixture with the evaluated command and verified a non-empty WAV with duration `3.262404`
- `nix fmt nixos/_mixins/server/hermes/default.nix nixos/_mixins/server/hermes/README.md`
- `just eval`
- `git diff --check`

## Notes

Hermes 0.12.0 has a native Piper provider, but the deployed Hermes Python environment does not currently expose an importable `piper` module, and this nixpkgs input does not expose `python312Packages.piper-tts`. The command provider avoids that interpreter mismatch while still using local Piper and the pinned voice assets.
