### PR TITLE
fix: provide awk in Hermes runtime

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -308,7 +308,7 @@ let
     lsof
     ltrace
     lurk
-    mawk
+    gawk
     nh
     nix-direnv
     nodejs-slim


### PR DESCRIPTION
## Summary
- Replace `mawk` with `gawk` in the Hermes extra package set.
- This gives the Hermes runtime a standard `awk` executable for project helper scripts such as `just release`.

## Root cause
`mawk` is present in the deployed Hermes `PATH`, but the Nix package only exposes `mawk`, not `awk`. Scripts that call `awk` therefore fail even though an AWK implementation is configured.

`gawk` exposes both `awk` and `gawk`, so it fixes the generic command name expected by POSIX-style scripts.

## Validation
- Confirmed live Hermes shell has `mawk` but no `awk`.
- Confirmed `nixpkgs#gawk` exposes `bin/awk` and `bin/gawk`.
- `just eval`
- `nix fmt -- nixos/_mixins/server/hermes/default.nix`
- `git diff --check`
