### PR TITLE
fix(hermes): include messaging SDKs in sealed venv

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -233,7 +233,14 @@ let
         Path.chmod = _managed_path_chmod
         builtins.__import__ = _managed_import
   '';
-  upstreamHermesAgentPackage = pkgs.hermesAgent;
+  # v2026.5.16 dropped messaging SDKs (python-telegram-bot, discord.py,
+  # slack-bolt, …) from the default install in favour of a runtime
+  # lazy-install path. That path cannot write into the sealed /nix/store
+  # venv, so opt the SDKs back in declaratively via the upstream module's
+  # extraDependencyGroups override (uv resolves them at build time).
+  upstreamHermesAgentPackage = pkgs.hermesAgent.override {
+    extraDependencyGroups = [ "messaging" ];
+  };
   hermesAgentPackage = pkgs.symlinkJoin {
     name = "hermes-agent-host";
     paths = [ upstreamHermesAgentPackage ];


### PR DESCRIPTION
Hermes Agent v2026.5.16 moved messaging SDKs from default to lazy-install, expecting runtime pip. On NixOS the sealed /nix/store venv is immutable; lazy-install fails and python-telegram-bot is never installed, breaking the Telegram gateway.

Override pkgs.hermesAgent with extraDependencyGroups = [ "messaging" ] to bake the Telegram SDK (and Discord/Slack) into the sealed venv at build time via uv.