### PR TITLE
fix(hermes): tune Piper voice settings

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -117,11 +117,24 @@ tts = {
     voice = "${piperVctkMediumVoice}/en_GB-vctk-medium.onnx";
     voices_dir = "${piperVctkMediumVoice}";
     speaker_id = 11;
+    length_scale = 1.25;
+    noise_scale = 0.35;
+    noise_w_scale = 0.80;
     use_cuda = false;
     normalize_audio = true;
   };
 };
 ```
+
+The synthesis tuning above keeps the VCTK `p276` voice a little quicker than
+the upstream model defaults while preserving a soft, breathy cadence:
+
+- `length_scale = 1.25` shortens phoneme duration from the model's slower `1.4`
+  default.
+- `noise_scale = 0.35` keeps acoustic texture close to the model's `0.333`
+  default without roughening the voice.
+- `noise_w_scale = 0.80` increases timing variation for a shy, less mechanical
+  delivery.
 
 The model and JSON config are symlinked into one Nix store directory before
 use. Piper resolves `<model>.json` next to the ONNX model at runtime, so the

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -845,6 +845,9 @@ in
             voice = "${piperVctkMediumVoice}/en_GB-vctk-medium.onnx";
             voices_dir = "${piperVctkMediumVoice}";
             speaker_id = 11;
+            length_scale = 1.25;
+            noise_scale = 0.35;
+            noise_w_scale = 0.80;
             use_cuda = false;
             normalize_audio = true;
           };


### PR DESCRIPTION
## Summary

- Tunes Traya's native Piper voice with the selected synthesis settings:
  - length_scale = 1.25
  - noise_scale = 0.35
  - noise_w_scale = 0.80
- Keeps the existing VCTK p276 speaker id 11, CPU Piper path, and native Hermes provider.
- Documents the tuning rationale in the Hermes on Revan README.

## Test Plan

- nix-instantiate --parse flake.nix
- nix-instantiate --parse nixos/_mixins/server/hermes/default.nix
- git diff --check
- nix eval --json .#nixosConfigurations.revan.config.services.hermes-agent.settings.tts with jq assertion for provider, speaker, tuning values, CUDA, and normalisation
- nix build --no-link .#nixosConfigurations.revan.config.system.build.toplevel --dry-run
- Native Python smoke test verified SynthesisConfig resolves speaker id 11 and the selected tuning values
