### PR TITLE
feat: add Harper integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Things I currently need to do manually after installation.
   - [ ] Authenticate with GitHub
   - [ ] Create Personal Profile
   - [ ] Create Work Profile
-- [ ] Grammarly - authenticate
+- [ ] Harper - review browser extension settings
 - [ ] Maelstral - `maestral_qt`
 - [ ] Matrix - authenticate
 - [ ] Slack - authenticate

--- a/home-manager/_mixins/agentic/claude-code/LSP.md
+++ b/home-manager/_mixins/agentic/claude-code/LSP.md
@@ -46,7 +46,7 @@ The LSP wrapper is built as a `symlinkJoin` derivation wrapping `claudePackage`.
 
 ## Language servers
 
-15 LSP fragments across 11 language modules. All `command` values are Nix store paths - no PATH dependency.
+16 LSP fragments across 12 language modules. All `command` values are Nix store paths - no PATH dependency.
 
 | Key | Module | `command` | `args` | Extensions |
 |-----|--------|-----------|--------|------------|
@@ -57,6 +57,7 @@ The LSP wrapper is built as a `symlinkJoin` derivation wrapping `claudePackage`.
 | `typescript` | `javascript/` | `lib.getExe pkgs.typescript-language-server` | `--stdio` | `.ts` `.tsx` `.js` `.jsx` `.mjs` `.mts` `.cjs` `.cts` |
 | `json` | `javascript/` | `${pkgs.vscode-langservers-extracted}/bin/vscode-json-language-server` | `--stdio` | `.json` `.jsonc` |
 | `html` | `javascript/` | `${pkgs.vscode-langservers-extracted}/bin/vscode-html-language-server` | `--stdio` | `.html` |
+| `harper` | `harper/` | `${pkgs.harper}/bin/harper-ls` | `--stdio` | 40+ prose and comment-aware language extensions (see `harper/default.nix`) |
 | `css` | `javascript/` | `${pkgs.vscode-langservers-extracted}/bin/vscode-css-language-server` | `--stdio` | `.css` `.scss` `.less` |
 | `svelte` | `svelte/` | `lib.getExe pkgs.svelte-language-server` | `--stdio` | `.svelte` |
 | `lua` | `love/` | `lib.getExe pkgs.lua-language-server` | - | `.lua` |

--- a/home-manager/_mixins/desktop/apps/browsers/default.nix
+++ b/home-manager/_mixins/desktop/apps/browsers/default.nix
@@ -10,7 +10,7 @@ let
   ];
   advancedExtensions = [
     { id = "cjpalhdlnbpafiamejdnhcphjbkeiagm"; } # uBlock Origin
-    { id = "kbfnbcaeplbcioakkpcpgfkobkghlhen"; } # Grammarly
+    { id = "lodbfhdipoipcjmlebjbgmmgekckhpfb"; } # Harper
     { id = "mdjildafknihdffpkfmmpnpoiajfjnjd"; } # Consent-O-Matic
     { id = "mnjggcdmjocbbbhaepdhchncahnbgone"; } # SponsorBlock for YouTube
     { id = "gebbhagfogifgggkldgodflihgfeippi"; } # Return YouTube Dislike

--- a/home-manager/_mixins/development/harper/default.nix
+++ b/home-manager/_mixins/development/harper/default.nix
@@ -1,0 +1,127 @@
+# Harper - privacy-first grammar and spelling checking.
+# Centralised configuration for editor and coding-agent integrations.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  harperLs = "${pkgs.harper}/bin/harper-ls";
+
+  harperSettings = {
+    dialect = "British";
+    diagnosticSeverity = "hint";
+  };
+
+  neovimFiletypes = [
+    "markdown"
+    "text"
+    "tex"
+    "typst"
+  ];
+
+  extensionToLanguage = {
+    ".adoc" = "asciidoc";
+    ".asciidoc" = "asciidoc";
+    ".c" = "c";
+    ".cc" = "cpp";
+    ".clj" = "clojure";
+    ".cljc" = "clojure";
+    ".cljs" = "clojure";
+    ".cmake" = "cmake";
+    ".cpp" = "cpp";
+    ".cs" = "csharp";
+    ".cxx" = "cpp";
+    ".dart" = "dart";
+    ".go" = "go";
+    ".groovy" = "groovy";
+    ".h" = "c";
+    ".hs" = "haskell";
+    ".html" = "html";
+    ".java" = "java";
+    ".js" = "javascript";
+    ".jsx" = "javascriptreact";
+    ".kt" = "kotlin";
+    ".kts" = "kotlin";
+    ".lhs" = "lhaskell";
+    ".lua" = "lua";
+    ".md" = "markdown";
+    ".mdx" = "markdown";
+    ".nix" = "nix";
+    ".org" = "org";
+    ".php" = "php";
+    ".ps1" = "powershell";
+    ".py" = "python";
+    ".rb" = "ruby";
+    ".rs" = "rust";
+    ".scala" = "scala";
+    ".sh" = "shellscript";
+    ".sol" = "solidity";
+    ".swift" = "swift";
+    ".tex" = "tex";
+    ".toml" = "toml";
+    ".ts" = "typescript";
+    ".tsx" = "typescriptreact";
+    ".txt" = "plaintext";
+    ".typ" = "typst";
+    ".zig" = "zig";
+  };
+
+  extensions = lib.attrNames extensionToLanguage;
+in
+{
+  home.packages = [ pkgs.harper ];
+
+  # Claude Code - LSP server plugin.
+  claude-code.lspServers.harper = {
+    command = harperLs;
+    args = [ "--stdio" ];
+    inherit extensionToLanguage;
+    initializationOptions = {
+      "harper-ls" = harperSettings;
+    };
+  };
+
+  # OpenCode - LSP server.
+  programs.opencode.settings.lsp.harper = {
+    command = [
+      harperLs
+      "--stdio"
+    ];
+    inherit extensions;
+    initialization = {
+      "harper-ls" = harperSettings;
+    };
+  };
+
+  # Zed Editor - extension and LSP settings.
+  programs.zed-editor = lib.mkIf config.programs.zed-editor.enable {
+    extensions = [ "harper" ];
+    userSettings.lsp."harper-ls" = {
+      binary = {
+        path = harperLs;
+        arguments = [ "--stdio" ];
+      };
+      settings."harper-ls" = harperSettings;
+    };
+  };
+
+  # Neovim - native LSP configuration.
+  programs.neovim = lib.mkIf config.programs.neovim.enable {
+    extraLuaConfig = ''
+      -- Harper grammar and spelling LSP using Neovim 0.11+ native API.
+      vim.lsp.config('harper', {
+        cmd = { '${harperLs}', '--stdio' },
+        filetypes = ${builtins.toJSON neovimFiletypes},
+        settings = {
+          ['harper-ls'] = {
+            dialect = 'British',
+            diagnosticSeverity = 'hint',
+          },
+        },
+      })
+      vim.lsp.enable('harper')
+    '';
+  };
+}

--- a/nixos/_mixins/desktop/apps/browsers/default.nix
+++ b/nixos/_mixins/desktop/apps/browsers/default.nix
@@ -42,7 +42,7 @@ let
   ];
   extraExtensions = [
     "cjpalhdlnbpafiamejdnhcphjbkeiagm" # uBlock Origin
-    "kbfnbcaeplbcioakkpcpgfkobkghlhen" # Grammarly
+    "lodbfhdipoipcjmlebjbgmmgekckhpfb" # Harper
     "mdjildafknihdffpkfmmpnpoiajfjnjd" # Consent-O-Matic
     "mnjggcdmjocbbbhaepdhchncahnbgone" # SponsorBlock for YouTube
     "gebbhagfogifgggkldgodflihgfeippi" # Return YouTube Dislike

--- a/nixos/_mixins/desktop/apps/browsers/martin.nix
+++ b/nixos/_mixins/desktop/apps/browsers/martin.nix
@@ -32,8 +32,8 @@ lib.mkIf (host.is.workstation && noughtyLib.isUser [ "martin" ]) {
             install_url = "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi";
             installation_mode = "force_installed";
           };
-          "87677a2c52b84ad3a151a4a72f5bd3c4@jetpack" = {
-            install_url = "https://addons.mozilla.org/firefox/downloads/latest/grammarly-1/latest.xpi";
+          "harper@writewithharper.com" = {
+            install_url = "https://addons.mozilla.org/firefox/downloads/latest/private-grammar-checker-harper/latest.xpi";
             installation_mode = "force_installed";
           };
           "gdpr@cavi.au.dk" = {

--- a/nixos/_mixins/desktop/apps/workspace/default.nix
+++ b/nixos/_mixins/desktop/apps/workspace/default.nix
@@ -108,7 +108,7 @@ lib.mkIf (noughtyLib.hostHasTag "workspace") {
     enable = true;
     extensions = [
       "hdokiejnpimakedhajhdlcegeplioahd" # LastPass
-      "kbfnbcaeplbcioakkpcpgfkobkghlhen" # Grammarly
+      "lodbfhdipoipcjmlebjbgmmgekckhpfb" # Harper
       "mdpfkohgfpidohkakdbpmnngaocglmhl" # Disable Ctrl + Scroll Zoom
       "aeblfdkhhhdcdjpifhhbdiojplfjncoa" # 1Password
       "mdkgfdijbhbcbajcdlebbodoppgnmhab" # GoLinks

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -20,6 +20,7 @@
     llama-cpp-vulkan = llama-cpp.override { vulkanSupport = true; };
 
     llama-swap = final.unstable.llama-swap;
+    harper = final.unstable.harper;
 
     linuxPackages_6_12 = prev.linuxPackages_6_12.extend (
       _lpself: lpsuper: {


### PR DESCRIPTION
## Summary
- Add a dedicated Harper development mixin that installs pkgs.harper and configures harper-ls for Claude Code, OpenCode, Zed, and Neovim.
- Replace Grammarly with Harper in Chromium/Brave, Wavebox, and Firefox extension policies.
- Update the Claude Code LSP documentation and post-install checklist to reflect Harper.

## Validation
- nix fmt
- git diff --check
- just eval
- pkgs.harper eval/build and harper-ls --version
- Evaluated martin@skrye Harper package, Claude Code LSP, OpenCode LSP, Zed LSP, and Neovim config
- Evaluated skrye Chromium, Wavebox, and Firefox policies for Harper present and Grammarly absent
