### PR TITLE
feat(hermes): add Tuya bulb control tooling

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -29,6 +29,11 @@ let
   # such as auth.json and cron state. That breaks this deployment because the
   # service account and the interactive host user intentionally share one
   # managed HERMES_HOME via the hermes group.
+  hermesTuyaPythonPackages = with pkgs.python3Packages; [
+    tinytuya
+    tuyaha
+  ];
+  hermesTuyaPythonPath = pkgs.python3Packages.makePythonPath hermesTuyaPythonPackages;
   hermesManagedPythonPath = pkgs.writeTextDir "sitecustomize.py" ''
     """Keep managed Hermes state group-accessible and patch doctor checks."""
 
@@ -162,7 +167,7 @@ let
             --set-default TRAYA_SANCTUARY_DIR "/var/lib/hermes/workspace/trayas-sanctuary" \
             --set-default TRAYA_SANCTUARY_REPO "the-cauldron/trayas-sanctuary" \
             --prefix PATH : "${lib.makeBinPath hermesExtraPackages}" \
-            --prefix PYTHONPATH : "${hermesManagedPythonPath}" \
+            --prefix PYTHONPATH : "${hermesManagedPythonPath}:${hermesTuyaPythonPath}" \
             --set-default HERMES_MANAGED "true"
         fi
       done
@@ -225,6 +230,7 @@ let
     poppler-utils
     procps
     python3Minimal
+    python3Packages.tinytuya
     rclone
     ripgrep
     rsync
@@ -256,6 +262,7 @@ let
     export TRAYA_SANCTUARY_DIR="/var/lib/hermes/workspace/trayas-sanctuary"
     export TRAYA_SANCTUARY_REPO="the-cauldron/trayas-sanctuary"
     export GNUPGHOME=${hermesGnupgHome}
+    export PYTHONPATH="${hermesManagedPythonPath}:${hermesTuyaPythonPath}:\''${PYTHONPATH-}"
 
     # Interactive CLI sandboxing: systemd hardening does not apply to host
     # shells, so we reuse bubblewrap to hide the same paths the gateway


### PR DESCRIPTION
## Summary
- add `tinytuya` to the Hermes managed tool PATH so I can run the TinyTuya CLI from terminal sessions
- add `tinytuya` and `tuyaha` to the Hermes Python path so agent-side Python can import both libraries
- keep the existing managed Hermes `sitecustomize.py` path intact while extending it with the Tuya modules

## Research notes
- `python3Packages.tinytuya` is present in nixpkgs and provides the `tinytuya` CLI.
- `python3Packages.tuyaha` is present in nixpkgs as a Python module, but does not expose a standalone CLI.
- TinyTuya is the useful first tool for local control/discovery of the Smart Life/Tuya G9 bulb once we have the device ID and local key.

## Test plan
- `nix fmt nixos/_mixins/server/hermes/default.nix`
- `just eval`
- `nix eval --raw .#nixosConfigurations.revan.config.system.build.toplevel.drvPath`
- `nix eval --json '.#nixosConfigurations.revan.config.services.hermes-agent.extraPackages' --apply 'map (p: builtins.unsafeDiscardStringContext (toString p))'`
- `nix eval --json '.#nixosConfigurations.revan.config.users.users.hermes.packages' --apply 'map (p: builtins.unsafeDiscardStringContext (toString p))'`
- `nix shell .#nixosConfigurations.revan.pkgs.python3Packages.tinytuya -c tinytuya --help`
- `PYTHONPATH=$(nix eval --raw --impure --expr 'let flake = builtins.getFlake (toString ./.) ; pkgs = flake.nixosConfigurations.revan.pkgs; packages = with pkgs.python3Packages; [ tinytuya tuyaha ]; in pkgs.python3Packages.makePythonPath packages') nix shell .#nixosConfigurations.revan.pkgs.python3 .#nixosConfigurations.revan.pkgs.python3Packages.tinytuya -c python -c 'import tinytuya, tuyaha'`
