### PR TITLE
feat(agentsview): add Hermes sync and server support

### DIFF
--- a/home-manager/_mixins/agentic/agentsview/README.md
+++ b/home-manager/_mixins/agentic/agentsview/README.md
@@ -1,0 +1,7 @@
+# AgentsView
+
+This Home Manager mixin installs the developer-side AgentsView CLI and pushes
+local agent state into the shared PostgreSQL-backed dashboard.
+
+For the full architecture, server service, Hermes service push, SOPS split, and
+operational checks, see the [NixOS AgentsView README](../../../../nixos/_mixins/server/agentsview/README.md).

--- a/home-manager/_mixins/agentic/agentsview/default.nix
+++ b/home-manager/_mixins/agentic/agentsview/default.nix
@@ -14,6 +14,15 @@ let
   agentsviewConfigPath = "${config.home.homeDirectory}/.agentsview/config.toml";
   agentsviewEnvPath = config.sops.templates."agentsview-pg.env".path;
   agentsviewConfigPython = pkgs.python3.withPackages (ps: [ ps.tomlkit ]);
+  agentsviewWrappedPackage = pkgs.symlinkJoin {
+    name = "agentsview-wrapped";
+    paths = [ agentsviewPackage ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram "$out/bin/agentsview" \
+        --run 'if [ -r "${agentsviewEnvPath}" ]; then set -a; . "${agentsviewEnvPath}"; set +a; fi'
+    '';
+  };
   agentsviewConfigActivationScript = ''
     ${agentsviewConfigPython}/bin/python - <<'PY'
     import pathlib
@@ -21,7 +30,6 @@ let
     import tomlkit
 
     path = pathlib.Path("${agentsviewConfigPath}")
-    env_path = pathlib.Path("${agentsviewEnvPath}")
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
 
     if path.exists() and path.is_file():
@@ -34,14 +42,7 @@ let
         pg = tomlkit.table()
         document["pg"] = pg
 
-    for line in env_path.read_text(encoding="utf-8").splitlines():
-        key, separator, value = line.partition("=")
-        if separator and key == "AGENTSVIEW_PG_URL":
-            pg["url"] = value
-            break
-    else:
-        raise RuntimeError(f"AGENTSVIEW_PG_URL is missing from {env_path}")
-
+    pg.pop("url", None)
     pg["schema"] = "agentsview"
     pg["machine_name"] = "${host.name}"
     pg["allow_insecure"] = True
@@ -70,7 +71,7 @@ lib.mkIf (noughtyLib.userHasTag "developer") {
   };
 
   home.packages = [
-    agentsviewPackage
+    agentsviewWrappedPackage
   ];
 
   home.activation.agentsviewConfig = lib.hm.dag.entryAfter [

--- a/home-manager/_mixins/agentic/agentsview/default.nix
+++ b/home-manager/_mixins/agentic/agentsview/default.nix
@@ -1,0 +1,113 @@
+{
+  config,
+  inputs,
+  lib,
+  noughtyLib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.noughty) host;
+  inherit (pkgs.stdenv.hostPlatform) system;
+  agentsviewPackage = inputs.llm-agents.packages.${system}.agentsview;
+  agentsviewSopsFile = ../../../../secrets/agentsview.yaml;
+  agentsviewConfigPath = "${config.home.homeDirectory}/.agentsview/config.toml";
+  agentsviewEnvPath = config.sops.templates."agentsview-pg.env".path;
+  agentsviewConfigPython = pkgs.python3.withPackages (ps: [ ps.tomlkit ]);
+  agentsviewConfigActivationScript = ''
+    ${agentsviewConfigPython}/bin/python - <<'PY'
+    import pathlib
+
+    import tomlkit
+
+    path = pathlib.Path("${agentsviewConfigPath}")
+    env_path = pathlib.Path("${agentsviewEnvPath}")
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    if path.exists() and path.is_file():
+        document = tomlkit.parse(path.read_text(encoding="utf-8"))
+    else:
+        document = tomlkit.document()
+
+    pg = document.get("pg")
+    if pg is None or not hasattr(pg, "__setitem__"):
+        pg = tomlkit.table()
+        document["pg"] = pg
+
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key == "AGENTSVIEW_PG_URL":
+            pg["url"] = value
+            break
+    else:
+        raise RuntimeError(f"AGENTSVIEW_PG_URL is missing from {env_path}")
+
+    pg["schema"] = "agentsview"
+    pg["machine_name"] = "${host.name}"
+    pg["allow_insecure"] = True
+
+    tmp = path.with_name(f"{path.name}.tmp")
+    tmp.write_text(tomlkit.dumps(document), encoding="utf-8")
+    tmp.chmod(0o600)
+    tmp.replace(path)
+    PY
+  '';
+in
+lib.mkIf (noughtyLib.userHasTag "developer") {
+  sops.secrets.AGENTSVIEW_PG_URL = {
+    sopsFile = agentsviewSopsFile;
+    mode = "0400";
+  };
+
+  sops.templates."agentsview-pg.env" = {
+    content = ''
+      AGENTSVIEW_PG_URL=${config.sops.placeholder.AGENTSVIEW_PG_URL}
+      AGENTSVIEW_PG_SCHEMA=agentsview
+      AGENTSVIEW_PG_MACHINE=${host.name}
+      AGENTSVIEW_DISABLE_UPDATE_CHECK=1
+    '';
+    mode = "0400";
+  };
+
+  home.packages = [
+    agentsviewPackage
+  ];
+
+  home.activation.agentsviewConfig = lib.hm.dag.entryAfter [
+    "writeBoundary"
+  ] agentsviewConfigActivationScript;
+
+  systemd.user.services.agentsview-pg-push = lib.mkIf host.is.linux {
+    Unit = {
+      Description = "Push local AgentsView data to PostgreSQL";
+      After = [
+        "sops-nix.service"
+      ];
+      Wants = [
+        "sops-nix.service"
+      ];
+    };
+
+    Service = {
+      Type = "exec";
+      EnvironmentFile = config.sops.templates."agentsview-pg.env".path;
+      ExecStart = "${agentsviewPackage}/bin/agentsview pg push";
+    };
+  };
+
+  systemd.user.timers.agentsview-pg-push = lib.mkIf host.is.linux {
+    Unit.Description = "Push local AgentsView data to PostgreSQL on a schedule";
+
+    Timer = {
+      OnBootSec = "5m";
+      OnUnitActiveSec = "15m";
+      RandomizedDelaySec = "2m";
+      Persistent = true;
+      Unit = "agentsview-pg-push.service";
+    };
+
+    Install.WantedBy = [
+      "timers.target"
+    ];
+  };
+}

--- a/home-manager/_mixins/agentic/claude-code/default.nix
+++ b/home-manager/_mixins/agentic/claude-code/default.nix
@@ -269,7 +269,6 @@ in
         ".claude/plugins/nix-lsp/.lsp.json".text = builtins.toJSON lspServers;
       };
       packages = [
-        inputs.llm-agents.packages.${system}.ccusage
         ccstatuslinePackage
         claudeAgentAcpPackage
         usageRemainingPackage

--- a/lib/registry-systems.toml
+++ b/lib/registry-systems.toml
@@ -236,7 +236,7 @@ vram = 24
 [revan]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny", "dropbox", "librechat", "inference", "hermes", "gatus"]
+tags = ["scrutiny", "dropbox", "librechat", "inference", "hermes", "gatus", "postgres", "agentsview"]
 
 [revan.gpu]
 vendors = ["intel", "nvidia"]

--- a/nixos/_mixins/server/agentsview/README.md
+++ b/nixos/_mixins/server/agentsview/README.md
@@ -1,0 +1,183 @@
+# AgentsView
+
+AgentsView gives local and service-run agents one shared dashboard. Each
+machine pushes its local AgentsView state into PostgreSQL, and the server mixin
+serves a read-only web UI at `/agentsview` over the Tailnet Caddy host.
+
+Use it when you need to inspect agent activity across machines without logging
+into each host or copying local state by hand.
+
+## Architecture
+
+The implementation has three parts:
+
+- [nixos/_mixins/server/agentsview/default.nix](default.nix) wires the server
+  mixin, SOPS secret template, shell alias, and Caddy route.
+- [nixos/_mixins/server/agentsview/module.nix](module.nix) runs
+  `agentsview pg serve` as a hardened systemd service.
+- [home-manager/_mixins/agentic/agentsview/default.nix](../../../../home-manager/_mixins/agentic/agentsview/default.nix)
+  installs a wrapped `agentsview` CLI for developer users and pushes local data
+  on a user timer.
+
+[nixos/_mixins/server/hermes/default.nix](../hermes/default.nix) adds a fourth
+producer: Hermes pushes its managed service state into the same PostgreSQL
+schema with a distinct machine name.
+
+## Central Server
+
+Hosts tagged `agentsview` run the central dashboard:
+
+```nix
+noughtyLib.hostHasTag "agentsview"
+```
+
+The service runs:
+
+```bash
+agentsview pg serve \
+  --host 127.0.0.1 \
+  --port 18080 \
+  --base-path /agentsview \
+  --public-url https://<host>.<tailnet> \
+  --no-browser \
+  --no-update-check
+```
+
+It binds to localhost only. Caddy exposes it at:
+
+```text
+https://<host>.<tailnet>/agentsview/
+```
+
+The route forwards `/agentsview/*` unchanged because AgentsView already serves
+with `--base-path /agentsview`.
+
+## PostgreSQL Sharing
+
+AgentsView uses PostgreSQL as the shared transport. Producers push local state
+into the `agentsview` schema, then the server reads that schema for the
+dashboard.
+
+Configured producers:
+
+| Producer | Scope | Machine name |
+|---|---|---|
+| Home Manager developer profile | Local user sessions | host name |
+| Hermes NixOS service | Managed Hermes sessions | `<host>-hermes` |
+
+Both producer paths set:
+
+```text
+AGENTSVIEW_PG_SCHEMA=agentsview
+AGENTSVIEW_DISABLE_UPDATE_CHECK=1
+```
+
+The generated TOML config sets `pg.schema`, `pg.machine_name`, and
+`pg.allow_insecure`. The PostgreSQL URL stays in the SOPS-rendered environment
+file.
+
+## Local Home Manager Push
+
+Developer users get a wrapped `agentsview` CLI. The wrapper sources
+`agentsview-pg.env` when it exists, so manual CLI use and the timer share the
+same database settings.
+
+Home activation writes:
+
+```text
+~/.agentsview/config.toml
+```
+
+The user service then runs:
+
+```bash
+agentsview pg push
+```
+
+On Linux, `agentsview-pg-push.timer` starts five minutes after boot, repeats
+every fifteen minutes, adds up to two minutes of random delay, and persists
+missed runs.
+
+## Hermes Push
+
+Hermes runs a system service push because its state lives under
+`/var/lib/hermes`, not a human user's home directory.
+
+The service sets:
+
+```text
+AGENTSVIEW_DATA_DIR=/var/lib/hermes/.agentsview
+HERMES_SESSIONS_DIR=/var/lib/hermes/.hermes/sessions
+HOME=/var/lib/hermes
+```
+
+Activation writes:
+
+```text
+/var/lib/hermes/.agentsview/config.toml
+```
+
+`hermes-agentsview-pg-push.timer` starts seven minutes after boot, repeats every
+fifteen minutes, adds up to two minutes of random delay, and persists missed
+runs.
+
+## Secrets and Config Split
+
+The PostgreSQL URL comes from `secrets/agentsview.yaml` as
+`AGENTSVIEW_PG_URL`. The implementation never writes the URL into TOML.
+
+Server path:
+
+- SOPS reads `AGENTSVIEW_PG_URL`.
+- A template renders `agentsview.env` as a `KEY=value` file.
+- `agentsview.service` reads that file through `EnvironmentFile`.
+
+Home Manager path:
+
+- SOPS reads `AGENTSVIEW_PG_URL`.
+- A template renders `agentsview-pg.env`.
+- The wrapper and user service read that environment file.
+
+Hermes path:
+
+- SOPS reads the same key as `HERMES_AGENTSVIEW_PG_URL`.
+- A template renders `hermes-agentsview-env`.
+- `hermes-agentsview-pg-push.service` reads that environment file.
+
+Keep non-secret config in generated TOML. Keep credentials in SOPS templates.
+
+## Operational Checks
+
+Check the dashboard service:
+
+```bash
+systemctl status agentsview.service
+agentsview-log
+```
+
+Check the server route:
+
+```bash
+curl -I https://<host>.<tailnet>/agentsview/
+```
+
+Check local user pushes:
+
+```bash
+systemctl --user status agentsview-pg-push.timer
+systemctl --user status agentsview-pg-push.service
+journalctl --user -u agentsview-pg-push.service
+```
+
+Check Hermes pushes:
+
+```bash
+systemctl status hermes-agentsview-pg-push.timer
+systemctl status hermes-agentsview-pg-push.service
+journalctl -u hermes-agentsview-pg-push.service
+```
+
+If the dashboard loads but a machine is missing, check its push timer first,
+then confirm the relevant SOPS-rendered environment file exists and contains
+only variable names plus redacted secret material when viewed through safe
+inspection tooling.

--- a/nixos/_mixins/server/agentsview/default.nix
+++ b/nixos/_mixins/server/agentsview/default.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  noughtyLib,
+  ...
+}:
+{
+  imports = [
+    ./module.nix
+  ];
+
+  config = lib.mkIf (noughtyLib.hostHasTag "agentsview") {
+    environment.shellAliases.agentsview-log = "journalctl _SYSTEMD_UNIT=agentsview.service";
+
+    # The sops secret stores AGENTSVIEW_PG_URL as a raw URL value, not a
+    # KEY=VALUE pair, so it cannot be passed directly to systemd's
+    # EnvironmentFile. A sops template assembles a properly-formatted env
+    # file by interpolating the placeholder at activation time. Owning it as
+    # `agentsview` lets the service user read it without DynamicUser tricks.
+    sops.secrets.AGENTSVIEW_PG_URL = {
+      sopsFile = ../../../../secrets/agentsview.yaml;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    sops.templates."agentsview.env" = {
+      content = ''
+        AGENTSVIEW_PG_URL=${config.sops.placeholder.AGENTSVIEW_PG_URL}
+      '';
+      owner = "agentsview";
+      group = "agentsview";
+      mode = "0400";
+    };
+  };
+}

--- a/nixos/_mixins/server/agentsview/default.nix
+++ b/nixos/_mixins/server/agentsview/default.nix
@@ -4,6 +4,13 @@
   noughtyLib,
   ...
 }:
+let
+  inherit (config.noughty) host;
+  basePath = "/agentsview";
+  # Keep this in sync with the `--port` flag in module.nix; AgentsView listens
+  # on localhost only and Caddy reverse-proxies into it.
+  agentsviewPort = 18080;
+in
 {
   imports = [
     ./module.nix
@@ -11,6 +18,17 @@
 
   config = lib.mkIf (noughtyLib.hostHasTag "agentsview") {
     environment.shellAliases.agentsview-log = "journalctl _SYSTEMD_UNIT=agentsview.service";
+
+    # Reverse proxy AgentsView at /agentsview when Caddy and Tailscale are
+    # enabled. AgentsView is launched with `--base-path /agentsview`, so it
+    # already serves on the prefixed path; forward the path through verbatim
+    # rather than stripping it. Mirrors the scrutiny / netdata pattern.
+    services.caddy.virtualHosts."${host.name}.${config.noughty.network.tailNet}".extraConfig =
+      lib.mkIf (config.services.caddy.enable && config.services.tailscale.enable)
+        ''
+          redir ${basePath} ${basePath}/
+          reverse_proxy ${basePath}/* localhost:${toString agentsviewPort}
+        '';
 
     # The sops secret stores AGENTSVIEW_PG_URL as a raw URL value, not a
     # KEY=VALUE pair, so it cannot be passed directly to systemd's

--- a/nixos/_mixins/server/agentsview/module.nix
+++ b/nixos/_mixins/server/agentsview/module.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  inputs,
+  lib,
+  noughtyLib,
+  pkgs,
+  ...
+}:
+let
+  agentsviewPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.agentsview;
+in
+lib.mkIf (noughtyLib.hostHasTag "agentsview") {
+  # Static system user for the agentsview service. A static UID lets the sops
+  # template that holds the PG URL be owned by `agentsview` directly, which is
+  # simpler than the LoadCredential dance required by DynamicUser. This also
+  # matches the static-user shape of the librechat hardening template the unit
+  # below is based on.
+  users.users.agentsview = {
+    isSystemUser = true;
+    group = "agentsview";
+    description = "AgentsView read-only PostgreSQL dashboard";
+  };
+  users.groups.agentsview = { };
+
+  systemd.services.agentsview = {
+    description = "AgentsView read-only dashboard (PostgreSQL-backed)";
+    after = [
+      "postgresql.service"
+      "network-online.target"
+    ];
+    wants = [
+      "postgresql.service"
+      "network-online.target"
+    ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "simple";
+      # AgentsView 0.29.0 takes host/port/base-path as CLI flags only; there
+      # is no PG_SERVE / AGENTSVIEW_PORT / AGENTSVIEW_LISTEN env var. The only
+      # env var consumed for `pg serve` is AGENTSVIEW_PG_URL, supplied via the
+      # sops-templated EnvironmentFile.
+      ExecStart = lib.concatStringsSep " " [
+        "${agentsviewPackage}/bin/agentsview"
+        "pg"
+        "serve"
+        "--host"
+        "127.0.0.1"
+        "--port"
+        "18080"
+        "--base-path"
+        "/agentsview"
+        "--no-browser"
+        "--no-update-check"
+      ];
+      EnvironmentFile = config.sops.templates."agentsview.env".path;
+
+      User = "agentsview";
+      Group = "agentsview";
+      StateDirectory = "agentsview";
+      StateDirectoryMode = "0750";
+
+      Restart = "on-failure";
+      RestartSec = 5;
+
+      # Hardening, copied from the librechat cloudflared-librechat unit
+      # (nixos/_mixins/server/librechat/default.nix:212-247).
+      NoNewPrivileges = true;
+      PrivateTmp = true;
+      ProtectSystem = "strict";
+      ProtectHome = true;
+      ProtectControlGroups = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+    };
+  };
+}

--- a/nixos/_mixins/server/agentsview/module.nix
+++ b/nixos/_mixins/server/agentsview/module.nix
@@ -38,7 +38,10 @@ lib.mkIf (noughtyLib.hostHasTag "agentsview") {
       # AgentsView 0.29.0 takes host/port/base-path as CLI flags only; there
       # is no PG_SERVE / AGENTSVIEW_PORT / AGENTSVIEW_LISTEN env var. The only
       # env var consumed for `pg serve` is AGENTSVIEW_PG_URL, supplied via the
-      # sops-templated EnvironmentFile.
+      # sops-templated EnvironmentFile. `--public-url` tells AgentsView which
+      # browser origin (via Caddy) is trusted; without it, requests proxied
+      # from the tailnet hostname prompt for a bearer token even though the
+      # tailnet itself is the auth boundary.
       ExecStart = lib.concatStringsSep " " [
         "${agentsviewPackage}/bin/agentsview"
         "pg"
@@ -49,6 +52,8 @@ lib.mkIf (noughtyLib.hostHasTag "agentsview") {
         "18080"
         "--base-path"
         "/agentsview"
+        "--public-url"
+        "https://${config.noughty.host.name}.${config.noughty.network.tailNet}"
         "--no-browser"
         "--no-update-check"
       ];

--- a/nixos/_mixins/server/agentsview/module.nix
+++ b/nixos/_mixins/server/agentsview/module.nix
@@ -53,6 +53,10 @@ lib.mkIf (noughtyLib.hostHasTag "agentsview") {
         "--no-update-check"
       ];
       EnvironmentFile = config.sops.templates."agentsview.env".path;
+      # AgentsView writes a small SQLite/cursor cache alongside its config; the
+      # default location is $HOME/.agentsview, which for systemd-managed users
+      # is /var/empty (read-only). Point it at the StateDirectory instead.
+      Environment = [ "AGENTSVIEW_DATA_DIR=/var/lib/agentsview" ];
 
       User = "agentsview";
       Group = "agentsview";

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -10,6 +10,7 @@ let
   aiSopsFile = ../../../../secrets + "/ai.yaml";
   bondSopsFile = ../../../../secrets + "/hermes-bond.yaml";
   hermesSopsFile = ../../../../secrets + "/hermes.yaml";
+  agentsviewSopsFile = ../../../../secrets + "/agentsview.yaml";
   cloudflareSopsFile = ../../../../secrets + "/cloudflare.yaml";
   hasCloudflareSopsFile = builtins.pathExists cloudflareSopsFile;
   mcpSopsFile = ../../../../secrets + "/mcp.yaml";
@@ -17,6 +18,8 @@ let
   claudePackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
   codexPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex;
   agentBrowserPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.agent-browser;
+  agentsviewPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.agentsview;
+  agentsviewConfigPython = pkgs.python3.withPackages (pythonPackages: [ pythonPackages.tomlkit ]);
   # Determinate Nix CLI, matching the host-level installation, so agent shells
   # expose the same `nix` CLI rather than stock upstream nixpkgs Nix. The
   # `determinate` flake's `packages.default` is `determinate-nixd` (the daemon
@@ -24,6 +27,9 @@ let
   nixPackage = inputs.determinate.inputs.nix.packages.${pkgs.stdenv.hostPlatform.system}.default;
   inherit (config.noughty) host;
   hermesHome = "${config.services.hermes-agent.stateDir}/.hermes";
+  hermesAgentsviewDataDir = "${config.services.hermes-agent.stateDir}/.agentsview";
+  hermesAgentsviewConfigPath = "${hermesAgentsviewDataDir}/config.toml";
+  hermesAgentsviewMachine = "${host.name}-hermes";
   hermesDashboardHost = "127.0.0.1";
   hermesDashboardPort = 9119;
   piperVoiceRevision = "7a6c333ec560f0e688371adc2fbb7bbe105028c6";
@@ -529,6 +535,14 @@ in
         mode = "0400";
       };
 
+      HERMES_AGENTSVIEW_PG_URL = {
+        sopsFile = agentsviewSopsFile;
+        key = "AGENTSVIEW_PG_URL";
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+
       EMAIL_ADDRESS = {
         sopsFile = trayaSopsFile;
         owner = "root";
@@ -605,6 +619,18 @@ in
       owner = "root";
       group = "root";
       mode = "0400";
+    };
+
+    sops.templates."hermes-agentsview-env" = {
+      content = ''
+        AGENTSVIEW_PG_URL=${config.sops.placeholder.HERMES_AGENTSVIEW_PG_URL}
+        AGENTSVIEW_PG_SCHEMA=agentsview
+        AGENTSVIEW_PG_MACHINE=${hermesAgentsviewMachine}
+        AGENTSVIEW_DISABLE_UPDATE_CHECK=1
+      '';
+      owner = hermesUser;
+      group = hermesGroup;
+      mode = "0440";
     };
 
     sops.templates."hermes-soul" = {
@@ -926,6 +952,54 @@ in
       };
     };
 
+    systemd.services.hermes-agentsview-pg-push = {
+      description = "Push Hermes AgentsView data to PostgreSQL";
+      after = [
+        "network-online.target"
+        "postgresql.service"
+      ];
+      wants = [
+        "network-online.target"
+        "postgresql.service"
+      ];
+      environment = {
+        AGENTSVIEW_DATA_DIR = hermesAgentsviewDataDir;
+        HERMES_SESSIONS_DIR = "${hermesHome}/sessions";
+        HOME = config.services.hermes-agent.stateDir;
+      };
+      serviceConfig = {
+        Type = "exec";
+        User = hermesUser;
+        Group = hermesGroup;
+        WorkingDirectory = config.services.hermes-agent.stateDir;
+        EnvironmentFile = config.sops.templates."hermes-agentsview-env".path;
+        ExecStart = "${agentsviewPackage}/bin/agentsview pg push";
+        UMask = "0007";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ config.services.hermes-agent.stateDir ];
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+      };
+    };
+
+    systemd.timers.hermes-agentsview-pg-push = {
+      description = "Push Hermes AgentsView data to PostgreSQL on a schedule";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "7m";
+        OnUnitActiveSec = "15m";
+        RandomizedDelaySec = "2m";
+        Persistent = true;
+        Unit = "hermes-agentsview-pg-push.service";
+      };
+    };
+
     services.caddy.virtualHosts."${config.noughty.host.name}.${config.noughty.network.tailNet}".extraConfig =
       lib.mkIf (config.services.caddy.enable && config.services.tailscale.enable) ''
         @hermesDashboard not path /agentsview* /syncthing* /netdata* /scrutiny* /novnc*
@@ -955,6 +1029,39 @@ in
       # Revan's Hermes config is Nix-managed, so replace the whole file after
       # that merge to prevent stale providers and retired settings lingering.
       install -m 0640 -o ${hermesUser} -g ${hermesGroup} ${managedHermesConfig} ${hermesHome}/config.yaml
+    '';
+
+    system.activationScripts.hermes-agentsview-config = lib.stringAfter [ "hermes-agent-setup" ] ''
+      ${agentsviewConfigPython}/bin/python - <<'PY'
+      import pathlib
+      import tomlkit
+
+      path = pathlib.Path("${hermesAgentsviewConfigPath}")
+      path.parent.mkdir(mode=0o750, parents=True, exist_ok=True)
+
+      if path.exists() and path.is_file():
+          document = tomlkit.parse(path.read_text(encoding="utf-8"))
+      else:
+          document = tomlkit.document()
+
+      pg = document.get("pg")
+      if pg is None or not hasattr(pg, "__setitem__"):
+          pg = tomlkit.table()
+          document["pg"] = pg
+
+      pg["schema"] = "agentsview"
+      pg["machine_name"] = "${hermesAgentsviewMachine}"
+      pg["allow_insecure"] = True
+
+      tmp = path.with_name(f"{path.name}.tmp")
+      tmp.write_text(tomlkit.dumps(document), encoding="utf-8")
+      tmp.chmod(0o640)
+      tmp.replace(path)
+      PY
+
+      chown -R ${hermesUser}:${hermesGroup} ${hermesAgentsviewDataDir}
+      chmod 0750 ${hermesAgentsviewDataDir}
+      chmod 0640 ${hermesAgentsviewConfigPath}
     '';
 
     systemd.services.cloudflared-hermes = lib.mkIf hasCloudflareSopsFile {
@@ -1005,6 +1112,7 @@ in
       "d ${tinytuyaConfigDir} 2750 ${hermesUser} ${hermesGroup} - -"
       "d ${hermesSshDir} 0700 ${hermesUser} ${hermesGroup} - -"
       "d ${hermesGnupgHome} 0700 ${hermesUser} ${hermesGroup} - -"
+      "d ${hermesAgentsviewDataDir} 0750 ${hermesUser} ${hermesGroup} - -"
       "d ${hermesHome}/skills 2770 ${hermesUser} ${hermesGroup} - -"
       "d ${hermesHome}/skills/traya 2770 ${hermesUser} ${hermesGroup} - -"
       "d ${openhueConfigDir} 2770 ${hermesUser} ${hermesGroup} - -"

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -928,7 +928,7 @@ in
 
     services.caddy.virtualHosts."${config.noughty.host.name}.${config.noughty.network.tailNet}".extraConfig =
       lib.mkIf (config.services.caddy.enable && config.services.tailscale.enable) ''
-        @hermesDashboard not path /syncthing* /netdata* /scrutiny* /novnc*
+        @hermesDashboard not path /agentsview* /syncthing* /netdata* /scrutiny* /novnc*
         reverse_proxy @hermesDashboard ${hermesDashboardHost}:${toString hermesDashboardPort} {
           header_up Host ${hermesDashboardHost}:${toString hermesDashboardPort}
         }

--- a/nixos/_mixins/server/postgresql/default.nix
+++ b/nixos/_mixins/server/postgresql/default.nix
@@ -1,0 +1,76 @@
+{
+  config,
+  lib,
+  noughtyLib,
+  pkgs,
+  ...
+}:
+# Network exposure policy (proposal Risk 5):
+# PostgreSQL listens on every interface (listen_addresses = '*') and access is
+# restricted in `authentication` (pg_hba.conf). The tailscale interface is the
+# only non-loopback access path and is treated as trusted (no host-firewall
+# rules). Tailscale's default CGNAT ranges (100.64.0.0/10 for IPv4 and
+# fd7a:115c:a1e0::/48 for IPv6) gate access to the `agentsview` database.
+# No 0.0.0.0/0 rule.
+lib.mkIf (noughtyLib.hostHasTag "postgres") {
+  sops.secrets.AGENTSVIEW_PG_PASSWORD = {
+    sopsFile = ../../../../secrets/agentsview.yaml;
+    path = "/run/secrets/AGENTSVIEW_PG_PASSWORD";
+    owner = "postgres";
+    group = "postgres";
+    mode = "0400";
+  };
+
+  services.postgresql = {
+    enable = true;
+    # Pin to postgresql_18 (18.4): latest upstream stable, available in both
+    # nixpkgs 25.11 and nixpkgs-unstable (proxy for 26.05). Pinning explicitly
+    # means the channel bump will not silently migrate the data directory to a
+    # newer major; revisit with pg_upgrade when 19 lands and matures.
+    package = pkgs.postgresql_18;
+
+    ensureDatabases = [ "agentsview" ];
+    ensureUsers = [
+      {
+        name = "agentsview";
+        ensureDBOwnership = true;
+      }
+    ];
+
+    settings = {
+      listen_addresses = lib.mkDefault "*";
+    };
+
+    authentication = lib.mkOverride 10 ''
+      # TYPE  DATABASE     USER         ADDRESS              METHOD
+      local   all          all                               peer
+      host    all          all          127.0.0.1/32         scram-sha-256
+      host    all          all          ::1/128              scram-sha-256
+      host    agentsview   agentsview   100.64.0.0/10        scram-sha-256
+      host    agentsview   agentsview   fd7a:115c:a1e0::/48  scram-sha-256
+    '';
+  };
+
+  # Apply the agentsview role password from sops on every start. `initialScript`
+  # only runs on the first init, so it cannot rotate the password when the sops
+  # value changes. `postStart` runs idempotently after the upstream ensureUsers
+  # logic and survives password rotation.
+  systemd.services.postgresql.postStart = lib.mkAfter ''
+    $PSQL -tAc "ALTER ROLE agentsview WITH PASSWORD '$(<${config.sops.secrets.AGENTSVIEW_PG_PASSWORD.path})';"
+  '';
+
+  # Native pg_dump backups to /mnt/snapshot/backup-postgres. Retention policy
+  # deferred (proposal Risk 7); revisit when /mnt/snapshot pressure warrants.
+  services.postgresqlBackup = {
+    enable = true;
+    databases = [ "agentsview" ];
+    location = "/mnt/snapshot/backup-postgres";
+    compression = "zstd";
+  };
+
+  systemd.tmpfiles.rules = [
+    "d /mnt/snapshot/backup-postgres 0700 postgres postgres -"
+  ];
+
+  environment.shellAliases.postgresql-log = "journalctl _SYSTEMD_UNIT=postgresql.service";
+}

--- a/nixos/_mixins/server/postgresql/default.nix
+++ b/nixos/_mixins/server/postgresql/default.nix
@@ -38,7 +38,11 @@ lib.mkIf (noughtyLib.hostHasTag "postgres") {
     ];
 
     settings = {
-      listen_addresses = lib.mkDefault "*";
+      # Force "*" because the upstream NixOS module sets a non-mkDefault value
+      # for `listen_addresses` (loopback only); without mkForce, `mkDefault "*"`
+      # loses the priority fight and PG only binds 127.0.0.1 / ::1. Access is
+      # still tightly restricted at the pg_hba layer below.
+      listen_addresses = lib.mkForce "*";
     };
 
     authentication = lib.mkOverride 10 ''

--- a/nixos/_mixins/server/postgresql/default.nix
+++ b/nixos/_mixins/server/postgresql/default.nix
@@ -54,9 +54,11 @@ lib.mkIf (noughtyLib.hostHasTag "postgres") {
   # Apply the agentsview role password from sops on every start. `initialScript`
   # only runs on the first init, so it cannot rotate the password when the sops
   # value changes. `postStart` runs idempotently after the upstream ensureUsers
-  # logic and survives password rotation.
+  # logic and survives password rotation. Use the absolute path to `psql` and
+  # connect via the local Unix socket; the upstream postStart no longer exposes
+  # a `$PSQL` helper variable in NixOS 25.11.
   systemd.services.postgresql.postStart = lib.mkAfter ''
-    $PSQL -tAc "ALTER ROLE agentsview WITH PASSWORD '$(<${config.sops.secrets.AGENTSVIEW_PG_PASSWORD.path})';"
+    ${config.services.postgresql.package}/bin/psql -h /run/postgresql -tAc "ALTER ROLE agentsview WITH PASSWORD '$(<${config.sops.secrets.AGENTSVIEW_PG_PASSWORD.path})';"
   '';
 
   # Native pg_dump backups to /mnt/snapshot/backup-postgres. Retention policy

--- a/nixos/_mixins/server/postgresql/default.nix
+++ b/nixos/_mixins/server/postgresql/default.nix
@@ -51,13 +51,14 @@ lib.mkIf (noughtyLib.hostHasTag "postgres") {
     '';
   };
 
-  # Apply the agentsview role password from sops on every start. `initialScript`
-  # only runs on the first init, so it cannot rotate the password when the sops
-  # value changes. `postStart` runs idempotently after the upstream ensureUsers
-  # logic and survives password rotation. Use the absolute path to `psql` and
-  # connect via the local Unix socket; the upstream postStart no longer exposes
-  # a `$PSQL` helper variable in NixOS 25.11.
-  systemd.services.postgresql.postStart = lib.mkAfter ''
+  # Apply the agentsview role password from sops after the upstream
+  # postgresql-setup oneshot has created the role via `ensureUsers`. Attaching
+  # to `postgresql.service.postStart` is too early in NixOS 25.11 because role
+  # creation moved into a separate `postgresql-setup.service` unit. `ALTER ROLE`
+  # is idempotent and re-applies on every restart of postgresql-setup, so this
+  # also handles password rotation (rotate the sops value, then
+  # `systemctl restart postgresql-setup.service`).
+  systemd.services.postgresql-setup.postStart = lib.mkAfter ''
     ${config.services.postgresql.package}/bin/psql -h /run/postgresql -tAc "ALTER ROLE agentsview WITH PASSWORD '$(<${config.sops.secrets.AGENTSVIEW_PG_PASSWORD.path})';"
   '';
 

--- a/nixos/_mixins/server/postgresql/default.nix
+++ b/nixos/_mixins/server/postgresql/default.nix
@@ -63,7 +63,10 @@ lib.mkIf (noughtyLib.hostHasTag "postgres") {
   # also handles password rotation (rotate the sops value, then
   # `systemctl restart postgresql-setup.service`).
   systemd.services.postgresql-setup.postStart = lib.mkAfter ''
-    ${config.services.postgresql.package}/bin/psql -h /run/postgresql -tAc "ALTER ROLE agentsview WITH PASSWORD '$(<${config.sops.secrets.AGENTSVIEW_PG_PASSWORD.path})';"
+    ${config.services.postgresql.package}/bin/psql -h /run/postgresql --no-psqlrc -v ON_ERROR_STOP=1 <<'SQL'
+    \set role_password `${pkgs.coreutils}/bin/cat ${config.sops.secrets.AGENTSVIEW_PG_PASSWORD.path}`
+    ALTER ROLE agentsview WITH PASSWORD :'role_password';
+    SQL
   '';
 
   # Native pg_dump backups to /mnt/snapshot/backup-postgres. Retention policy

--- a/secrets/agentsview.yaml
+++ b/secrets/agentsview.yaml
@@ -1,5 +1,5 @@
 AGENTSVIEW_PG_PASSWORD: ENC[AES256_GCM,data:t4yTi++/YhxCqKRrTVHV6VqmOQxhjHbZzWAJmfTRtsEmgX7hKK4PwShfIAUkjPdH,iv:1rtSOIe53T3XWPAkdn5lxvJ6Loteu/sDC+BgmVSmNz8=,tag:4/834UTiPgxhzqtT5WwbkA==,type:str]
-AGENTSVIEW_PG_URL: ENC[AES256_GCM,data:W2qm6ahm7E9DZ8JY2qvQBKtR7oTSYJ5x047pWy46/yY61apRreGMkP0JSgfFkKLUrG2hT8ilgqZ6+2Z1p6vWakyRCOi+7eVMY+I7VBLWiIhdbeGSOkcih6s6OpjI71AmrdEmKkdKSVBXXG9JhvX8/Q==,iv:kf/Ocfr+N0KW8U5Zak5kMO8JioDgTpenCtBj5Knnt4o=,tag:uzTVCLbBXgftO4x1hTaUlw==,type:str]
+AGENTSVIEW_PG_URL: ENC[AES256_GCM,data:RVKcNnHUWvyFA6G/7PCszn4zcGlahIwrOd8P5P0y+n9Iw0Km1wKhoghetCp4ECEIOaEnizFbQU3AL8AjOH1eUxzRDa4TwmyFh2a4Fbj5zbWuLvUKsrZKxQhodGpsnIRJJwtAnNQj2yYm78JAuRmDHiELltcp7cppfKc+PRdx/Cc=,iv:ySlsXxg0xT8dhNGW52ZKhpDrMg+mkNKz4ULB/xKtOaw=,tag:PyFKPF1BYgh6g/tT5QCL3A==,type:str]
 sops:
     age:
         - recipient: age1xfpzwdsz06243ndj39x4yr2qs4u3ja777r3xautdtm59j54wa3kssualcn
@@ -38,7 +38,7 @@ sops:
             L0RlVFJyMjgxK1ROMmR5bjdVZFhMUmMKl8KDOXo7kF/JVUcZg4rYdCHlv0R3Z03t
             mgbdvynU37PIU0MjAaLrO3Oe0UlYK22NNPaD5qZB/D/uEUUJ3JO6pA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-21T11:21:38Z"
-    mac: ENC[AES256_GCM,data:++NQt/ElZvujnEKXDRyVEBl/5VBN09V8GvgweUr2OFEnFBazyYJkg93ZYpNiswxkEsNcHi7IvYrH4vWg1a4MgHk5oDOm7eE4vtLjY4f8gm606TCtf90bzlOW59DgVCJIekdqGgv8YcYiluZsEqrmb5tUFopC+oavhCSUxI9TbbU=,iv:bncsUAt7y4sTwWloTYelHHg6lb9SjemR7BDwgGumloE=,tag:uzqCh5K47WC4R+iSLvOTbw==,type:str]
+    lastmodified: "2026-05-21T12:09:03Z"
+    mac: ENC[AES256_GCM,data:TEaSOidNimQRGf9g2l9jVZe32gk1Gj14QrzK11KN6krBurvZZKbnnp0KZbLHCY8705wqOcnCEkHhXFTfnjgf5c3EHdztGP1bIZxJzlRKLEx47sQJIQjpMDQIeiTTmJ0sqaeOAufll4k+GsF+KBjH1RJ4CrKJq3T2SMrcxO1FcUQ=,iv:6Fe6I+WtB8C063MLR3BvqkzIOv6bSuEMTJQOVLZv/7A=,tag:KEShzif2fhpL5v3/yR7yQw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1

--- a/secrets/agentsview.yaml
+++ b/secrets/agentsview.yaml
@@ -1,0 +1,44 @@
+AGENTSVIEW_PG_PASSWORD: ENC[AES256_GCM,data:t4yTi++/YhxCqKRrTVHV6VqmOQxhjHbZzWAJmfTRtsEmgX7hKK4PwShfIAUkjPdH,iv:1rtSOIe53T3XWPAkdn5lxvJ6Loteu/sDC+BgmVSmNz8=,tag:4/834UTiPgxhzqtT5WwbkA==,type:str]
+AGENTSVIEW_PG_URL: ENC[AES256_GCM,data:4DhsOjNX+LHz02TSc+5gZ1TvvMJJkz9BfnQiokxeKsuQudADWvCWE/bWcl3b4KamFDnuVLKxHHGBIh4J/U/w2KnsyJi7gKp9oog=,iv:qQNFwmflKLAF+dBzCMUHEIOAX8b9ZJlbVXIyjDqi9Yg=,tag:+cVHAiBN9UFhDO6YTNVp4Q==,type:str]
+sops:
+    age:
+        - recipient: age1xfpzwdsz06243ndj39x4yr2qs4u3ja777r3xautdtm59j54wa3kssualcn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2aFpEdnBWakNOMmt2c1Az
+            eldTcldJSFJqb2tOb1VVd3BQV3crZEVLRXpjClp4VUxZZy94ekZwOTE4dG1aQjU0
+            WGt5SitNZ09qTkdQSkM5N1NpVXdONkEKLS0tIE00SEJUNCtNdndsVXZNUG1SU3ZF
+            WmdqdjB6U1JtSTFLREM4UU1FcWJaeDgKDkaiLMdEhrRrz7AZhp698Vom3PnkKCc8
+            tmPZL9ZBxowBfh3gfwjoJ/zvE+41qYI0SRdmv1QPjJ3vv8Eq5ArNyw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1v5c455hd0shs745dhd3gl7kzw6zaqflnyl4v96pq56j96xyvvc5sgse0za
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQQVlwOGNPUzR4S0dZeG83
+            SkJXRis1c2lzZ1dwVnhsLzlBUzRVTG9xc3pBClJ6U1d0RjNDbFJqdUFNb1ZvNkh6
+            OWJTUFBBVjEzYTYyaXlUeGM2TEpEUnMKLS0tIEh6cnZDMXlqdjZRR1o3aUJ4RWRD
+            eDNYMkMzaEV5WFNqUVcxd1JlVGp0WmMKDN9FHl+LRVDm2Lh41Sc6GuzQBphe2N9D
+            sQ+V7n7GJn+UP9WFeiQuPGnlxrQDlGUXg+Jg5Kfz/1njpJLH6lX+9w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1pyd2u05gah05us62wf3msjktsgu2vgv80c9cag88wwsy64qp6gvqhlj55k
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMNmFNK0pabVc3K0hvcXFH
+            WkpDeitaOFVCZzVUUGtqZ3oyVUFRQlNPVWlFCmZSZzh3SnJLUTcwbFJ3cnNRdFJ6
+            MWpiTmI0b0ZaRVEwK0doZ0VuZXY1ekEKLS0tIFV2aStRalRVendkS2xibmxiMzZl
+            RzNPc0ZqVmhjLzVzUC9TYjFUT3BWV1kKI5G50AgaY/1+renonMdv9qLRsHNB3cX+
+            cbouKDq7vmDdvZ0p4uRwpq4rlpHTCQpmrgdljJGfTLyn499y4hm/nA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1ueuse0p74zqh7jcm5n97ajfw4az2cpf7pjl9q6zv475jdcepeujq8xlv23
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqQzFKZTlrTWM5SDJSN1pD
+            VXZwcHJyM0NEZllJQVNTMWFwczZOVGFhblhjCmhLZzVKeWdXKysxczNvd2hRTnhm
+            TmRXWTROOStKNFptM1FpYUl2b0piQUEKLS0tIFcyblA2Z3RsWXNkazFlbEpobjZV
+            L0RlVFJyMjgxK1ROMmR5bjdVZFhMUmMKl8KDOXo7kF/JVUcZg4rYdCHlv0R3Z03t
+            mgbdvynU37PIU0MjAaLrO3Oe0UlYK22NNPaD5qZB/D/uEUUJ3JO6pA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-21T10:26:17Z"
+    mac: ENC[AES256_GCM,data:TNFAEv2btgb9Z56C8lcYInHiyumv9ocS+MmsBOPIQiWFvF0SNIYYzgzU6lf9Ew6M6yhLCLuTcbXLddzqVbAKrvyiJWkFhSsxX5al8qf7wNSussGrt1QvXi8qbu8hNFv3PpLOzti3vQYfI5Ubrg+h7nDspKt0Bg8WqHOY38hWK3g=,iv:T9tCn2jfJgdD9RajgncrS58ONp0lgPLy1bhWKoUQXuQ=,tag:trcc2iwMSc9sDMCmsRpKkA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.1

--- a/secrets/agentsview.yaml
+++ b/secrets/agentsview.yaml
@@ -1,5 +1,5 @@
 AGENTSVIEW_PG_PASSWORD: ENC[AES256_GCM,data:t4yTi++/YhxCqKRrTVHV6VqmOQxhjHbZzWAJmfTRtsEmgX7hKK4PwShfIAUkjPdH,iv:1rtSOIe53T3XWPAkdn5lxvJ6Loteu/sDC+BgmVSmNz8=,tag:4/834UTiPgxhzqtT5WwbkA==,type:str]
-AGENTSVIEW_PG_URL: ENC[AES256_GCM,data:4DhsOjNX+LHz02TSc+5gZ1TvvMJJkz9BfnQiokxeKsuQudADWvCWE/bWcl3b4KamFDnuVLKxHHGBIh4J/U/w2KnsyJi7gKp9oog=,iv:qQNFwmflKLAF+dBzCMUHEIOAX8b9ZJlbVXIyjDqi9Yg=,tag:+cVHAiBN9UFhDO6YTNVp4Q==,type:str]
+AGENTSVIEW_PG_URL: ENC[AES256_GCM,data:W2qm6ahm7E9DZ8JY2qvQBKtR7oTSYJ5x047pWy46/yY61apRreGMkP0JSgfFkKLUrG2hT8ilgqZ6+2Z1p6vWakyRCOi+7eVMY+I7VBLWiIhdbeGSOkcih6s6OpjI71AmrdEmKkdKSVBXXG9JhvX8/Q==,iv:kf/Ocfr+N0KW8U5Zak5kMO8JioDgTpenCtBj5Knnt4o=,tag:uzTVCLbBXgftO4x1hTaUlw==,type:str]
 sops:
     age:
         - recipient: age1xfpzwdsz06243ndj39x4yr2qs4u3ja777r3xautdtm59j54wa3kssualcn
@@ -38,7 +38,7 @@ sops:
             L0RlVFJyMjgxK1ROMmR5bjdVZFhMUmMKl8KDOXo7kF/JVUcZg4rYdCHlv0R3Z03t
             mgbdvynU37PIU0MjAaLrO3Oe0UlYK22NNPaD5qZB/D/uEUUJ3JO6pA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-21T10:26:17Z"
-    mac: ENC[AES256_GCM,data:TNFAEv2btgb9Z56C8lcYInHiyumv9ocS+MmsBOPIQiWFvF0SNIYYzgzU6lf9Ew6M6yhLCLuTcbXLddzqVbAKrvyiJWkFhSsxX5al8qf7wNSussGrt1QvXi8qbu8hNFv3PpLOzti3vQYfI5Ubrg+h7nDspKt0Bg8WqHOY38hWK3g=,iv:T9tCn2jfJgdD9RajgncrS58ONp0lgPLy1bhWKoUQXuQ=,tag:trcc2iwMSc9sDMCmsRpKkA==,type:str]
+    lastmodified: "2026-05-21T11:21:38Z"
+    mac: ENC[AES256_GCM,data:++NQt/ElZvujnEKXDRyVEBl/5VBN09V8GvgweUr2OFEnFBazyYJkg93ZYpNiswxkEsNcHi7IvYrH4vWg1a4MgHk5oDOm7eE4vtLjY4f8gm606TCtf90bzlOW59DgVCJIekdqGgv8YcYiluZsEqrmb5tUFopC+oavhCSUxI9TbbU=,iv:bncsUAt7y4sTwWloTYelHHg6lb9SjemR7BDwgGumloE=,tag:uzqCh5K47WC4R+iSLvOTbw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION
## Summary
Add the AgentsView deployment stack for Hermes, including server-side PostgreSQL support, the dashboard service, Home Manager sync, proxying, and documentation.

## Changes
- Add the NixOS AgentsView server mixin and read-only dashboard service.
- Add PostgreSQL support for the AgentsView database and credential handling.
- Wire Hermes for AgentsView tags, bind-address fixes, and public URL handling.
- Add the Home Manager sync mixin for user-side integration.
- Add documentation and the encrypted AgentsView secret.
- Remove the obsolete `ccusage` agentic mixin reference.

## Testing
- No runtime validation run during PR creation.
- `git status` confirms the branch is pushed to `origin/agentsview`.

## Related Issues
None