### PR TITLE
fix(hermes): use full Python runtime

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -229,7 +229,7 @@ let
     openssh
     poppler-utils
     procps
-    python3Minimal
+    python3
     python3Packages.tinytuya
     rclone
     ripgrep


### PR DESCRIPTION
## Summary
- replace Hermes' ambient `python3Minimal` with full `python3`
- keep the TinyTuya CLI and Python package path wiring from the previous Tuya tooling change
- fix standard-library extension imports such as `zlib`, which are needed by normal Python networking stacks like `requests -> urllib3`

## Why
The deployed Tuya tooling exposed that `python3Minimal` does not provide the `zlib` extension module. TinyTuya's CLI wrapper works, but agent-side Python imports through `tuyaha` fail when `urllib3` imports `zlib`.

Full `python3` includes `lib-dynload/zlib...so`, so it is the safer default for Hermes automation now that we are using Python libraries directly rather than only tiny standalone scripts.

## Test plan
- `nix fmt nixos/_mixins/server/hermes/default.nix`
- `just eval`
- `nix eval --raw .#nixosConfigurations.revan.config.system.build.toplevel.drvPath`
- confirmed Hermes extra packages now include `python3-3.13.12`, not `python3-minimal`
- verified full Python can import `zlib`, `tinytuya`, and `tuyaha` with the configured Tuya package path
