### PR TITLE
feat(agentic): integrate pi agent support

### DIFF
--- a/home-manager/_mixins/agentic/assistants/README.md
+++ b/home-manager/_mixins/agentic/assistants/README.md
@@ -1,6 +1,6 @@
 # AI Agents
 
-Fourteen specialist agents, 31 commands, and seven skills - composed by Nix from a single source tree and delivered to Claude Code, OpenCode, and Codex without duplication.
+Fourteen specialist agents, 31 commands, and seven skills - composed by Nix from a single source tree and delivered to Claude Code, OpenCode, Codex, and Pi Agent without duplication.
 
 The Nix composition is the delivery mechanism, not the strategy. Everything below - the prompt hierarchy, agent specialisation, model selection, context-efficiency constraints, and orchestration patterns - is a general approach to prompt and context engineering. The output is plain Markdown files with YAML frontmatter. If you use Claude Code or OpenCode directly, you can recreate any part of this by placing files in the right directories.
 
@@ -26,6 +26,18 @@ The Nix composition is the delivery mechanism, not the strategy. Everything belo
 ```
 
 Global instructions in OpenCode are set via the `rules` option in `settings.json` rather than a file.
+
+**Pi Agent:**
+
+```
+~/.pi/agent/
+├── AGENTS.md                       # Global instructions (loaded every session)
+├── agents/<name>.md                # Subagent definitions for pi-subagents
+├── prompts/<name>.md               # Prompt templates (invocable with /<name>)
+└── skills/<name>/SKILL.md          # Agent Skills (loaded contextually)
+```
+
+Pi Agent resources are rendered here and consumed by `../pi`, which owns the Pi package, runtime wrapper, settings, MCP adapter, subagent extension config, and theme files.
 
 Each file is Markdown with YAML frontmatter specifying `name`, `description`, and optionally `model`. The prompt body follows the `---` delimiters. No build step required - drop the files in and they work.
 
@@ -325,11 +337,16 @@ Three tiers map to task complexity:
 
 `compose.nix` reads the source tree and generates platform-specific output. Each agent has one `prompt.md` and per-platform `header.<platform>.yaml` files for Claude Code and OpenCode. Codex agents use `header.codex.toml` for role-local config, and Codex command skills can use `header.codex.toml` with `spawn-agent = true` to delegate through `spawn_agent`.
 
+Pi Agent rendering lives in `default.nix` beside the shared secret-aware Traya rendering. Generated Pi subagents use `systemPromptMode: append`, inherit project context and skills, and set `maxSubagentDepth: 0` so child sessions cannot delegate further. Prompt templates carry `description` and reuse Claude `argument-hint` values where present.
+
+OpenCode `permission` headers are not mapped to Pi. Pi supports an explicit `tools` allowlist for subagents, but OpenCode's allow/deny permission model is not equivalent.
+
 | Platform | Agents | Commands | Global rules | Skills |
 |----------|--------|----------|-------------|--------|
 | Claude Code | `~/.claude/agents/*.agent.md` | `~/.claude/commands/*.prompt.md` | `~/.claude/rules/instructions.md` | `~/.claude/skills/*/SKILL.md` |
 | OpenCode | `~/.config/opencode/agents/*.agent.md` | `~/.config/opencode/commands/*.prompt.md` | `rules` option | `~/.config/opencode/skills/*/SKILL.md` |
 | Codex | `~/.config/codex/agents/*.toml` | `~/.config/codex/skills/*/SKILL.md` | `programs.codex.custom-instructions` | `~/.config/codex/skills/*/SKILL.md` |
+| Pi Agent | `~/.pi/agent/agents/*.md` | `~/.pi/agent/prompts/*.md` | `~/.pi/agent/AGENTS.md` | `~/.pi/agent/skills/*/SKILL.md` |
 
 ### Skills
 

--- a/home-manager/_mixins/agentic/assistants/default.nix
+++ b/home-manager/_mixins/agentic/assistants/default.nix
@@ -150,6 +150,162 @@ let
   opencodeCommands = compose.composeCommands "opencode";
   opencodeInstructions = compose.composeInstructions "opencode";
 
+  # ============ PI AGENT ============
+
+  piAgentPrompt =
+    prompt:
+    lib.replaceStrings
+      [
+        "Task tool"
+        "Permitted tools: Task tool for delegation, direct conversation"
+      ]
+      [
+        "subagent tool"
+        "Permitted tools: subagent tool for delegation, direct conversation"
+      ]
+      prompt;
+  renderPiMarkdown = header: body: ''
+    ---
+    ${header}
+    ---
+
+    ${body}
+  '';
+  renderPiAgentMarkdown =
+    {
+      name,
+      description,
+      prompt,
+    }:
+    renderPiMarkdown (lib.concatStringsSep "\n" [
+      "name: ${name}"
+      "description: ${builtins.toJSON description}"
+      "systemPromptMode: append"
+      "inheritProjectContext: true"
+      "inheritSkills: true"
+      "maxSubagentDepth: 0"
+    ]) (piAgentPrompt prompt);
+  renderPiPromptMarkdown =
+    {
+      description,
+      argumentHint ? null,
+      prompt,
+    }:
+    let
+      headerLines = [
+        "description: ${builtins.toJSON description}"
+      ]
+      ++ lib.optional (argumentHint != null) "argument-hint: ${builtins.toJSON argumentHint}";
+    in
+    renderPiMarkdown (lib.concatStringsSep "\n" headerLines) prompt;
+  piTrayaWriter = pkgs.writeText "write-traya-pi-agent.py" (
+    builtins.concatStringsSep "\n" [
+      "import pathlib"
+      "import sys"
+      ""
+      "prompt_path, description_path, bond_path, output_path = sys.argv[1:5]"
+      "prompt = pathlib.Path(prompt_path).read_text(encoding=\"utf-8\").strip()"
+      "prompt = prompt.replace(\"Task tool\", \"subagent tool\")"
+      "prompt = prompt.replace(\"Permitted tools: subagent tool for delegation, direct conversation\", \"Permitted tools: subagent tool for delegation, direct conversation\")"
+      "description = pathlib.Path(description_path).read_text(encoding=\"utf-8\").strip()"
+      "bond = pathlib.Path(bond_path).read_text(encoding=\"utf-8\").strip()"
+      "body = prompt if not bond else f\"{prompt}\\n{bond}\""
+      "content = \"---\\n\""
+      "content += \"name: traya\\n\""
+      "content += f\"description: {description!r}\\n\""
+      "content += \"systemPromptMode: append\\n\""
+      "content += \"inheritProjectContext: true\\n\""
+      "content += \"inheritSkills: true\\n\""
+      "content += \"maxSubagentDepth: 0\\n\""
+      "content += \"---\\n\\n\""
+      "content += body + \"\\n\""
+      "output = pathlib.Path(output_path)"
+      "output.parent.mkdir(parents=True, exist_ok=True)"
+      "tmp = output.with_name(f\"{output.name}.tmp\")"
+      "tmp.write_text(content, encoding=\"utf-8\")"
+      "tmp.chmod(0o600)"
+      "tmp.replace(output)"
+    ]
+    + "\n"
+  );
+  piAgents = lib.removeAttrs compose.agentDirs [ "traya" ];
+  piAgentFiles = lib.mapAttrs' (
+    name: _:
+    let
+      agentPath = ./agents + "/${name}";
+      description = readFileTrim (agentPath + "/description.txt");
+      prompt = readFileTrim (agentPath + "/prompt.md");
+    in
+    {
+      name = ".pi/agent/agents/${name}.md";
+      value.text = renderPiAgentMarkdown {
+        inherit name description prompt;
+      };
+    }
+  ) piAgents;
+  piSkillFiles = lib.mapAttrs' (name: skill: {
+    name = ".pi/agent/skills/${name}";
+    value.source = skill.path;
+  }) skills;
+  piStandalonePromptFiles = lib.mapAttrs' (
+    cmdName: _:
+    let
+      cmdPath = ./commands + "/${cmdName}";
+      description = readFileTrim (cmdPath + "/description.txt");
+      prompt = readFileTrim (cmdPath + "/prompt.md");
+      argumentHint = extractYamlField "argument-hint" (cmdPath + "/header.claude.yaml");
+    in
+    {
+      name = ".pi/agent/prompts/${cmdName}.md";
+      value.text = renderPiPromptMarkdown {
+        inherit description argumentHint prompt;
+      };
+    }
+  ) compose.standaloneCommandDirs;
+  piAgentPromptFiles = lib.foldlAttrs (
+    acc: agentName: _:
+    let
+      commandDirs = compose.discoverAgentCommands agentName;
+    in
+    acc
+    // lib.mapAttrs' (
+      cmdName: _:
+      let
+        cmdPath = ./agents + "/${agentName}/commands/${cmdName}";
+        description = readFileTrim (cmdPath + "/description.txt");
+        prompt = readFileTrim (cmdPath + "/prompt.md");
+        argumentHint = extractYamlField "argument-hint" (cmdPath + "/header.claude.yaml");
+        piPrompt = ''
+          Use the subagent tool to launch the `${agentName}` agent for the task below.
+
+          ${prompt}
+        '';
+      in
+      {
+        name = ".pi/agent/prompts/${agentName}-${cmdName}.md";
+        value.text = renderPiPromptMarkdown {
+          inherit description argumentHint;
+          prompt = piPrompt;
+        };
+      }
+    ) commandDirs
+  ) { } compose.agentDirs;
+  piGlobalInstructions = readFileTrim ./instructions/global.md;
+  piHomeFiles = {
+    ".pi/agent/AGENTS.md".text = piGlobalInstructions;
+  }
+  // piAgentFiles
+  // piSkillFiles
+  // piStandalonePromptFiles
+  // piAgentPromptFiles;
+  piTrayaActivation = ''
+    ${pkgs.python3}/bin/python ${piTrayaWriter} \
+      ${./agents/traya/prompt.md} \
+      ${./agents/traya/description.txt} \
+      ${config.sops.secrets.BOND_MD.path} \
+      "${config.home.homeDirectory}/.pi/agent/agents/traya.md"
+  '';
+
   # ============ SKILLS ============
 
   # composeSkills returns { name = { content; path; extras; }; ... }
@@ -372,89 +528,112 @@ let
 
 in
 {
-  sops = {
-    secrets.BOND_MD = {
-      sopsFile = trayaBondSopsFile;
-      mode = "0400";
+  options.agentic.assistants.pi = {
+    homeFiles = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      internal = true;
+      description = "Home Manager file entries for Pi Agent assistant resources.";
     };
 
-    templates.${trayaPromptTemplateName} = {
-      content = trayaPromptWithBond;
-      mode = "0600";
+    trayaActivation = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      internal = true;
+      description = "Activation script that writes Traya's Pi Agent file outside the Nix store.";
+    };
+  };
+
+  config = {
+    agentic.assistants.pi = {
+      homeFiles = piHomeFiles;
+      trayaActivation = piTrayaActivation;
     };
 
-    templates.${trayaClaudeAgentTemplateName} = {
-      content = compose.composeAgentFromPrompt "claude" "traya" trayaPromptWithBond;
-      mode = "0600";
-    };
-
-    templates.${trayaOpencodeAgentTemplateName} = {
-      content = compose.composeAgentFromPrompt "opencode" "traya" trayaPromptWithBond;
-      mode = "0600";
-    };
-
-    templates.${trayaCodexAgentTemplateName} = {
-      content = renderCodexAgentToml {
-        name = "traya";
-        description = trayaDescription;
-        developerInstructions = codexAgentPrompt trayaPromptWithBond;
-        header = readFileTrimIfExists (./agents + "/traya/header.codex.toml");
+    sops = {
+      secrets.BOND_MD = {
+        sopsFile = trayaBondSopsFile;
+        mode = "0400";
       };
-      mode = "0600";
+
+      templates.${trayaPromptTemplateName} = {
+        content = trayaPromptWithBond;
+        mode = "0600";
+      };
+
+      templates.${trayaClaudeAgentTemplateName} = {
+        content = compose.composeAgentFromPrompt "claude" "traya" trayaPromptWithBond;
+        mode = "0600";
+      };
+
+      templates.${trayaOpencodeAgentTemplateName} = {
+        content = compose.composeAgentFromPrompt "opencode" "traya" trayaPromptWithBond;
+        mode = "0600";
+      };
+
+      templates.${trayaCodexAgentTemplateName} = {
+        content = renderCodexAgentToml {
+          name = "traya";
+          description = trayaDescription;
+          developerInstructions = codexAgentPrompt trayaPromptWithBond;
+          header = readFileTrimIfExists (./agents + "/traya/header.codex.toml");
+        };
+        mode = "0600";
+      };
+
     };
 
-  };
+    home = {
+      file = {
+        # Traya's prompt is rendered via sops-nix at activation time so the bond
+        # is appended outside the Nix store. These entries symlink the tool paths
+        # to the rendered files.
+        "${config.home.homeDirectory}/.claude/agents/traya.md".source =
+          config.lib.file.mkOutOfStoreSymlink
+            config.sops.templates.${trayaClaudeAgentTemplateName}.path;
+        "${config.xdg.configHome}/opencode/agent/traya.md".source =
+          config.lib.file.mkOutOfStoreSymlink
+            config.sops.templates.${trayaOpencodeAgentTemplateName}.path;
 
-  home = {
-    file = {
-      # Traya's prompt is rendered via sops-nix at activation time so the bond
-      # is appended outside the Nix store. These entries symlink the tool paths
-      # to the rendered files.
-      "${config.home.homeDirectory}/.claude/agents/traya.md".source =
-        config.lib.file.mkOutOfStoreSymlink
-          config.sops.templates.${trayaClaudeAgentTemplateName}.path;
-      "${config.xdg.configHome}/opencode/agent/traya.md".source =
-        config.lib.file.mkOutOfStoreSymlink
-          config.sops.templates.${trayaOpencodeAgentTemplateName}.path;
+        # Claude Code global instructions
+        "${config.home.homeDirectory}/.claude/rules/instructions.md".text = claudeInstructions;
+      }
+      # Claude Code skill files
+      // mkClaudeSkillFiles
+      # OpenCode skill files
+      // mkOpencodeSkillFiles;
 
-      # Claude Code global instructions
-      "${config.home.homeDirectory}/.claude/rules/instructions.md".text = claudeInstructions;
-    }
-    # Claude Code skill files
-    // mkClaudeSkillFiles
-    # OpenCode skill files
-    // mkOpencodeSkillFiles;
-
-    # Codex skills and agents: written as real files via activation script (not symlinks).
-    # codex-rs uses file_type().is_file() for discovery, which returns false for symlinks
-    # on Linux. home.file creates symlinks, so both are invisible without this workaround.
-    # Run this after sops-nix so Traya's BOND secret is available to the
-    # activation-time Codex writers.
-    activation.codexFiles = lib.mkIf config.programs.codex.enable (
-      lib.hm.dag.entryAfter [ "writeBoundary" "sops-nix" ] (
-        codexRootInstructionsActivationScript + codexSkillsActivationScript + codexAgentsActivationScript
-      )
-    );
-  };
-
-  programs = {
-    claude-code = lib.mkIf config.programs.claude-code.enable {
-      # Custom agents (auto-generated from agents/ directory)
-      agents = claudeAgents;
-
-      # Reusable commands (auto-generated from commands/ directories)
-      commands = claudeCommands;
+      # Codex skills and agents: written as real files via activation script (not symlinks).
+      # codex-rs uses file_type().is_file() for discovery, which returns false for symlinks
+      # on Linux. home.file creates symlinks, so both are invisible without this workaround.
+      # Run this after sops-nix so Traya's BOND secret is available to the
+      # activation-time Codex writers.
+      activation.codexFiles = lib.mkIf config.programs.codex.enable (
+        lib.hm.dag.entryAfter [ "writeBoundary" "sops-nix" ] (
+          codexRootInstructionsActivationScript + codexSkillsActivationScript + codexAgentsActivationScript
+        )
+      );
     };
 
-    opencode = lib.mkIf config.programs.opencode.enable {
-      # Custom agents (auto-generated from agents/ directory)
-      agents = opencodeAgents;
+    programs = {
+      claude-code = lib.mkIf config.programs.claude-code.enable {
+        # Custom agents (auto-generated from agents/ directory)
+        agents = claudeAgents;
 
-      # Reusable commands (auto-generated from commands/ directories)
-      commands = opencodeCommands;
+        # Reusable commands (auto-generated from commands/ directories)
+        commands = claudeCommands;
+      };
 
-      # Global rules
-      rules = opencodeInstructions;
+      opencode = lib.mkIf config.programs.opencode.enable {
+        # Custom agents (auto-generated from agents/ directory)
+        agents = opencodeAgents;
+
+        # Reusable commands (auto-generated from commands/ directories)
+        commands = opencodeCommands;
+
+        # Global rules
+        rules = opencodeInstructions;
+      };
     };
   };
 }

--- a/home-manager/_mixins/agentic/mcp/README.md
+++ b/home-manager/_mixins/agentic/mcp/README.md
@@ -153,9 +153,12 @@ These three carry `enabled = false` at the top level. They stay declared so re-e
 
 `mcp/default.nix` consumes the renderer outputs and writes them to the correct path at activation time. Zed and OpenCode are wired here directly; Claude Code reads via Home Manager's native `programs.claude-code.mcpServers`; Codex's mixin imports `servers.nix` and reads `codexServers`.
 
+Pi Agent is installed by `../pi` with `pi-mcp-adapter` pinned in the Home Manager-owned `~/.pi/agent/settings.json`. The adapter reads `~/.config/mcp/mcp.json` automatically, so Pi consumes the shared generic MCP file rather than a Pi-specific copy of the server list. Pi-specific adapter settings live in the Home Manager-owned `~/.pi/agent/mcp.json`.
+
 | Platform | Config path | Source |
 |----------|-------------|--------|
 | Claude Code | `~/.config/mcp/mcp.json` | `claudeServers` |
+| Pi Agent | `~/.config/mcp/mcp.json` plus `~/.pi/agent/mcp.json` settings | `claudeServers` plus Pi adapter settings |
 | OpenCode | `~/.config/opencode/settings.json` `mcp` block | `opencodeServers` |
 | Zed | `~/.config/zed/settings.json` `context_servers` and `extensions` | `zedContextServers`, `zedExtensions` |
 | Codex | `~/.config/codex/config.toml` `[mcp_servers.*]` | `codexServers` |
@@ -163,6 +166,7 @@ These three carry `enabled = false` at the top level. They stay declared so re-e
 ### Platform-specific shapes
 
 - **Claude Code** — bearer auth becomes `headers.Authorization = "Bearer ${config.sops.placeholder.<envVar>}"`; the placeholder is interpolated at activation time from the decrypted sops file.
+- **Pi Agent** — `pi-mcp-adapter` reads the same generic `mcpServers` JSON as Claude Code. The Home Manager-owned Pi override file keeps `directTools`, `autoAuth`, and sampling disabled so the default surface is the adapter's single proxy tool.
 - **Codex** — schema strictness rejects unknown fields (`RawMcpServerConfig` uses `deny_unknown_fields`), so `codexServers` only emits keys Codex accepts: `url`, `bearer_token_env_var`, `command`, `args`, `env`, and `enabled`. Bearer auth becomes `bearer_token_env_var = "<envVar>"`. Every entry carries an `enabled` field (default `true`); flip `consumers.codex.enabled` to `false` to keep the entry visible to `codex mcp list` while skipping initialisation.
 - **OpenCode** — bearer auth becomes `headers.Authorization = "Bearer {env:<envVar>}"` (resolved at process start from the shell environment). Stdio `command` is rendered as a list (canonical `command` plus `args` concatenated).
 - **Zed** — HTTP servers are wrapped as `npx -y mcp-remote <url>` so Zed can launch them as local processes. Servers tagged `mode = "extension"` install via the marketplace and skip `context_servers` while enabled. Every emitted entry carries an `enabled` field (default `true`); flip `consumers.zed.enabled` to `false` to disable a server without removing it from the config. Extension-mode servers gain a stub `context_servers` entry (`{ enabled = false; settings = {}; }`) under the same name when disabled, which is how Zed's `Extension` settings variant is identified.

--- a/home-manager/_mixins/agentic/mcp/README.md
+++ b/home-manager/_mixins/agentic/mcp/README.md
@@ -25,6 +25,7 @@ The Nix composition is the delivery mechanism, not the strategy. Most servers he
 | `claudeServers` | Renderer for Claude Code's `mcpServers` and the generic JSON template |
 | `codexServers` | Renderer for Codex's `[mcp_servers.*]` TOML tables |
 | `opencodeServers` | Renderer for OpenCode's `mcp` settings block |
+| `piServers` | Renderer for Pi's `pi-mcp-adapter` server overrides with Pi-native `directTools` |
 | `zedContextServers` | Renderer for Zed's `context_servers` setting (stdio + HTTP) |
 | `zedExtensions` | Sorted list of Zed extension marketplace ids |
 | `zedExtensionDisables` | Stub `context_servers` entries that flip extension-mode servers off |
@@ -56,6 +57,7 @@ Each entry in `servers` carries the following fields. Only `transport` is mandat
 | `consumers.claudeCode.enabled` | bool | `true` | When `false`, the server is omitted from Claude Code output. |
 | `consumers.codex.enabled` | bool | `true` | Mirrors OpenCode. When `false`, the server is **still emitted** with `enabled = false` so `codex mcp list` continues to show it, but Codex skips initialising the server. |
 | `consumers.opencode.enabled` | bool | `true` | When `false`, the server is **still emitted** with `enabled = false` so the OpenCode TUI can toggle it at runtime. |
+| `consumers.pi.directTools` | bool or list of strings | follows `consumers.opencode.enabled` | Pi has no per-server `enabled` flag. `true` promotes all tools from that server into Pi's first-class tool list. `false` keeps the server proxy-only through the adapter's `mcp` tool. A list promotes only the named original MCP tools. |
 | `consumers.zed.enabled` | bool | `true` | Mirrors OpenCode. When `false`, the server is **still emitted** with `enabled = false` so Zed's agent panel can toggle it at runtime. Works for stdio, HTTP, and extension-mode servers. |
 | `consumers.zed.mode` | `"context_server"` \| `"extension"` \| `"skip"` | `"context_server"` | How Zed installs the server. `"extension"` requires `consumers.zed.id` to name the marketplace slug. `"skip"` excludes Zed entirely. |
 | `consumers.zed.id` | string | - | Required when `mode = "extension"`. |
@@ -131,7 +133,7 @@ Searches NixOS packages and options, Home Manager options, and nix-darwin option
 
 Playwright MCP gives agents browser automation for page inspection, navigation, screenshots, and interaction tests. It is configured as a local stdio server using Nixpkgs' `playwright-mcp` package only when browser automation is enabled.
 
-The shared browser automation policy requires both Chromium and Firefox. Servers that do not meet that policy omit Playwright entirely, so generated MCP config does not reference the `playwright-mcp` closure. Where emitted, Codex, OpenCode, and Zed keep the server visible but disabled by default through their per-server `enabled = false` settings. Claude Code receives the server through the shared `mcpServers` output because its renderer has no visible disabled state.
+The shared browser automation policy requires both Chromium and Firefox. Servers that do not meet that policy omit Playwright entirely, so generated MCP config does not reference the `playwright-mcp` closure. Where emitted, Codex, OpenCode, and Zed keep the server visible but disabled by default through their per-server `enabled = false` settings. Pi keeps it present but proxy-only with `directTools = false`, since Pi has no per-server `enabled` flag. Claude Code receives the server through the shared `mcpServers` output because its renderer has no visible disabled state.
 
 #### svelte
 
@@ -151,14 +153,14 @@ These three carry `enabled = false` at the top level. They stay declared so re-e
 
 ## Platform delivery
 
-`mcp/default.nix` consumes the renderer outputs and writes them to the correct path at activation time. Zed and OpenCode are wired here directly; Claude Code reads via Home Manager's native `programs.claude-code.mcpServers`; Codex's mixin imports `servers.nix` and reads `codexServers`.
+`mcp/default.nix` consumes the renderer outputs and writes them to the correct path at activation time. Zed and OpenCode are wired here directly; Claude Code reads via Home Manager's native `programs.claude-code.mcpServers`; Codex's mixin imports `servers.nix` and reads `codexServers`. Pi's mixin imports `servers.nix` and reads `piServers`.
 
-Pi Agent is installed by `../pi` with `pi-mcp-adapter` pinned in the Home Manager-owned `~/.pi/agent/settings.json`. The adapter reads `~/.config/mcp/mcp.json` automatically, so Pi consumes the shared generic MCP file rather than a Pi-specific copy of the server list. Pi-specific adapter settings live in the Home Manager-owned `~/.pi/agent/mcp.json`.
+Pi Agent is installed by `../pi` with `pi-mcp-adapter` pinned in the Home Manager-owned `~/.pi/agent/settings.json`. The adapter reads `~/.config/mcp/mcp.json` automatically, then shallow-merges Pi's Home Manager-owned `~/.pi/agent/mcp.json`. Because that merge is shallow by server name, `piServers` emits full server definitions with Pi-specific `directTools` values rather than partial overrides.
 
 | Platform | Config path | Source |
 |----------|-------------|--------|
 | Claude Code | `~/.config/mcp/mcp.json` | `claudeServers` |
-| Pi Agent | `~/.config/mcp/mcp.json` plus `~/.pi/agent/mcp.json` settings | `claudeServers` plus Pi adapter settings |
+| Pi Agent | `~/.config/mcp/mcp.json` plus `~/.pi/agent/mcp.json` settings and server overrides | `claudeServers` plus `piServers` |
 | OpenCode | `~/.config/opencode/settings.json` `mcp` block | `opencodeServers` |
 | Zed | `~/.config/zed/settings.json` `context_servers` and `extensions` | `zedContextServers`, `zedExtensions` |
 | Codex | `~/.config/codex/config.toml` `[mcp_servers.*]` | `codexServers` |
@@ -166,7 +168,7 @@ Pi Agent is installed by `../pi` with `pi-mcp-adapter` pinned in the Home Manage
 ### Platform-specific shapes
 
 - **Claude Code** — bearer auth becomes `headers.Authorization = "Bearer ${config.sops.placeholder.<envVar>}"`; the placeholder is interpolated at activation time from the decrypted sops file.
-- **Pi Agent** — `pi-mcp-adapter` reads the same generic `mcpServers` JSON as Claude Code. The Home Manager-owned Pi override file keeps `directTools`, `autoAuth`, and sampling disabled so the default surface is the adapter's single proxy tool.
+- **Pi Agent** — `pi-mcp-adapter` has no per-server `enabled` field. Server presence means Pi can use the server, and servers connect lazily when used. Global adapter settings keep the proxy tool enabled and default `directTools`, `autoAuth`, and sampling disabled. Per-server `directTools` follows OpenCode's enabled-by-default preference: context7, exa, and nixos are promoted to direct tools; cloudflare, svelte, and Playwright remain proxy-only when present. Globally disabled servers are omitted. Playwright is still omitted entirely unless the shared browser automation policy enables both Chromium and Firefox.
 - **Codex** — schema strictness rejects unknown fields (`RawMcpServerConfig` uses `deny_unknown_fields`), so `codexServers` only emits keys Codex accepts: `url`, `bearer_token_env_var`, `command`, `args`, `env`, and `enabled`. Bearer auth becomes `bearer_token_env_var = "<envVar>"`. Every entry carries an `enabled` field (default `true`); flip `consumers.codex.enabled` to `false` to keep the entry visible to `codex mcp list` while skipping initialisation.
 - **OpenCode** — bearer auth becomes `headers.Authorization = "Bearer {env:<envVar>}"` (resolved at process start from the shell environment). Stdio `command` is rendered as a list (canonical `command` plus `args` concatenated).
 - **Zed** — HTTP servers are wrapped as `npx -y mcp-remote <url>` so Zed can launch them as local processes. Servers tagged `mode = "extension"` install via the marketplace and skip `context_servers` while enabled. Every emitted entry carries an `enabled` field (default `true`); flip `consumers.zed.enabled` to `false` to disable a server without removing it from the config. Extension-mode servers gain a stub `context_servers` entry (`{ enabled = false; settings = {}; }`) under the same name when disabled, which is how Zed's `Extension` settings variant is identified.

--- a/home-manager/_mixins/agentic/mcp/default.nix
+++ b/home-manager/_mixins/agentic/mcp/default.nix
@@ -115,7 +115,7 @@ in
     secrets = lib.genAttrs allSecrets (_: {
       sopsFile = mcpSopsFile;
     });
-    # MCP servers - used by other agents
+    # Shared MCP servers used by Claude Code, Pi Agent, and generic clients.
     templates."mcp-config.json" = {
       content = builtins.toJSON { mcpServers = mcpServerDefs.claudeServers; };
       path = "${config.xdg.configHome}/mcp/mcp.json";

--- a/home-manager/_mixins/agentic/mcp/servers.nix
+++ b/home-manager/_mixins/agentic/mcp/servers.nix
@@ -47,6 +47,13 @@ rec {
   #                                     `codex mcp list` still sees it but
   #                                     Codex skips initialising the server.
   #                  opencode.enabled   (default true)
+  #                  pi.directTools     bool | list of strings, default follows
+  #                                     `consumers.opencode.enabled`: `true`
+  #                                     promotes the server's tools into Pi's
+  #                                     first-class tool list, `false` leaves
+  #                                     the server proxy-only through Pi's
+  #                                     single `mcp` tool, and a list promotes
+  #                                     only the named original MCP tools.
   #                  zed.enabled        (default true) - mirrors OpenCode:
   #                                     `false` keeps the entry visible in
   #                                     Zed's agent panel with `enabled = false`
@@ -353,6 +360,55 @@ rec {
           }
           // lib.optionalAttrs ((s.env or { }) != { }) {
             environment = lib.mapAttrs (_: secretName: "{env:${secretName}}") s.env;
+          };
+    in
+    lib.mapAttrs render (lib.filterAttrs keep servers);
+
+  # piServers: Pi adapter server entries for `~/.pi/agent/mcp.json`.
+  # `pi-mcp-adapter` has no per-server `enabled` field: server presence means
+  # Pi can use it, and servers connect lazily when a tool call needs them.
+  #
+  # The adapter shallow-merges MCP config files by server name. Entries here
+  # therefore include the complete server definition, not only Pi-specific
+  # overrides, otherwise adding `directTools` would replace the shared entry
+  # and drop command, args, URL, or auth data.
+  #
+  # Pi's direct-tool preference follows OpenCode's enabled-by-default state:
+  # OpenCode-enabled servers get `directTools = true`, while OpenCode-disabled
+  # servers remain present but proxy-only with `directTools = false`. A future
+  # `consumers.pi.directTools = [ ... ]` override can promote only selected
+  # original MCP tool names where Pi needs a narrower direct surface.
+  piServers =
+    let
+      keep = _: s: s.enabled or true;
+      directToolsFor = s: s.consumers.pi.directTools or (s.consumers.opencode.enabled or true);
+      render =
+        _: s:
+        let
+          common = {
+            directTools = directToolsFor s;
+          };
+        in
+        if s.transport == "http" then
+          {
+            type = "http";
+            inherit (s) url;
+          }
+          // common
+          // lib.optionalAttrs (s.auth or null != null && s.auth.kind == "bearer") {
+            headers = {
+              Authorization = "Bearer ${config.sops.placeholder.${s.auth.envVar}}";
+            };
+          }
+        else
+          {
+            type = "stdio";
+            inherit (s) command;
+            args = s.args or [ ];
+          }
+          // common
+          // lib.optionalAttrs ((s.env or { }) != { }) {
+            env = lib.mapAttrs (_: secretName: config.sops.placeholder.${secretName}) s.env;
           };
     in
     lib.mapAttrs render (lib.filterAttrs keep servers);

--- a/home-manager/_mixins/agentic/pi/README.md
+++ b/home-manager/_mixins/agentic/pi/README.md
@@ -9,7 +9,7 @@ The upstream package comes from `inputs.llm-agents.packages.${system}.pi`, match
 - Adds a `pi` wrapper to `home.packages`
 - Gates installation with `noughtyLib.userHasTag "developer"`
 - Exports `ANTHROPIC_API_KEY` from the sops-nix runtime secret path before execing the Nix-provided Pi binary
-- Adds a `pi-npm` wrapper backed by Nixpkgs `nodejs`, with npm's global prefix redirected to `~/.pi/agent/npm-global`
+- Adds a `pi-npm` wrapper backed by Nixpkgs `nodejs`, with npm's global prefix redirected to `~/.pi/agent/npm-global` and routine npm advisory output disabled
 - Owns Pi config and resource files through Home Manager:
   - `~/.pi/agent/settings.json`
   - `~/.pi/agent/mcp.json`

--- a/home-manager/_mixins/agentic/pi/README.md
+++ b/home-manager/_mixins/agentic/pi/README.md
@@ -1,0 +1,47 @@
+# Pi Agent module
+
+Installs [Pi Agent](https://github.com/badlogic/pi-mono), the `pi` coding-agent CLI, for developer-tagged Home Manager users.
+
+The package comes from `inputs.llm-agents.packages.${system}.pi`, matching the other coding-agent packages sourced from `numtide/llm-agents.nix`.
+
+## Behaviour
+
+- Adds `pi` to `home.packages`
+- Gates installation with `noughtyLib.userHasTag "developer"`
+- Adds a `pi-npm` wrapper backed by Nixpkgs `nodejs`, with npm's global prefix redirected to `~/.pi/agent/npm-global`
+- Owns Pi config files through Home Manager `home.file`:
+  - `~/.pi/agent/settings.json`
+  - `~/.pi/agent/mcp.json`
+- Does not enable services
+- Does not add secrets or token material
+- Does not run `pi install` during activation
+
+The `llm-agents` package wrapper disables Pi's version check and telemetry at runtime.
+
+## MCP
+
+Pi MCP support is provided by [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter), installed through Pi's pinned package setting:
+
+```json
+{
+  "packages": ["npm:pi-mcp-adapter@2.5.4"]
+}
+```
+
+Pi installs the package into the user-owned npm prefix on first startup if it is missing. The versioned package spec is skipped by `pi update`, so updates stay explicit.
+
+Home Manager owns `~/.pi/agent/settings.json` completely. Project-specific or mutable package settings should live outside this file.
+
+The adapter reads the shared MCP config at `~/.config/mcp/mcp.json` automatically. That file is still rendered by `../mcp` from `mcp/servers.nix`, so Pi uses the same canonical server definitions as Claude Code and other generic MCP clients.
+
+`~/.pi/agent/mcp.json` is Pi-specific and only carries adapter settings:
+
+- `directTools = false`
+- `disableProxyTool = false`
+- `autoAuth = false`
+- `sampling = false`
+- `samplingAutoApprove = false`
+
+That keeps the default surface to the adapter's single `mcp` proxy tool and prevents MCP servers from sampling through Pi. Home Manager owns the user-level `~/.pi/agent/mcp.json`; project-level `.pi/mcp.json` files can override these settings deliberately.
+
+Upstream limitation: Pi package settings support npm, git, and local path package sources. The adapter's npm package needs runtime dependencies, so this module declares the pinned npm package source and leaves the first install to Pi's package manager rather than copying an incomplete Nix store path into Pi's package list.

--- a/home-manager/_mixins/agentic/pi/README.md
+++ b/home-manager/_mixins/agentic/pi/README.md
@@ -2,21 +2,68 @@
 
 Installs [Pi Agent](https://github.com/badlogic/pi-mono), the `pi` coding-agent CLI, for developer-tagged Home Manager users.
 
-The package comes from `inputs.llm-agents.packages.${system}.pi`, matching the other coding-agent packages sourced from `numtide/llm-agents.nix`.
+The upstream package comes from `inputs.llm-agents.packages.${system}.pi`, matching the other coding-agent packages sourced from `numtide/llm-agents.nix`.
 
 ## Behaviour
 
-- Adds `pi` to `home.packages`
+- Adds a `pi` wrapper to `home.packages`
 - Gates installation with `noughtyLib.userHasTag "developer"`
+- Exports `ANTHROPIC_API_KEY` from the sops-nix runtime secret path before execing the Nix-provided Pi binary
 - Adds a `pi-npm` wrapper backed by Nixpkgs `nodejs`, with npm's global prefix redirected to `~/.pi/agent/npm-global`
-- Owns Pi config files through Home Manager `home.file`:
+- Owns Pi config and resource files through Home Manager:
   - `~/.pi/agent/settings.json`
   - `~/.pi/agent/mcp.json`
+  - `~/.pi/agent/extensions/subagent/config.json`
+  - `~/.pi/agent/AGENTS.md`
+  - `~/.pi/agent/agents/*.md`
+  - `~/.pi/agent/prompts/*.md`
+  - `~/.pi/agent/skills/*/SKILL.md`
+  - `~/.pi/agent/themes/catppuccin-mocha.json`
 - Does not enable services
-- Does not add secrets or token material
+- Does not write literal token material into the Nix store
 - Does not run `pi install` during activation
 
-The `llm-agents` package wrapper disables Pi's version check and telemetry at runtime.
+The `llm-agents` package wrapper disables Pi's version check and telemetry at runtime. Pi's own install telemetry is also disabled in `settings.json`.
+
+## Native settings
+
+Home Manager owns `~/.pi/agent/settings.json` completely. Project-specific or mutable package settings should live in `.pi/settings.json`, which Pi merges over the global settings. Nested objects merge.
+
+The managed settings use Anthropic by default:
+
+```json
+{
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-opus-4-7",
+  "defaultThinkingLevel": "high",
+  "hideThinkingBlock": true,
+  "enabledModels": [
+    "anthropic/claude-opus-4-7",
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-haiku-4-5"
+  ],
+  "theme": "catppuccin-mocha",
+  "themes": [
+    "themes/*.json"
+  ]
+}
+```
+
+Compaction and retry are enabled with conservative defaults. `enableSkillCommands` is enabled so shared skills are invocable as `/skill:<name>`.
+
+## Theme
+
+Pi supports JSON themes loaded from `~/.pi/agent/themes/*.json`, package theme directories, or the `themes` setting.
+
+This module writes `~/.pi/agent/themes/catppuccin-mocha.json` from the repository's `catppuccinPalette` and sets Pi's default theme to `catppuccin-mocha`. No third-party theme package is installed.
+
+## Authentication
+
+`secrets/ai.yaml` provides `ANTHROPIC_API_KEY`.
+
+The `pi` wrapper reads `config.sops.secrets.ANTHROPIC_API_KEY.path` at runtime and exports the key only for the Pi process. The managed `settings.json` and all managed Pi resource files contain no literal secret values.
+
+This module does not manage `~/.pi/agent/auth.json`. Pi can still create that file through `/login` for subscription providers or manually entered API keys.
 
 ## MCP
 
@@ -24,15 +71,13 @@ Pi MCP support is provided by [pi-mcp-adapter](https://github.com/nicobailon/pi-
 
 ```json
 {
-  "packages": ["npm:pi-mcp-adapter@2.5.4"]
+  "packages": [
+    "npm:pi-mcp-adapter@2.5.4"
+  ]
 }
 ```
 
-Pi installs the package into the user-owned npm prefix on first startup if it is missing. The versioned package spec is skipped by `pi update`, so updates stay explicit.
-
-Home Manager owns `~/.pi/agent/settings.json` completely. Project-specific or mutable package settings should live outside this file.
-
-The adapter reads the shared MCP config at `~/.config/mcp/mcp.json` automatically. That file is still rendered by `../mcp` from `mcp/servers.nix`, so Pi uses the same canonical server definitions as Claude Code and other generic MCP clients.
+The adapter reads the shared MCP config at `~/.config/mcp/mcp.json` automatically. That file is rendered by `../mcp` from `mcp/servers.nix`, so Pi uses the same canonical server definitions as Claude Code and other generic MCP clients.
 
 `~/.pi/agent/mcp.json` is Pi-specific and only carries adapter settings:
 
@@ -42,6 +87,58 @@ The adapter reads the shared MCP config at `~/.config/mcp/mcp.json` automaticall
 - `sampling = false`
 - `samplingAutoApprove = false`
 
-That keeps the default surface to the adapter's single `mcp` proxy tool and prevents MCP servers from sampling through Pi. Home Manager owns the user-level `~/.pi/agent/mcp.json`; project-level `.pi/mcp.json` files can override these settings deliberately.
+That keeps the default surface to the adapter's single `mcp` proxy tool and prevents MCP servers from sampling through Pi. Project-level `.pi/mcp.json` files can override these settings deliberately.
 
-Upstream limitation: Pi package settings support npm, git, and local path package sources. The adapter's npm package needs runtime dependencies, so this module declares the pinned npm package source and leaves the first install to Pi's package manager rather than copying an incomplete Nix store path into Pi's package list.
+The Playwright MCP server remains gated by the shared MCP module. It appears only where browser automation is enabled, so server hosts such as `malak` do not receive it.
+
+## Subagents
+
+[`pi-subagents`](https://github.com/nicobailon/pi-subagents) is installed through Pi's pinned package setting:
+
+```json
+{
+  "packages": [
+    "npm:pi-subagents@0.24.0"
+  ]
+}
+```
+
+The extension config is managed at `~/.pi/agent/extensions/subagent/config.json`:
+
+```json
+{
+  "asyncByDefault": false,
+  "forceTopLevelAsync": false,
+  "parallel": {
+    "maxTasks": 4,
+    "concurrency": 2
+  },
+  "defaultSessionDir": "~/.pi/agent/sessions/subagent",
+  "maxSubagentDepth": 1,
+  "intercomBridge": {
+    "mode": "off"
+  }
+}
+```
+
+`maxSubagentDepth = 1` allows explicit direct subagent use and blocks nested subagent chains by default. Each generated assistant agent also sets `maxSubagentDepth: 0`, so child sessions cannot delegate further.
+
+The builtin `researcher` agent is disabled by default because it requires `pi-web-access`, which this module does not install.
+
+## Assistant mapping
+
+Source content comes from `home-manager/_mixins/agentic/assistants`. Rendering for Pi lives in `home-manager/_mixins/agentic/assistants/default.nix`; this module consumes the generated Home Manager file entries.
+
+| Source | Pi destination | Mapping |
+|--------|----------------|---------|
+| `instructions/global.md` | `~/.pi/agent/AGENTS.md` | Global context file loaded by Pi |
+| `agents/<name>/prompt.md` and `description.txt` | `~/.pi/agent/agents/<name>.md` | Pi subagent Markdown with YAML frontmatter |
+| `agents/<name>/commands/<command>/prompt.md` | `~/.pi/agent/prompts/<name>-<command>.md` | Prompt template that asks Pi to call the matching subagent |
+| `commands/<command>/prompt.md` | `~/.pi/agent/prompts/<command>.md` | Native Pi prompt template |
+| `skills/<name>/` | `~/.pi/agent/skills/<name>/` | Symlinked Agent Skills directory |
+
+Traya is written during Home Manager activation rather than through `home.file`, because her prompt appends the sops-backed bond text outside the Nix store. Other agents and prompts contain no secrets and are rendered declaratively.
+
+Pi agent frontmatter uses `name`, `description`, `systemPromptMode: append`, `inheritProjectContext: true`, `inheritSkills: true`, and `maxSubagentDepth: 0`. Prompt templates carry `description` and reuse Claude's `argument-hint` field where present, because Pi supports the same prompt-template field.
+
+OpenCode-specific permission headers are not mapped. Pi subagent Markdown supports tool allowlists, but OpenCode's allow/deny permission policy does not translate cleanly into Pi's explicit `tools` allowlist.

--- a/home-manager/_mixins/agentic/pi/README.md
+++ b/home-manager/_mixins/agentic/pi/README.md
@@ -69,6 +69,32 @@ Anthropic can return `overloaded_error` during provider-side capacity pressure. 
 
 `enableSkillCommands` is enabled so shared skills are invocable as `/skill:<name>`.
 
+## Pinned packages
+
+Pi packages are installed through the Home Manager-owned package setting:
+
+```json
+{
+  "packages": [
+    "npm:pi-mcp-adapter@2.5.4",
+    "npm:pi-subagents@0.24.0",
+    "npm:@juicesharp/rpiv-args@1.1.5",
+    "npm:@juicesharp/rpiv-btw@1.1.5",
+    "npm:@juicesharp/rpiv-todo@1.1.5"
+  ]
+}
+```
+
+Versioned Pi package specs are pinned and skipped by `pi update`. These packages are user-level JavaScript extensions installed by Pi's npm integration under the user-owned npm prefix.
+
+The `juicesharp/rpiv-mono` extensions add native Pi behaviour:
+
+- `rpiv-args` adds skill argument placeholders
+- `rpiv-btw` performs an explicit side model call using current conversation context
+- `rpiv-todo` adds a model-visible todo tool and `/todos` UI
+
+`@juicesharp/rpiv-i18n` is not installed.
+
 ## Theme
 
 Pi supports JSON themes loaded from `~/.pi/agent/themes/*.json`, package theme directories, or the `themes` setting.
@@ -85,15 +111,7 @@ This module does not manage `~/.pi/agent/auth.json`. Pi can still create that fi
 
 ## MCP
 
-Pi MCP support is provided by [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter), installed through Pi's pinned package setting:
-
-```json
-{
-  "packages": [
-    "npm:pi-mcp-adapter@2.5.4"
-  ]
-}
-```
+Pi MCP support is provided by [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter), installed through the pinned package setting.
 
 The adapter reads the shared MCP config at `~/.config/mcp/mcp.json` automatically. That file is rendered by `../mcp` from `mcp/servers.nix`, so Pi uses the same canonical server definitions as Claude Code and other generic MCP clients.
 
@@ -126,15 +144,7 @@ The Playwright MCP server remains gated by the shared MCP module. It appears onl
 
 ## Subagents
 
-[`pi-subagents`](https://github.com/nicobailon/pi-subagents) is installed through Pi's pinned package setting:
-
-```json
-{
-  "packages": [
-    "npm:pi-subagents@0.24.0"
-  ]
-}
-```
+[`pi-subagents`](https://github.com/nicobailon/pi-subagents) is installed through the pinned package setting.
 
 The extension config is managed at `~/.pi/agent/extensions/subagent/config.json`:
 

--- a/home-manager/_mixins/agentic/pi/README.md
+++ b/home-manager/_mixins/agentic/pi/README.md
@@ -97,7 +97,7 @@ Pi MCP support is provided by [pi-mcp-adapter](https://github.com/nicobailon/pi-
 
 The adapter reads the shared MCP config at `~/.config/mcp/mcp.json` automatically. That file is rendered by `../mcp` from `mcp/servers.nix`, so Pi uses the same canonical server definitions as Claude Code and other generic MCP clients.
 
-`~/.pi/agent/mcp.json` is Pi-specific and only carries adapter settings:
+`~/.pi/agent/mcp.json` is Pi-specific and is rendered through sops-nix because the full Context7 server entry includes an auth header. It carries conservative global adapter settings:
 
 - `directTools = false`
 - `disableProxyTool = false`
@@ -105,7 +105,22 @@ The adapter reads the shared MCP config at `~/.config/mcp/mcp.json` automaticall
 - `sampling = false`
 - `samplingAutoApprove = false`
 
-That keeps the default surface to the adapter's single `mcp` proxy tool and prevents MCP servers from sampling through Pi. Project-level `.pi/mcp.json` files can override these settings deliberately.
+That keeps the adapter's proxy tool enabled, disables direct tools by default, and prevents MCP servers from sampling through Pi. Project-level `.pi/mcp.json` files can override these settings deliberately.
+
+Pi's adapter does not support a per-server `enabled` flag. Server presence in `mcpServers` means Pi can use it, and servers connect lazily when a tool call needs them.
+
+Pi follows OpenCode's enabled-by-default MCP preference through `directTools`:
+
+| Server | Pi default |
+|--------|------------|
+| `context7` | Direct tools promoted |
+| `exa` | Direct tools promoted |
+| `nixos` | Direct tools promoted |
+| `cloudflare` | Present, proxy-only |
+| `svelte` | Present, proxy-only |
+| `playwright` | Present only on browser automation hosts, proxy-only when present |
+
+The Pi-specific file emits full server entries, not partial overrides, because `pi-mcp-adapter` shallow-merges MCP config files by server name. A partial entry that only set `directTools` would replace the shared command, args, URL, or auth fields.
 
 The Playwright MCP server remains gated by the shared MCP module. It appears only where browser automation is enabled, so server hosts such as `malak` do not receive it.
 

--- a/home-manager/_mixins/agentic/pi/README.md
+++ b/home-manager/_mixins/agentic/pi/README.md
@@ -49,7 +49,25 @@ The managed settings use Anthropic by default:
 }
 ```
 
-Compaction and retry are enabled with conservative defaults. `enableSkillCommands` is enabled so shared skills are invocable as `/skill:<name>`.
+Compaction and retry are enabled. Retry settings favour longer backoff for transient provider overloads:
+
+```json
+{
+  "retry": {
+    "enabled": true,
+    "maxRetries": 5,
+    "baseDelayMs": 3000,
+    "provider": {
+      "maxRetries": 3,
+      "maxRetryDelayMs": 120000
+    }
+  }
+}
+```
+
+Anthropic can return `overloaded_error` during provider-side capacity pressure. These settings give Pi more time to recover before the error reaches chat. Pi still displays provider errors after retries are exhausted, and the failed request remains recorded in the session logs.
+
+`enableSkillCommands` is enabled so shared skills are invocable as `/skill:<name>`.
 
 ## Theme
 

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  inputs,
+  lib,
+  noughtyLib,
+  pkgs,
+  ...
+}:
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+  piPackage = inputs.llm-agents.packages.${system}.pi;
+  piMcpAdapterVersion = "2.5.4";
+  piMcpAdapterSource = "npm:pi-mcp-adapter@${piMcpAdapterVersion}";
+
+  # Pi's npm package installer uses global npm operations. Nix's default npm
+  # global prefix is the read-only store, so give Pi a user-owned prefix while
+  # keeping the npm binary itself from Nixpkgs.
+  piNpmPackage = pkgs.writeShellApplication {
+    name = "pi-npm";
+    runtimeInputs = [ pkgs.nodejs ];
+    text = ''
+      export NPM_CONFIG_PREFIX="${config.home.homeDirectory}/.pi/agent/npm-global"
+      exec npm "$@"
+    '';
+  };
+
+  piSettings = {
+    # Versioned Pi package specs are pinned and skipped by `pi update`.
+    packages = [ piMcpAdapterSource ];
+    npmCommand = [ "${piNpmPackage}/bin/pi-npm" ];
+  };
+
+  piMcpConfig = {
+    settings = {
+      # Keep Pi's MCP surface to the adapter proxy tool. Project-level
+      # `.pi/mcp.json` can override these settings when a project needs a
+      # deliberately wider tool surface.
+      directTools = false;
+      disableProxyTool = false;
+      autoAuth = false;
+      sampling = false;
+      samplingAutoApprove = false;
+    };
+    # The adapter reads the shared server definitions from
+    # `~/.config/mcp/mcp.json`; this Home Manager-owned file only carries
+    # Pi-specific adapter settings.
+    mcpServers = { };
+  };
+in
+lib.mkIf (noughtyLib.userHasTag "developer") {
+  home = {
+    packages = [
+      piPackage
+      piNpmPackage
+    ];
+    file = {
+      ".pi/agent/settings.json".text = builtins.toJSON piSettings;
+      ".pi/agent/mcp.json".text = builtins.toJSON piMcpConfig;
+    };
+  };
+}

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -127,13 +127,18 @@ let
 
   # Pi's npm package installer uses global npm operations. Nix's default npm
   # global prefix is the read-only store, so give Pi a user-owned prefix while
-  # keeping the npm binary itself from Nixpkgs.
+  # keeping the npm binary itself from Nixpkgs. Keep routine npm advisory
+  # chatter quiet while preserving npm errors and exit status.
   piNpmPackage = pkgs.writeShellApplication {
     name = "pi-npm";
     runtimeInputs = [ pkgs.nodejs ];
     text = ''
       export NPM_CONFIG_PREFIX="${config.home.homeDirectory}/.pi/agent/npm-global"
-      exec npm "$@"
+      export NPM_CONFIG_AUDIT=false
+      export NPM_CONFIG_FUND=false
+      export NPM_CONFIG_LOGLEVEL=error
+
+      exec npm --loglevel=error --no-audit --no-fund "$@"
     '';
   };
 

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -183,7 +183,12 @@ let
     };
     retry = {
       enabled = true;
-      maxRetries = 2;
+      maxRetries = 5;
+      baseDelayMs = 3000;
+      provider = {
+        maxRetries = 3;
+        maxRetryDelayMs = 120000;
+      };
     };
     markdown.codeBlockIndent = " ";
     warnings.anthropicExtraUsage = true;

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -1,4 +1,5 @@
 {
+  catppuccinPalette,
   config,
   inputs,
   lib,
@@ -8,9 +9,114 @@
 }:
 let
   inherit (pkgs.stdenv.hostPlatform) system;
+  aiSopsFile = ../../../../secrets/ai.yaml;
   piPackage = inputs.llm-agents.packages.${system}.pi;
   piMcpAdapterVersion = "2.5.4";
+  piSubagentsVersion = "0.24.0";
   piMcpAdapterSource = "npm:pi-mcp-adapter@${piMcpAdapterVersion}";
+  piSubagentsSource = "npm:pi-subagents@${piSubagentsVersion}";
+  piAssistant = config.agentic.assistants.pi;
+  piThemeName = "catppuccin-${catppuccinPalette.flavor}";
+  piCatppuccinTheme =
+    let
+      getColor = colorName: catppuccinPalette.getColor colorName;
+    in
+    {
+      "$schema" =
+        "https://raw.githubusercontent.com/badlogic/pi-mono/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json";
+      name = piThemeName;
+      vars = lib.genAttrs [
+        "rosewater"
+        "flamingo"
+        "pink"
+        "mauve"
+        "red"
+        "maroon"
+        "peach"
+        "yellow"
+        "green"
+        "teal"
+        "sky"
+        "sapphire"
+        "blue"
+        "lavender"
+        "text"
+        "subtext1"
+        "subtext0"
+        "overlay2"
+        "overlay1"
+        "overlay0"
+        "surface2"
+        "surface1"
+        "surface0"
+        "base"
+        "mantle"
+        "crust"
+      ] getColor;
+      colors = {
+        accent = catppuccinPalette.accent;
+        border = "surface2";
+        borderAccent = "blue";
+        borderMuted = "surface0";
+        success = "green";
+        error = "red";
+        warning = "yellow";
+        muted = "subtext0";
+        dim = "overlay0";
+        text = "text";
+        thinkingText = "overlay2";
+
+        selectedBg = "surface0";
+        userMessageBg = "mantle";
+        userMessageText = "text";
+        customMessageBg = "surface0";
+        customMessageText = "text";
+        customMessageLabel = "mauve";
+        toolPendingBg = "mantle";
+        toolSuccessBg = "surface0";
+        toolErrorBg = "surface0";
+        toolTitle = "sapphire";
+        toolOutput = "subtext1";
+
+        mdHeading = "mauve";
+        mdLink = "blue";
+        mdLinkUrl = "sapphire";
+        mdCode = "teal";
+        mdCodeBlock = "text";
+        mdCodeBlockBorder = "surface1";
+        mdQuote = "subtext0";
+        mdQuoteBorder = "surface1";
+        mdHr = "surface1";
+        mdListBullet = "peach";
+
+        toolDiffAdded = "green";
+        toolDiffRemoved = "red";
+        toolDiffContext = "overlay1";
+
+        syntaxComment = "overlay1";
+        syntaxKeyword = "mauve";
+        syntaxFunction = "blue";
+        syntaxVariable = "text";
+        syntaxString = "green";
+        syntaxNumber = "peach";
+        syntaxType = "yellow";
+        syntaxOperator = "sky";
+        syntaxPunctuation = "overlay2";
+
+        thinkingOff = "surface1";
+        thinkingMinimal = "overlay0";
+        thinkingLow = "sapphire";
+        thinkingMedium = "blue";
+        thinkingHigh = "mauve";
+        thinkingXhigh = "pink";
+        bashMode = "peach";
+      };
+      export = {
+        pageBg = "base";
+        cardBg = "mantle";
+        infoBg = "surface0";
+      };
+    };
 
   # Pi's npm package installer uses global npm operations. Nix's default npm
   # global prefix is the read-only store, so give Pi a user-owned prefix while
@@ -24,10 +130,90 @@ let
     '';
   };
 
+  piWrapperPackage = pkgs.writeShellApplication {
+    name = "pi";
+    runtimeInputs = [
+      piPackage
+      pkgs.coreutils
+    ];
+    text = ''
+      anthropic_api_key_path="${config.sops.secrets.ANTHROPIC_API_KEY.path}"
+      if [ ! -r "$anthropic_api_key_path" ]; then
+        echo "pi: Anthropic API key secret is missing or unreadable: $anthropic_api_key_path" >&2
+        exit 1
+      fi
+
+      ANTHROPIC_API_KEY="$(cat "$anthropic_api_key_path")"
+      export ANTHROPIC_API_KEY
+
+      exec "${lib.getExe piPackage}" "$@"
+    '';
+  };
+
   piSettings = {
+    defaultProvider = "anthropic";
+    defaultModel = "claude-opus-4-7";
+    defaultThinkingLevel = "high";
+    thinkingBudgets = {
+      minimal = 1024;
+      low = 4096;
+      medium = 10240;
+      high = 32768;
+      xhigh = 64000;
+    };
+    hideThinkingBlock = true;
+    enabledModels = [
+      "anthropic/claude-opus-4-7"
+      "anthropic/claude-sonnet-4-6"
+      "anthropic/claude-haiku-4-5"
+    ];
+
+    theme = piThemeName;
+    quietStartup = true;
+    collapseChangelog = true;
+    enableInstallTelemetry = false;
+    doubleEscapeAction = "tree";
+    treeFilterMode = "default";
+    autocompleteMaxVisible = 8;
+
+    compaction = {
+      enabled = true;
+      reserveTokens = 16384;
+      keepRecentTokens = 20000;
+    };
+    retry = {
+      enabled = true;
+      maxRetries = 2;
+    };
+    markdown.codeBlockIndent = " ";
+    warnings.anthropicExtraUsage = true;
+
     # Versioned Pi package specs are pinned and skipped by `pi update`.
-    packages = [ piMcpAdapterSource ];
+    packages = [
+      piMcpAdapterSource
+      piSubagentsSource
+    ];
+    extensions = [ ];
+    skills = [
+      "skills"
+    ];
+    prompts = [
+      "prompts/*.md"
+    ];
+    themes = [
+      "themes/*.json"
+    ];
+    enableSkillCommands = true;
     npmCommand = [ "${piNpmPackage}/bin/pi-npm" ];
+
+    subagents = {
+      disableBuiltins = false;
+      agentOverrides = {
+        # This builtin requires pi-web-access, which is not installed in this
+        # pass. Keep it visible in /agents but disabled by default.
+        researcher.disabled = true;
+      };
+    };
   };
 
   piMcpConfig = {
@@ -46,16 +232,40 @@ let
     # Pi-specific adapter settings.
     mcpServers = { };
   };
+
+  piSubagentsConfig = {
+    asyncByDefault = false;
+    forceTopLevelAsync = false;
+    parallel = {
+      maxTasks = 4;
+      concurrency = 2;
+    };
+    defaultSessionDir = "~/.pi/agent/sessions/subagent";
+    maxSubagentDepth = 1;
+    intercomBridge.mode = "off";
+  };
 in
 lib.mkIf (noughtyLib.userHasTag "developer") {
+  sops.secrets.ANTHROPIC_API_KEY = {
+    sopsFile = aiSopsFile;
+    mode = "0400";
+  };
+
   home = {
     packages = [
-      piPackage
+      piWrapperPackage
       piNpmPackage
     ];
     file = {
       ".pi/agent/settings.json".text = builtins.toJSON piSettings;
       ".pi/agent/mcp.json".text = builtins.toJSON piMcpConfig;
-    };
+      ".pi/agent/extensions/subagent/config.json".text = builtins.toJSON piSubagentsConfig;
+      ".pi/agent/themes/${piThemeName}.json".text = builtins.toJSON piCatppuccinTheme;
+    }
+    // piAssistant.homeFiles;
+
+    activation.piTrayaAgent = lib.hm.dag.entryAfter [ "writeBoundary" "sops-nix" ] ''
+      ${piAssistant.trayaActivation}
+    '';
   };
 }

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -13,8 +13,14 @@ let
   piPackage = inputs.llm-agents.packages.${system}.pi;
   piMcpAdapterVersion = "2.5.4";
   piSubagentsVersion = "0.24.0";
+  rpivArgsVersion = "1.1.5";
+  rpivBtwVersion = "1.1.5";
+  rpivTodoVersion = "1.1.5";
   piMcpAdapterSource = "npm:pi-mcp-adapter@${piMcpAdapterVersion}";
   piSubagentsSource = "npm:pi-subagents@${piSubagentsVersion}";
+  rpivArgsSource = "npm:@juicesharp/rpiv-args@${rpivArgsVersion}";
+  rpivBtwSource = "npm:@juicesharp/rpiv-btw@${rpivBtwVersion}";
+  rpivTodoSource = "npm:@juicesharp/rpiv-todo@${rpivTodoVersion}";
   piAssistant = config.agentic.assistants.pi;
   mcpServerDefs = import ../mcp/servers.nix { inherit config pkgs; };
   piThemeName = "catppuccin-${catppuccinPalette.flavor}";
@@ -198,6 +204,9 @@ let
     packages = [
       piMcpAdapterSource
       piSubagentsSource
+      rpivArgsSource
+      rpivBtwSource
+      rpivTodoSource
     ];
     extensions = [ ];
     skills = [

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -16,6 +16,7 @@ let
   piMcpAdapterSource = "npm:pi-mcp-adapter@${piMcpAdapterVersion}";
   piSubagentsSource = "npm:pi-subagents@${piSubagentsVersion}";
   piAssistant = config.agentic.assistants.pi;
+  mcpServerDefs = import ../mcp/servers.nix { inherit config pkgs; };
   piThemeName = "catppuccin-${catppuccinPalette.flavor}";
   piCatppuccinTheme =
     let
@@ -232,10 +233,10 @@ let
       sampling = false;
       samplingAutoApprove = false;
     };
-    # The adapter reads the shared server definitions from
-    # `~/.config/mcp/mcp.json`; this Home Manager-owned file only carries
-    # Pi-specific adapter settings.
-    mcpServers = { };
+    # The adapter shallow-merges files by server name, so Pi-specific
+    # `directTools` preferences must include full server entries rather than
+    # partial overrides.
+    mcpServers = mcpServerDefs.piServers;
   };
 
   piSubagentsConfig = {
@@ -256,6 +257,12 @@ lib.mkIf (noughtyLib.userHasTag "developer") {
     mode = "0400";
   };
 
+  sops.templates."pi-mcp-config" = {
+    content = builtins.toJSON piMcpConfig;
+    path = "${config.home.homeDirectory}/.pi/agent/mcp.json";
+    mode = "0600";
+  };
+
   home = {
     packages = [
       piWrapperPackage
@@ -263,7 +270,6 @@ lib.mkIf (noughtyLib.userHasTag "developer") {
     ];
     file = {
       ".pi/agent/settings.json".text = builtins.toJSON piSettings;
-      ".pi/agent/mcp.json".text = builtins.toJSON piMcpConfig;
       ".pi/agent/extensions/subagent/config.json".text = builtins.toJSON piSubagentsConfig;
       ".pi/agent/themes/${piThemeName}.json".text = builtins.toJSON piCatppuccinTheme;
     }


### PR DESCRIPTION
## Summary
Add declarative Pi Agent support across the agentic Home Manager stack, including MCP integration, model defaults, rendering support, and package pinning.

## Changes
- Add the Pi Agent Home Manager module from `inputs.llm-agents`
- Integrate `pi-mcp-adapter` and `pi-subagents` declaratively
- Add Anthropic and GPT Pi model defaults, Catppuccin Mocha theming, assistant rendering support, and a secret-backed API key wrapper
- Add Pi MCP direct-tool preferences based on OpenCode preferences
- Pin Pi extension packages from `@juicesharp`
- Tune Pi retries for Anthropic overloads and quiet npm advisory output

## Testing
- Verified the branch is clean with `git status`
- Pushed the branch to `origin`
- Created the pull request from `pi-agent`

## Related Issues
