### PR TITLE
chore(defold): update to 1.12.4

### DIFF
--- a/pkgs/defold-bob/default.nix
+++ b/pkgs/defold-bob/default.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "defold-bob";
-  version = "1.12.3";
+  version = "1.12.4";
 
   src = fetchurl {
     url = "https://github.com/defold/defold/releases/download/${version}/bob.jar";
-    hash = "sha256-6fF0/OcVF2ZBYAKedcaM+qkJb+myBDfyjWaCZAa+kvc=";
+    hash = "sha256-VKxX2XEvzR6d5j9AWAPRWdiKL76UC47wWLpQOqQY+hg=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/defold/default.nix
+++ b/pkgs/defold/default.nix
@@ -35,14 +35,14 @@
 }:
 let
   pname = "defold";
-  version = "1.12.3";
+  version = "1.12.4";
 
   defold = stdenv.mkDerivation {
     inherit pname version;
 
     src = fetchurl {
       url = "https://github.com/defold/defold/releases/download/${version}/Defold-x86_64-linux.tar.gz";
-      hash = "sha256-ATaLlo5xI5rLgILnDiQgVuDGLsseqqd9kaVa0S9AKVQ=";
+      hash = "sha256-VRCCuwcTODYx9CzH/tna5OfKlnslswEsiHHQIM5FEYg=";
     };
 
     dontBuild = true;


### PR DESCRIPTION
Automated Defold update to version 1.12.4.

Updates all three packages: defold, defold-bob, and defold-gdc.

Release: https://github.com/defold/defold/releases/tag/1.12.4