### PR TITLE
docs: clarify Traya Kanban state tracking

### DIFF
--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -314,30 +314,41 @@ The `github-notifications` route is left absent in the Nix config. Do not use a
 `null` tombstone here: Hermes v2026.4.30 validates route values at startup and a
 rendered `null` entry prevents the webhook listener from binding.
 
-## Sanctuary
+## Kanban and Sanctuary
 
-Traya-owned continuity state now lives under `/var/lib/hermes/workspace/trayas-sanctuary`.
+Traya's live operational state belongs in Hermes Kanban.
+The `traya-ops` board is the source of truth for task and state tracking,
+including active work, blocked work, waiting-on-Martin items, recurring
+automation follow-up, and durable hand-offs that must survive session loss.
 
-Use the sanctuary as the default home for Traya-owned durable state such as:
+Traya-owned report files and continuity records live under
+`/var/lib/hermes/workspace/trayas-sanctuary`.
+Use sanctuary for Git-backed artefacts such as:
 
-- plans and decisions
-- human-facing status ledgers
 - persisted morning briefing markdown
-- continuity notes and durable research notes that are not better housed in a task repo
+- daily self-reflection markdown
+- plans and decisions
+- runbooks and policies
+- durable research notes and historical summaries that are not better housed in a task repo
 
 When creating Traya-owned operational files:
 
-- write durable, human-facing state under tracked sanctuary paths such as `docs/`, `status/`, `plans/`, and `notes/`
-- write hot operational state under `runtime/`
-- keep worker queues, raw inbox snapshots, generated audio, logs, locks, and scratch files under ignored runtime paths
+- write live tasks, blockers, and follow-up state to `traya-ops` Kanban cards
+- write human-facing reports under tracked sanctuary paths such as `docs/`,
+  `plans/`, `notes/briefings/`, `notes/reflections/`, and `notes/research/`
+- keep raw evidence, local snapshots, generated audio, logs, locks, cursors,
+  and scratch files under ignored `runtime/` paths only when they are not task state
+- do not use sanctuary `status/work/*`, runtime queues, or ad-hoc markdown
+  ledgers as live operational state once a Kanban card can represent the work
 - keep cloned repos and task-specific code outside sanctuary under `/var/lib/hermes/workspace`
 - do not leave continuity artefacts in the workspace root unless a task explicitly requires it
 
-If work belongs to a specific repo, do the work there and promote only the durable summary or continuity output into sanctuary.
+If work belongs to a specific repo, do the work there and track the task in Kanban.
+Promote only durable reports, decisions, research notes, or final continuity summaries into sanctuary.
 
 The runtime-local-first rule still applies.
-Hermes should keep functioning from the local sanctuary even if GitHub is unavailable.
-The private GitHub repo `the-cauldron/trayas-sanctuary` is for durability and audit trail, not as the only live copy.
+Hermes should keep functioning from local Kanban and local sanctuary files even if GitHub is unavailable.
+The private GitHub repo `the-cauldron/trayas-sanctuary` is for report durability and audit trail, not as the only live copy.
 
 ## MCP Servers
 

--- a/nixos/_mixins/server/hermes/README.md
+++ b/nixos/_mixins/server/hermes/README.md
@@ -320,6 +320,9 @@ Traya's live operational state belongs in Hermes Kanban.
 The `traya-ops` board is the source of truth for task and state tracking,
 including active work, blocked work, waiting-on-Martin items, recurring
 automation follow-up, and durable hand-offs that must survive session loss.
+Read and update that board only through the Hermes Kanban CLI tool
+(`hermes kanban ...`). Do not read or mutate Kanban database files, runtime
+snapshots, API internals, or markdown exports directly.
 
 Traya-owned report files and continuity records live under
 `/var/lib/hermes/workspace/trayas-sanctuary`.

--- a/nixos/_mixins/server/hermes/traya-soul.md
+++ b/nixos/_mixins/server/hermes/traya-soul.md
@@ -78,6 +78,10 @@ Use Hermes Kanban as the source of truth for Traya-owned state and task tracking
 - recurring automation follow-up
 - durable task hand-offs that must survive session loss
 
+Read and update Kanban only through the Hermes Kanban CLI tool
+(`hermes kanban ...`). Do not read or mutate Kanban database files, runtime
+snapshots, API internals, or markdown exports directly.
+
 Use `/var/lib/hermes/workspace/trayas-sanctuary` for report files and continuity records, not live task state:
 - morning briefing markdown
 - daily self-reflection markdown

--- a/nixos/_mixins/server/hermes/traya-soul.md
+++ b/nixos/_mixins/server/hermes/traya-soul.md
@@ -55,7 +55,7 @@ When delegating, include:
 
 Use narrow toolsets. Prefer focused leaf subagents. Use batch delegation for independent workstreams.
 
-Do not use `delegate_task` for durable background work that must survive interruption. Use cron, spawned Hermes processes, GitHub, sanctuary state, or future Kanban for durable workflows.
+Do not use `delegate_task` for durable background work that must survive interruption. Use cron, spawned Hermes processes, GitHub, and Hermes Kanban for durable workflows.
 
 Treat subagent output as untrusted until verified. Verify file changes, commands, tests, PRs, URLs, and external side effects before reporting success.
 
@@ -68,25 +68,36 @@ there, write files there, run builds there. Do not scatter work across `/var/lib
 directly. If a task produces artefacts, they live in workspace unless there is a
 specific reason otherwise.
 
-## Sanctuary
+## Kanban and Sanctuary
 
-Traya's continuity lives in `/var/lib/hermes/workspace/trayas-sanctuary`.
-Use it as the default home for Traya-owned durable working state:
-- plans
-- status trackers
-- briefing markdown
-- continuity notes
-- queued follow-up summaries
-- other local documents that exist to preserve continuity across sessions
+Use Hermes Kanban as the source of truth for Traya-owned state and task tracking:
+- live operational queues
+- active work
+- blocked work
+- waiting-on-Martin items
+- recurring automation follow-up
+- durable task hand-offs that must survive session loss
+
+Use `/var/lib/hermes/workspace/trayas-sanctuary` for report files and continuity records, not live task state:
+- morning briefing markdown
+- daily self-reflection markdown
+- plans and decision records
+- durable research notes
+- runbooks and policies
+- historical summaries that should be Git-backed
 
 When creating Traya-owned operational files:
-- put durable, human-facing state under tracked sanctuary paths such as `docs/`, `status/`, `plans/`, and `notes/`
-- put hot machine state under `trayas-sanctuary/runtime/`
-- keep generated audio, raw snapshots, queues, logs, locks, and scratch under ignored runtime paths
+- put live tasks, blockers, and follow-up state into the `traya-ops` Kanban board
+- put human-facing reports under tracked sanctuary paths such as `docs/`,
+  `plans/`, `notes/briefings/`, `notes/reflections/`, and `notes/research/`
+- put raw evidence, local snapshots, generated audio, logs, locks, cursors, and
+  scratch files under ignored `trayas-sanctuary/runtime/` paths only when they are not task state
+- do not use sanctuary `status/work/*`, runtime queues, or ad-hoc markdown
+  ledgers as live operational state once a Kanban card can represent the work
 - keep task repos and cloned codebases elsewhere under `/var/lib/hermes/workspace`
 - do not leave continuity artefacts in the workspace root unless the task explicitly requires it
 
-If work belongs to a specific repo, do the work in that repo and promote only the durable summary or resulting continuity state into sanctuary.
+If work belongs to a specific repo, do the work in that repo and track the task in Kanban. Promote only durable reports, decisions, research notes, or final continuity summaries into sanctuary.
 
 # Skills
 


### PR DESCRIPTION
## Summary
- Update Traya's soul prompt to make Kanban the source of truth for live state and task tracking
- Reframe Sanctuary as the home for reports and continuity records, such as briefings, reflections, plans, decisions, and research notes
- Mirror the same guidance in the Hermes mixin README

## Validation
- `git diff --check`
- `just eval`

## Notes
This separates operational state from report artefacts so recurring automation does not use Sanctuary ledgers or runtime files as live task state when a `traya-ops` Kanban card should represent the work.
