### PR TITLE
fix(hermes): render Catppuccin skin as scalar

### DIFF
--- a/nixos/_mixins/server/hermes/catppuccin.nix
+++ b/nixos/_mixins/server/hermes/catppuccin.nix
@@ -230,7 +230,9 @@ let
 in
 {
   config = lib.mkIf (noughtyLib.hostHasTag "hermes") {
-    services.hermes-agent.settings.display.skin = lib.mkDefault "catppuccin-mocha";
+    # services.hermes-agent.settings is serialised directly to YAML, so do not
+    # use lib.mkDefault here: override metadata leaks into Hermes' config.yaml.
+    services.hermes-agent.settings.display.skin = "catppuccin-mocha";
 
     system.activationScripts.hermes-catppuccin-skins =
       lib.stringAfter


### PR DESCRIPTION
## Summary

- Render `services.hermes-agent.settings.display.skin` as a plain YAML scalar again.
- Add an inline comment documenting why `lib.mkDefault` is deliberately avoided in this freeform Hermes settings attrset.

## Why

`services.hermes-agent.settings` is serialised directly to Hermes' `config.yaml`.
Using `lib.mkDefault` for `display.skin` leaks Nix override metadata into the generated YAML:

```yaml
display:
  skin:
    _type: override
    content: catppuccin-mocha
    priority: 1000
```

Hermes expects a skin name string:

```yaml
display:
  skin: catppuccin-mocha
```

The leaked override object makes the CLI fall back to the default skin even though the Catppuccin skin YAML files are installed correctly.

## Validation

- `nix fmt -- nixos/_mixins/server/hermes/catppuccin.nix`
- `git diff --check`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); in flake.nixosConfigurations.revan.config.services.hermes-agent.settings.display.skin'`
- `nix eval --impure --raw .#nixosConfigurations.revan.config.system.activationScripts.hermes-agent-managed-config.text` plus `yq '.display.skin'` on the generated store config
- `just eval`
- `nix build --no-link --impure .#nixosConfigurations.revan.config.system.build.toplevel`

Validated rendered value:

```json
"catppuccin-mocha"
```
