### PR TITLE
fix: use portable Pi provider regex

### DIFF
--- a/home-manager/_mixins/agentic/assistants/compose.nix
+++ b/home-manager/_mixins/agentic/assistants/compose.nix
@@ -111,7 +111,7 @@ let
     line:
     let
       uncommented = lib.head (lib.splitString "#" line);
-      matched = builtins.match "^[[:space:]]*model-([A-Za-z0-9_-]+):[[:space:]]*(.+?)[[:space:]]*$" uncommented;
+      matched = builtins.match "^[[:space:]]*model-([A-Za-z0-9_-]+):[[:space:]]*(.+)[[:space:]]*$" uncommented;
     in
     if matched == null then
       null


### PR DESCRIPTION
## Summary
- Replace the Pi provider-router `builtins.match` lazy quantifier with a portable greedy capture.
- Keep the existing value normalisation path responsible for trimming whitespace and rejecting unsupported YAML forms.

## Root cause
- GitHub Actions rejected `(.+?)` as an invalid regular expression while evaluating `agentic.assistants.pi.providerRouterMap` for `homeConfigurations."martin@momin"`.
- Nix's regex dialect is not consistently tolerant of lazy quantifiers across environments.

## Validation
- `nix eval --raw '.#homeConfigurations."martin@momin".config.home.file.".pi/agent/extensions/provider-router/agents.json".text' | jq -e '.garfield.anthropic == "claude-haiku-4-5" and .garfield.google == "gemini-3-flash" and .garfield.openai == "gpt-5-mini"'`
- `just eval`
- `git diff --check`

## Notes
- `nix build '.#homeConfigurations."martin@momin".activationPackage' --no-link -L` cannot complete on this x86_64 Linux runner because the target is `aarch64-darwin`; evaluation reaches the activation derivation after this fix and CI should build it on the macOS ARM runner.
- `just format home-manager/_mixins/agentic/assistants/compose.nix` is currently blocked locally by missing formatter helper commands in the outer/dev shell, first `deadnix`, then `nixfmt-tree`. No formatting changes are required for this one-line regex replacement.
