### PR TITLE
fix(hermes): use native Piper TTS provider

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,14 +493,18 @@
         "uv2nix": "uv2nix_2"
       },
       "locked": {
-        "lastModified": 1777573861,
-        "narHash": "sha256-whY/1WL2fQUhPqDp7CGm3MSwOOo7FB1eADhNVnHeCRU=",
-        "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.4.30.tar.gz"
+        "lastModified": 1777542800,
+        "narHash": "sha256-wzNl+TWSnH88Nsh8SxPovuebbrBsgZpVaS5LK6sd0n8=",
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "8d302e37a8966a20c472c6ef202524685b864021",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.4.30.tar.gz"
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "8d302e37a8966a20c472c6ef202524685b864021",
+        "type": "github"
       }
     },
     "home-manager": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
-    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.4.30.tar.gz";
+    hermes-agent.url = "github:NousResearch/hermes-agent/8d302e37a8966a20c472c6ef202524685b864021";
     hermes-agent.inputs.nixpkgs.follows = "nixpkgs-unstable";
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -88,17 +88,16 @@ Anthropic held as fallback.
 
 ## Local Piper TTS
 
-Hermes 0.12.0 supports local TTS providers. This deployment uses Piper by
-default through a command provider so Hermes can select the VCTK multi-speaker
-voice explicitly.
+Hermes supports a native Piper provider. This deployment uses that provider
+instead of a command wrapper, so synthesis happens inside Hermes through the
+Python `piper` module.
 
-The shell exposes the same Piper package selected for the service through
-`services.hermes-agent.extraPackages`, and the managed Hermes wrapper prepends
-the same package set to `PATH` for manual host-side `hermes` invocations. On
-CUDA-capable hosts this is a CUDA-enabled Piper build: `piper-tts` is rebuilt
-against an ONNX Runtime derivation with `cudaSupport = true`, and the service
-wrapper passes `--cuda` automatically. Non-CUDA hosts keep the stock CPU Piper
-package.
+The Hermes package is pinned to a native-Piper commit. Hermes' current native
+Piper runtime reads the provider config but does not yet pass `speaker_id` into
+Piper's `SynthesisConfig`, so this deployment injects `HERMES_PIPER_SPEAKER_ID=11`
+through the managed `sitecustomize.py` shim. That keeps synthesis inside Hermes'
+native Python provider while selecting Traya's VCTK `p276` voice without shelling
+out to the `piper` CLI.
 
 The voice assets are fixed-output Nix fetches from
 `rhasspy/piper-voices` at revision
@@ -109,30 +108,17 @@ The voice assets are fixed-output Nix fetches from
 - speaker: `p276`
 - speaker id: `11`
 
-The command provider wraps Piper with a small FFmpeg post-processing step. Piper
-still writes a temporary WAV first, then the wrapper writes the requested Hermes
-WAV output after applying the production Jivetalking voice-cleanup tunings:
-
-- `anlmdn=s=0.00001:p=0.0060:r=0.0020:m=3`
-- `adeclick=t=2.0:w=55:o=50:m=s`
-
-Those settings come from the measured optimum in
-[`linuxmatters/jivetalking/docs/Benchmarks.md`](https://github.com/linuxmatters/jivetalking/blob/main/docs/Benchmarks.md):
-`anlmdn` keeps the FFmpeg minimum research radius with stricter smoothing, and
-`adeclick` uses a less sensitive threshold, lower overlap, and spline repair.
-
 The config shape is:
 
 ```nix
 tts = {
-  provider = "piper-vctk-p276";
-  providers.piper-vctk-p276 = {
-    type = "command";
-    command = "<wrapper>/bin/hermes-piper-vctk-p276 --input-file {input_path} --output-file {output_path}";
-    output_format = "wav";
-    voice_compatible = true;
-    model = "en_GB-vctk-medium";
-    voice = "p276";
+  provider = "piper";
+  piper = {
+    voice = "${piperVctkMediumVoice}/en_GB-vctk-medium.onnx";
+    voices_dir = "${piperVctkMediumVoice}";
+    speaker_id = 11;
+    use_cuda = false;
+    normalize_audio = true;
   };
 };
 ```

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -40,45 +40,29 @@ let
     ln -s ${piperVctkMediumModel} "$out/en_GB-vctk-medium.onnx"
     ln -s ${piperVctkMediumConfig} "$out/en_GB-vctk-medium.onnx.json"
   '';
-  piperTtsPackage = pkgs.piper-tts;
-  piperVctkP276Command = pkgs.writeShellApplication {
-    name = "hermes-piper-vctk-p276";
-    runtimeInputs = [ piperTtsPackage ];
-    text = ''
-      set -euo pipefail
-
-      input_file=""
-      output_file=""
-
-      while [[ $# -gt 0 ]]; do
-        case "$1" in
-          --input-file)
-            input_file="$2"
-            shift 2
-            ;;
-          --output-file)
-            output_file="$2"
-            shift 2
-            ;;
-          *)
-            echo "Unknown argument: $1" >&2
-            exit 64
-            ;;
-        esac
-      done
-
-      if [[ -z "$input_file" || -z "$output_file" ]]; then
-        echo "Usage: hermes-piper-vctk-p276 --input-file PATH --output-file PATH" >&2
-        exit 64
-      fi
-
-      piper \
-        --model ${piperVctkMediumVoice}/en_GB-vctk-medium.onnx \
-        --speaker 11 \
-        --output-file "$output_file" \
-        --input-file "$input_file"
-    '';
-  };
+  patchedOnnxruntimePythonPackage =
+    pkgs.runCommand "python312-onnxruntime-execstack-cleared"
+      {
+        nativeBuildInputs = [ pkgs.pax-utils ];
+      }
+      ''
+        cp -a --no-preserve=mode,ownership ${pkgs.python312Packages.onnxruntime} "$out"
+        chmod -R u+w "$out"
+        find "$out/${pkgs.python312.sitePackages}/onnxruntime/capi" -name "*.so" -print0 \
+          | xargs -0 -r scanelf -X -e
+      '';
+  piperTtsPythonPackage = pkgs.python312Packages.toPythonModule (
+    pkgs.callPackage "${inputs.nixpkgs}/pkgs/by-name/pi/piper-tts/package.nix" {
+      python3Packages = pkgs.python312Packages;
+      withAlignment = false;
+      withHTTP = false;
+      withTrain = false;
+    }
+  );
+  piperPythonPath = lib.makeSearchPath pkgs.python312.sitePackages (
+    [ patchedOnnxruntimePythonPackage ]
+    ++ pkgs.python312Packages.requiredPythonModules [ piperTtsPythonPackage ]
+  );
   managedHermesConfig =
     (pkgs.formats.yaml { }).generate "hermes-managed-config.yaml"
       config.services.hermes-agent.settings;
@@ -92,7 +76,7 @@ let
   ];
   hermesTuyaPythonPath = pkgs.python3Packages.makePythonPath hermesTuyaPythonPackages;
   hermesManagedPythonPath = pkgs.writeTextDir "sitecustomize.py" ''
-    """Keep managed Hermes state group-accessible and patch doctor checks."""
+    """Keep managed Hermes state group-accessible, patch Piper speaker selection, and patch doctor checks."""
 
     import builtins
     import os
@@ -158,6 +142,47 @@ let
                 **kwargs,
             )
 
+        def _managed_piper_speaker_id() -> int | None:
+            value = os.environ.get("HERMES_PIPER_SPEAKER_ID", "").strip()
+            if not value:
+                return None
+
+            try:
+                return int(value)
+            except ValueError:
+                return None
+
+        def _patch_piper_module(module) -> None:
+            if getattr(module, "_noughty_piper_patch_applied", False):
+                return
+
+            speaker_id = _managed_piper_speaker_id()
+            if speaker_id is None:
+                return
+
+            original_synthesis_config = getattr(module, "SynthesisConfig", None)
+            if original_synthesis_config is None:
+                return
+
+            class ManagedSynthesisConfig(original_synthesis_config):
+                def __init__(self, *args, **kwargs):
+                    if kwargs.get("speaker_id") in (None, ""):
+                        kwargs["speaker_id"] = speaker_id
+                    super().__init__(*args, **kwargs)
+
+            module.SynthesisConfig = ManagedSynthesisConfig
+            try:
+                module.config.SynthesisConfig = ManagedSynthesisConfig
+            except AttributeError:
+                pass
+
+            try:
+                module.voice._DEFAULT_SYNTHESIS_CONFIG.speaker_id = speaker_id
+            except AttributeError:
+                pass
+
+            module._noughty_piper_patch_applied = True
+
         def _patch_doctor_module(module) -> None:
             if getattr(module, "_noughty_doctor_patch_applied", False):
                 return
@@ -191,7 +216,9 @@ let
         def _managed_import(name, globals=None, locals=None, fromlist=(), level=0):
             module = _original_import(name, globals, locals, fromlist, level)
 
-            if name == "hermes_cli.doctor":
+            if name == "piper":
+                _patch_piper_module(module)
+            elif name == "hermes_cli.doctor":
                 _patch_doctor_module(module)
                 builtins.__import__ = _original_import
             elif name == "hermes_cli" and fromlist and "doctor" in fromlist:
@@ -224,8 +251,9 @@ let
             --set-default TRAYA_SANCTUARY_DIR "/var/lib/hermes/workspace/trayas-sanctuary" \
             --set-default TRAYA_SANCTUARY_REPO "the-cauldron/trayas-sanctuary" \
             --prefix PATH : "${lib.makeBinPath hermesExtraPackages}" \
-            --prefix PYTHONPATH : "${hermesManagedPythonPath}:${hermesTuyaPythonPath}" \
-            --set-default HERMES_MANAGED "true"
+            --prefix PYTHONPATH : "${hermesManagedPythonPath}:${hermesTuyaPythonPath}:${piperPythonPath}" \
+            --set-default HERMES_MANAGED "true" \
+            --set-default HERMES_PIPER_SPEAKER_ID "11"
         fi
       done
     '';
@@ -287,7 +315,7 @@ let
     openhue-cli
     openssh
     poppler-utils
-    piperTtsPackage
+    piperTtsPythonPackage
     procps
     python3
     python3Packages.tinytuya
@@ -322,7 +350,7 @@ let
     export TRAYA_SANCTUARY_DIR="/var/lib/hermes/workspace/trayas-sanctuary"
     export TRAYA_SANCTUARY_REPO="the-cauldron/trayas-sanctuary"
     export GNUPGHOME=${hermesGnupgHome}
-    export PYTHONPATH="${hermesManagedPythonPath}:${hermesTuyaPythonPath}:\''${PYTHONPATH-}"
+    export PYTHONPATH="${hermesManagedPythonPath}:${hermesTuyaPythonPath}:${piperPythonPath}:\''${PYTHONPATH-}"
 
     # Interactive CLI sandboxing: systemd hardening does not apply to host
     # shells, so we reuse bubblewrap to hide the same paths the gateway
@@ -665,6 +693,8 @@ in
       package = hermesAgentPackage;
       environment = {
         GNUPGHOME = hermesGnupgHome;
+        HERMES_PIPER_SPEAKER_ID = "11";
+        PYTHONPATH = "${hermesManagedPythonPath}:${hermesTuyaPythonPath}:${piperPythonPath}";
         TELEGRAM_HOME_CHANNEL = "-1003933927882";
         TRAYA_SANCTUARY_DIR = "/var/lib/hermes/workspace/trayas-sanctuary";
         TRAYA_SANCTUARY_REPO = "the-cauldron/trayas-sanctuary";
@@ -810,15 +840,13 @@ in
         ];
 
         tts = {
-          provider = "piper-vctk-p276";
-          providers.piper-vctk-p276 = {
-            type = "command";
-            command = "${piperVctkP276Command}/bin/hermes-piper-vctk-p276 --input-file {input_path} --output-file {output_path}";
-            output_format = "wav";
-            voice_compatible = true;
-            timeout = 120;
-            model = "en_GB-vctk-medium";
-            voice = "p276";
+          provider = "piper";
+          piper = {
+            voice = "${piperVctkMediumVoice}/en_GB-vctk-medium.onnx";
+            voices_dir = "${piperVctkMediumVoice}";
+            speaker_id = 11;
+            use_cuda = false;
+            normalize_audio = true;
           };
         };
 


### PR DESCRIPTION
## Summary
- Replace the transitional `piper-vctk-p276` command provider with Hermes' native `tts.provider = "piper"` config.
- Pin Hermes Agent to the native-Piper commit used in testing.
- Add Python 3.12 Piper/ONNX Runtime modules to the Hermes runtime path and clear ONNX Runtime executable-stack markings.
- Preserve Traya's VCTK `p276` voice with `speaker_id = 11` through the managed Piper speaker shim until upstream Hermes passes `speaker_id` directly into `SynthesisConfig`.
- Keep CUDA and FFmpeg post-processing out of the path.

## Test plan
- `nix-instantiate --parse flake.nix`
- `nix-instantiate --parse nixos/_mixins/server/hermes/default.nix`
- `git diff --check`
- `nix eval --json .#nixosConfigurations.revan.config.services.hermes-agent.settings.tts`
- `nix eval --raw .#nixosConfigurations.revan.config.system.activationScripts.hermes-agent-managed-config.text`
- `nix build --no-link .#nixosConfigurations.revan.config.system.build.toplevel --dry-run`
- Native Piper import smoke test using the built Hermes Python environment, verifying `piper`, patched `onnxruntime`, and speaker id `11`.
- Native Piper synthesis smoke test wrote `/tmp/traya-native-piper.wav` with 22050 Hz mono audio.
