### PR TITLE
fix(hermes): enable CUDA-capable Piper voice cleanup

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -92,9 +92,13 @@ Hermes 0.12.0 supports local TTS providers. This deployment uses Piper by
 default through a command provider so Hermes can select the VCTK multi-speaker
 voice explicitly.
 
-The shell exposes `piper` through `services.hermes-agent.extraPackages`, and
-the managed Hermes wrapper prepends the same package set to `PATH` for manual
-host-side `hermes` invocations.
+The shell exposes the same Piper package selected for the service through
+`services.hermes-agent.extraPackages`, and the managed Hermes wrapper prepends
+the same package set to `PATH` for manual host-side `hermes` invocations. On
+CUDA-capable hosts this is a CUDA-enabled Piper build: `piper-tts` is rebuilt
+against an ONNX Runtime derivation with `cudaSupport = true`, and the service
+wrapper passes `--cuda` automatically. Non-CUDA hosts keep the stock CPU Piper
+package.
 
 The voice assets are fixed-output Nix fetches from
 `rhasspy/piper-voices` at revision
@@ -105,6 +109,18 @@ The voice assets are fixed-output Nix fetches from
 - speaker: `p276`
 - speaker id: `11`
 
+The command provider wraps Piper with a small FFmpeg post-processing step. Piper
+still writes a temporary WAV first, then the wrapper writes the requested Hermes
+WAV output after applying the production Jivetalking voice-cleanup tunings:
+
+- `anlmdn=s=0.00001:p=0.0060:r=0.0020:m=3`
+- `adeclick=t=2.0:w=55:o=50:m=s`
+
+Those settings come from the measured optimum in
+[`linuxmatters/jivetalking/docs/Benchmarks.md`](https://github.com/linuxmatters/jivetalking/blob/main/docs/Benchmarks.md):
+`anlmdn` keeps the FFmpeg minimum research radius with stricter smoothing, and
+`adeclick` uses a less sensitive threshold, lower overlap, and spline repair.
+
 The config shape is:
 
 ```nix
@@ -112,7 +128,7 @@ tts = {
   provider = "piper-vctk-p276";
   providers.piper-vctk-p276 = {
     type = "command";
-    command = "piper --model <voice-dir>/en_GB-vctk-medium.onnx --speaker 11 --output-file {output_path} --input-file {input_path}";
+    command = "<wrapper>/bin/hermes-piper-vctk-p276 --input-file {input_path} --output-file {output_path}";
     output_format = "wav";
     voice_compatible = true;
     model = "en_GB-vctk-medium";

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -22,6 +22,7 @@ let
   # `determinate` flake's `packages.default` is `determinate-nixd` (the daemon
   # helper); the actual `nix` CLI lives in its `nix` input.
   nixPackage = inputs.determinate.inputs.nix.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  inherit (config.noughty) host;
   hermesHome = "${config.services.hermes-agent.stateDir}/.hermes";
   hermesDashboardHost = "127.0.0.1";
   hermesDashboardPort = 9119;
@@ -39,6 +40,83 @@ let
     ln -s ${piperVctkMediumModel} "$out/en_GB-vctk-medium.onnx"
     ln -s ${piperVctkMediumConfig} "$out/en_GB-vctk-medium.onnx.json"
   '';
+  onnxruntimeCuda = pkgs.onnxruntime.override {
+    cudaSupport = true;
+  };
+  python3PackagesWithCudaOnnxruntime = pkgs.python3Packages.override {
+    overrides = pyFinal: pyPrev: {
+      onnxruntime = pyPrev.onnxruntime.override {
+        onnxruntime = onnxruntimeCuda;
+      };
+    };
+  };
+  piperTtsCuda = pkgs.piper-tts.override {
+    python3Packages = python3PackagesWithCudaOnnxruntime;
+  };
+  piperTtsPackage = if host.gpu.hasCuda then piperTtsCuda else pkgs.piper-tts;
+  piperCudaFlag = lib.optionalString host.gpu.hasCuda "--cuda";
+  # Jivetalking's benchmarked production tunings keep these FFmpeg filters on
+  # the fast/transparent frontier for podcast voice. Piper still emits WAV, then
+  # this wrapper denoises and repairs clicks into the requested Hermes output.
+  # See: https://github.com/linuxmatters/jivetalking/blob/main/docs/Benchmarks.md
+  piperPostFilter = "anlmdn=s=0.00001:p=0.0060:r=0.0020:m=3,adeclick=t=2.0:w=55:o=50:m=s";
+  piperVctkP276Command = pkgs.writeShellApplication {
+    name = "hermes-piper-vctk-p276";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.ffmpeg
+      piperTtsPackage
+    ];
+    text = ''
+      set -euo pipefail
+
+      input_file=""
+      output_file=""
+
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --input-file)
+            input_file="$2"
+            shift 2
+            ;;
+          --output-file)
+            output_file="$2"
+            shift 2
+            ;;
+          *)
+            echo "Unknown argument: $1" >&2
+            exit 64
+            ;;
+        esac
+      done
+
+      if [[ -z "$input_file" || -z "$output_file" ]]; then
+        echo "Usage: hermes-piper-vctk-p276 --input-file PATH --output-file PATH" >&2
+        exit 64
+      fi
+
+      tmp_wav="$(mktemp --tmpdir hermes-piper-vctk-p276.XXXXXX.wav)"
+      cleanup() {
+        rm -f "$tmp_wav"
+      }
+      trap cleanup EXIT
+
+      piper \
+        ${piperCudaFlag} \
+        --model ${piperVctkMediumVoice}/en_GB-vctk-medium.onnx \
+        --speaker 11 \
+        --output-file "$tmp_wav" \
+        --input-file "$input_file"
+
+      ffmpeg \
+        -hide_banner \
+        -loglevel error \
+        -y \
+        -i "$tmp_wav" \
+        -af ${lib.escapeShellArg piperPostFilter} \
+        "$output_file"
+    '';
+  };
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the
   # service account and the interactive host user intentionally share one
@@ -244,7 +322,7 @@ let
     openhue-cli
     openssh
     poppler-utils
-    piper-tts
+    piperTtsPackage
     procps
     python3
     python3Packages.tinytuya
@@ -770,7 +848,7 @@ in
           provider = "piper-vctk-p276";
           providers.piper-vctk-p276 = {
             type = "command";
-            command = "${pkgs.piper-tts}/bin/piper --model ${piperVctkMediumVoice}/en_GB-vctk-medium.onnx --speaker 11 --output-file {output_path} --input-file {input_path}";
+            command = "${piperVctkP276Command}/bin/hermes-piper-vctk-p276 --input-file {input_path} --output-file {output_path}";
             output_format = "wav";
             voice_compatible = true;
             timeout = 120;


### PR DESCRIPTION
## Summary
- wraps Piper output with the Jivetalking production anlmdn and adeclick filter chain
- rebuilds Piper against CUDA-enabled ONNX Runtime on CUDA-capable hosts
- passes --cuda automatically for the Hermes Piper wrapper on CUDA hosts
- exposes the same selected Piper package in Hermes service and shell PATH
- documents the post-processing and CUDA behaviour

## Test plan
- nix run nixpkgs#nixfmt-rfc-style -- nixos/_mixins/server/hermes/default.nix
- nix-instantiate --parse nixos/_mixins/server/hermes/default.nix
- nix eval .#nixosConfigurations.revan.config.noughty.host.gpu.hasCuda
- nix eval .#nixosConfigurations.revan.config.services.hermes-agent.settings.tts.providers.piper-vctk-p276.command
- nix build --no-write-lock-file --dry-run .#nixosConfigurations.revan.config.system.build.toplevel

Follow-up to #804.