### PR TITLE
fix(hermes): simplify Piper TTS configuration

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -40,33 +40,10 @@ let
     ln -s ${piperVctkMediumModel} "$out/en_GB-vctk-medium.onnx"
     ln -s ${piperVctkMediumConfig} "$out/en_GB-vctk-medium.onnx.json"
   '';
-  onnxruntimeCuda = pkgs.onnxruntime.override {
-    cudaSupport = true;
-  };
-  python3PackagesWithCudaOnnxruntime = pkgs.python3Packages.override {
-    overrides = pyFinal: pyPrev: {
-      onnxruntime = pyPrev.onnxruntime.override {
-        onnxruntime = onnxruntimeCuda;
-      };
-    };
-  };
-  piperTtsCuda = pkgs.piper-tts.override {
-    python3Packages = python3PackagesWithCudaOnnxruntime;
-  };
-  piperTtsPackage = if host.gpu.hasCuda then piperTtsCuda else pkgs.piper-tts;
-  piperCudaFlag = lib.optionalString host.gpu.hasCuda "--cuda";
-  # Jivetalking's benchmarked production tunings keep these FFmpeg filters on
-  # the fast/transparent frontier for podcast voice. Piper still emits WAV, then
-  # this wrapper denoises and repairs clicks into the requested Hermes output.
-  # See: https://github.com/linuxmatters/jivetalking/blob/main/docs/Benchmarks.md
-  piperPostFilter = "anlmdn=s=0.00001:p=0.0060:r=0.0020:m=3,adeclick=t=2.0:w=55:o=50:m=s";
+  piperTtsPackage = pkgs.piper-tts;
   piperVctkP276Command = pkgs.writeShellApplication {
     name = "hermes-piper-vctk-p276";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.ffmpeg
-      piperTtsPackage
-    ];
+    runtimeInputs = [ piperTtsPackage ];
     text = ''
       set -euo pipefail
 
@@ -95,28 +72,16 @@ let
         exit 64
       fi
 
-      tmp_wav="$(mktemp --tmpdir hermes-piper-vctk-p276.XXXXXX.wav)"
-      cleanup() {
-        rm -f "$tmp_wav"
-      }
-      trap cleanup EXIT
-
       piper \
-        ${piperCudaFlag} \
         --model ${piperVctkMediumVoice}/en_GB-vctk-medium.onnx \
         --speaker 11 \
-        --output-file "$tmp_wav" \
+        --output-file "$output_file" \
         --input-file "$input_file"
-
-      ffmpeg \
-        -hide_banner \
-        -loglevel error \
-        -y \
-        -i "$tmp_wav" \
-        -af ${lib.escapeShellArg piperPostFilter} \
-        "$output_file"
     '';
   };
+  managedHermesConfig =
+    (pkgs.formats.yaml { }).generate "hermes-managed-config.yaml"
+      config.services.hermes-agent.settings;
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the
   # service account and the interactive host user intentionally share one
@@ -855,11 +820,6 @@ in
             model = "en_GB-vctk-medium";
             voice = "p276";
           };
-          piper = {
-            voice = "${piperVctkMediumVoice}/en_GB-vctk-medium.onnx";
-            voices_dir = "${hermesHome}/cache/piper-voices";
-            use_cuda = false;
-          };
         };
 
         memory = {
@@ -945,6 +905,13 @@ in
       "/run/current-system"
       "/run/booted-system"
     ];
+
+    system.activationScripts.hermes-agent-managed-config = lib.stringAfter [ "hermes-agent-setup" ] ''
+      # The upstream NixOS module deep-merges settings into mutable config.yaml.
+      # Revan's Hermes config is Nix-managed, so replace the whole file after
+      # that merge to prevent stale providers and retired settings lingering.
+      install -m 0640 -o ${hermesUser} -g ${hermesGroup} ${managedHermesConfig} ${hermesHome}/config.yaml
+    '';
 
     systemd.services.cloudflared-hermes = lib.mkIf hasCloudflareSopsFile {
       description = "Cloudflare Tunnel connector for Hermes webhooks";


### PR DESCRIPTION
## What
- Keep Traya's existing VCTK p276 Piper voice.
- Simplify the provider wrapper to direct `piper-tts` only: no CUDA ONNX Runtime override and no FFmpeg cleanup filters.
- Continue using `pkgs.piper-tts` 1.3.0.
- Remove the native Piper switch from the previous revision because Hermes native Piper does not currently expose the VCTK speaker selection needed for p276.
- Replace the whole Nix-managed Hermes `config.yaml` after the upstream module's deep-merge activation, so stale providers and retired settings cannot linger.

## Why
The click/pop issue was fixed by the Piper stack itself, not by CUDA or FFmpeg filtering. CUDA is too expensive for this path and likely CI-hostile on `revan`. The deployment should keep the existing voice while removing the unnecessary heavy pieces.

Replacing the whole config file is cleaner here because this Hermes deployment treats Nix as the source of truth for `config.yaml`. Mutable state still lives in separate files such as auth, sessions, cron state, memory, skills, and platform/runtime state.

## Validation
- `nix fmt -- flake.nix nixos/_mixins/server/hermes/default.nix`
- `nix eval --raw .#nixosConfigurations.revan.pkgs.piper-tts.version` → `1.3.0`
- `nix eval --json .#nixosConfigurations.revan.config.services.hermes-agent.settings.tts`
- `nix eval --raw .#nixosConfigurations.revan.config.system.activationScripts.hermes-agent-managed-config.text`
- `nix-instantiate --parse flake.nix`
- `nix-instantiate --parse nixos/_mixins/server/hermes/default.nix`
- `git diff --check`
- `nix build --dry-run .#nixosConfigurations.revan.config.system.build.toplevel`