### PR TITLE
chore: bump hermes-agent to v2026.5.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,14 +493,14 @@
         "uv2nix": "uv2nix_2"
       },
       "locked": {
-        "lastModified": 1777573861,
-        "narHash": "sha256-whY/1WL2fQUhPqDp7CGm3MSwOOo7FB1eADhNVnHeCRU=",
+        "lastModified": 1778170968,
+        "narHash": "sha256-YQQUEDUim2CiYpL3uG7Wi1fWPsT2wtIqoBeJuAj9hUk=",
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.4.30.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.7.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.4.30.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.7.tar.gz"
       }
     },
     "home-manager": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
-    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.4.30.tar.gz";
+    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.7.tar.gz";
     hermes-agent.inputs.nixpkgs.follows = "nixpkgs-unstable";
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
## Release
- https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.7

## Version bump
- previous tag: v2026.4.30
- new tag: v2026.5.7

## Summary of files changed
- `flake.nix` - bump `hermes-agent.url` tarball tag from `v2026.4.30` to `v2026.5.7`
- `flake.lock` - refresh the `hermes-agent` lock entry to `https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.7.tar.gz`

## Validation
- `git diff --check` - passed
- `just eval` - passed
- `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.package.name --raw` - passed, returned `hermes-agent-host`
