### PR TITLE
feat(nixos): enable gatus telegram alerts on revan

### DIFF
--- a/lib/registry-systems.toml
+++ b/lib/registry-systems.toml
@@ -216,7 +216,7 @@ vendors = ["amd"]
 [malak]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny"]
+tags = ["scrutiny", "gatus", "ntfy"]
 
 [malak.gpu]
 vendors = ["intel"]
@@ -236,7 +236,7 @@ vram = 24
 [revan]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny", "dropbox", "librechat", "inference", "hermes"]
+tags = ["scrutiny", "dropbox", "librechat", "inference", "hermes", "gatus", "ntfy"]
 
 [revan.gpu]
 vendors = ["intel", "nvidia"]

--- a/lib/registry-systems.toml
+++ b/lib/registry-systems.toml
@@ -216,7 +216,7 @@ vendors = ["amd"]
 [malak]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny", "gatus"]
+tags = ["scrutiny", "gatus", "ntfy"]
 
 [malak.gpu]
 vendors = ["intel"]
@@ -236,7 +236,7 @@ vram = 24
 [revan]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny", "dropbox", "librechat", "inference", "hermes", "gatus"]
+tags = ["scrutiny", "dropbox", "librechat", "inference", "hermes", "gatus", "ntfy"]
 
 [revan.gpu]
 vendors = ["intel", "nvidia"]

--- a/lib/registry-systems.toml
+++ b/lib/registry-systems.toml
@@ -216,7 +216,7 @@ vendors = ["amd"]
 [malak]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny", "gatus", "ntfy"]
+tags = ["scrutiny", "gatus"]
 
 [malak.gpu]
 vendors = ["intel"]
@@ -236,7 +236,7 @@ vram = 24
 [revan]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny", "dropbox", "librechat", "inference", "hermes", "gatus", "ntfy"]
+tags = ["scrutiny", "dropbox", "librechat", "inference", "hermes", "gatus"]
 
 [revan.gpu]
 vendors = ["intel", "nvidia"]

--- a/nixos/_mixins/server/gatus/default.nix
+++ b/nixos/_mixins/server/gatus/default.nix
@@ -5,6 +5,9 @@
   pkgs,
   ...
 }:
+let
+  hermesSopsFile = ../../../../secrets + "/hermes.yaml";
+in
 lib.mkIf (noughtyLib.hostHasTag "gatus") {
   environment = {
     shellAliases = {
@@ -21,6 +24,20 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
         path = "/etc/gatus/secrets.env";
         sopsFile = ../../../../secrets/gatus.yaml;
       };
+      TELEGRAM_BOT_TOKEN = {
+        group = "root";
+        mode = "0400";
+        owner = "root";
+        sopsFile = hermesSopsFile;
+      };
+    };
+    templates."gatus-telegram-env" = {
+      content = ''
+        GATUS_TELEGRAM_TOKEN=${config.sops.placeholder.TELEGRAM_BOT_TOKEN}
+      '';
+      group = "root";
+      mode = "0400";
+      owner = "root";
     };
   };
   services = {
@@ -42,10 +59,10 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
       environmentFile = config.sops.secrets.gatus-env.path;
       settings = {
         alerting = {
-          ntfy = {
-            topic = "$GATUS_NTFY_TOPIC";
-            url = "$GATUS_NTFY_URL";
-            click = "https://status.wimpys.world";
+          telegram = {
+            token = "$GATUS_TELEGRAM_TOKEN";
+            id = "-1003933927882";
+            topic-id = "5657";
             default-alert = {
               description = "Gatus health check";
               send-on-resolved = true;
@@ -83,7 +100,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -98,7 +115,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -112,7 +129,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -127,7 +144,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -141,7 +158,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -155,7 +172,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -170,7 +187,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -185,7 +202,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -200,7 +217,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -215,7 +232,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -230,7 +247,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -245,7 +262,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -260,7 +277,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -275,7 +292,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -290,7 +307,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -304,7 +321,7 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
             ];
             alerts = [
               {
-                type = "ntfy";
+                type = "telegram";
               }
             ];
           }
@@ -312,6 +329,10 @@ lib.mkIf (noughtyLib.hostHasTag "gatus") {
       };
     };
   };
+
+  systemd.services.gatus.serviceConfig.EnvironmentFile = [
+    config.sops.templates."gatus-telegram-env".path
+  ];
 
   systemd.services.goaccess-gatus = {
     description = "Generate goaccess gatus report";

--- a/nixos/_mixins/server/gatus/default.nix
+++ b/nixos/_mixins/server/gatus/default.nix
@@ -5,7 +5,7 @@
   pkgs,
   ...
 }:
-lib.mkIf (noughtyLib.isHost [ "malak" ]) {
+lib.mkIf (noughtyLib.hostHasTag "gatus") {
   environment = {
     shellAliases = {
       gatus-log = "journalctl _SYSTEMD_UNIT=gatus.service";

--- a/nixos/_mixins/server/ntfy/default.nix
+++ b/nixos/_mixins/server/ntfy/default.nix
@@ -5,7 +5,7 @@
   pkgs,
   ...
 }:
-lib.mkIf (noughtyLib.isHost [ "malak" ]) {
+lib.mkIf (noughtyLib.hostHasTag "ntfy") {
   environment = {
     shellAliases = {
       goaccess-ntfy = "sudo ${pkgs.goaccess}/bin/goaccess -f /var/log/caddy/ntfy.log --log-format=CADDY --geoip-database=/var/lib/GeoIP/GeoLite2-City.mmdb";

--- a/nixos/_mixins/server/ntfy/default.nix
+++ b/nixos/_mixins/server/ntfy/default.nix
@@ -5,7 +5,7 @@
   pkgs,
   ...
 }:
-lib.mkIf (noughtyLib.hostHasTag "ntfy") {
+lib.mkIf (noughtyLib.isHost [ "malak" ]) {
   environment = {
     shellAliases = {
       goaccess-ntfy = "sudo ${pkgs.goaccess}/bin/goaccess -f /var/log/caddy/ntfy.log --log-format=CADDY --geoip-database=/var/lib/GeoIP/GeoLite2-City.mmdb";


### PR DESCRIPTION
## Summary
- enable the existing gatus mixin on both malak and revan via a `gatus` host tag
- configure Gatus alerts for the Telegram `Alerts` forum topic in The Cauldron
- reuse the existing Hermes `TELEGRAM_BOT_TOKEN` secret via a rendered Gatus env file
- drop the ntfy expansion from this PR and keep the ntfy mixin scoped to malak

## Verification
- `nix fmt`
- `git diff --check`
- `rg 'ntfy|GATUS_NTFY' nixos/_mixins/server/gatus/default.nix` returns no matches
- `rg -c 'type = "telegram"' nixos/_mixins/server/gatus/default.nix` returns `16`
- `nix eval --json .#nixosConfigurations.revan.config.services.gatus.settings.alerting`
- `nix eval --json .#nixosConfigurations.revan.config.noughty.host.tags`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString /var/lib/hermes/workspace/nix-config); cfg = flake.nixosConfigurations.revan.config; in { gatus = cfg.services.gatus.enable; ntfy = cfg.services.ntfy-sh.enable; }'`
- `just eval`

## Not done here
- no deployment to revan, this worker has no SSH access to malak/revan
- no Cloudflare Tunnel routing change, no Cloudflare API credentials are visible in the worker environment
- no gatus state copy, source/target host SSH access is missing
- no live Telegram test alert, this PR only wires the deployed Gatus configuration