### PR TITLE
fix(home): remove Notesnook from momin

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -191,7 +191,6 @@ in
           "/Users/${username}/Applications/Home Manager Apps/Kitty.app"
           "/System/Applications/Music.app"
           "/Users/${username}/Applications/Home Manager Apps/Heynote.app"
-          "/Users/${username}/Applications/Home Manager Apps/Notesnook.app"
           "/System/Applications/Apps.app"
         ];
         show-recents = false;

--- a/home-manager/_mixins/desktop/apps/notes/default.nix
+++ b/home-manager/_mixins/desktop/apps/notes/default.nix
@@ -12,6 +12,8 @@ lib.mkIf (noughtyLib.isUser [ "martin" ] && host.is.workstation) {
   home = {
     packages = [
       pkgs.heynote
+    ]
+    ++ lib.optionals host.is.linux [
       pkgs.unstable.notesnook
     ];
   };


### PR DESCRIPTION
## Summary
- remove Notesnook from the Darwin Dock configuration for momin
- keep Notesnook installed only on Linux workstations in the Home Manager notes mixin

## Test Plan
- `nix fmt -- home-manager/_mixins/desktop/apps/notes/default.nix darwin/default.nix`
- `git diff --check`
- `just eval`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); in builtins.filter (name: name == "notesnook" || name == "Notesnook" || name == "heynote") (map (p: p.pname or p.name) flake.homeConfigurations."martin@momin".config.home.packages)'`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); in builtins.filter (name: name == "notesnook" || name == "heynote") (map (p: p.pname or p.name) flake.homeConfigurations."martin@skrye".config.home.packages)'`
