### PR TITLE
feat(home-manager): add fresh editor

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -158,6 +158,21 @@
         "url": "https://flakehub.com/f/ipetkov/crane/0"
       }
     },
+    "crane_2": {
+      "locked": {
+        "lastModified": 1765145449,
+        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "determinate": {
       "inputs": {
         "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
@@ -279,6 +294,27 @@
         "url": "https://flakehub.com/f/nix-community/fenix/%3D0.1.2375"
       }
     },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1765435813,
+        "narHash": "sha256-C6tT7K1Lx6VsYw1BY5S3OavtapUvEnDQtmQB5DSgbCc=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "6399553b7a300c77e7f07342904eb696a5b6bf9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "fh": {
       "inputs": {
         "crane": "crane",
@@ -315,6 +351,22 @@
       }
     },
     "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1730663653,
@@ -452,6 +504,32 @@
       "original": {
         "id": "flake-utils",
         "type": "indirect"
+      }
+    },
+    "fresh": {
+      "inputs": {
+        "crane": "crane_2",
+        "fenix": "fenix_2",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779366752,
+        "narHash": "sha256-HMKvqJ69EvlAK2Tc4yeY0mfJgUwFIGyhUWdqqOgu6Ec=",
+        "owner": "sinelaw",
+        "repo": "fresh",
+        "rev": "81bab68c01c09ca3b3e3f9ef7a77cb80328761c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sinelaw",
+        "repo": "fresh",
+        "type": "github"
       }
     },
     "git-hooks-nix": {
@@ -604,7 +682,7 @@
     "mac-app-util": {
       "inputs": {
         "cl-nix-lite": "cl-nix-lite",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
@@ -1007,6 +1085,7 @@
         "fh": "fh",
         "flake-parts": "flake-parts_2",
         "flake-utils": "flake-utils",
+        "fresh": "fresh",
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
         "iwmenu": "iwmenu",
@@ -1037,6 +1116,23 @@
         "owner": "rust-lang",
         "repo": "rust-analyzer",
         "rev": "21614ed2d3279a9aa1f15c88d293e65a98991b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765400135,
+        "narHash": "sha256-D3+4hfNwUhG0fdCpDhOASLwEQ1jKuHi4mV72up4kLQM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "fface27171988b3d605ef45cf986c25533116f7e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,10 @@
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";
     llm-agents.inputs.treefmt-nix.follows = "direnv-instant/treefmt-nix";
     llm-agents.inputs.blueprint.inputs.systems.follows = "systems";
+    fresh.url = "github:sinelaw/fresh";
+    fresh.inputs.nixpkgs.follows = "nixpkgs-unstable";
+    fresh.inputs.flake-parts.follows = "flake-parts";
+    fresh.inputs.fenix.inputs.nixpkgs.follows = "nixpkgs-unstable";
     sidra.url = "github:wimpysworld/sidra";
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     bzmenu.url = "https://github.com/e-tho/bzmenu/archive/refs/tags/v0.3.0.tar.gz";

--- a/home-manager/_mixins/development/fresh/default.nix
+++ b/home-manager/_mixins/development/fresh/default.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.noughty) host;
+  inherit (pkgs.stdenv.hostPlatform) system;
+in
+lib.mkIf host.is.workstation {
+  home.packages = [
+    inputs.fresh.packages.${system}.fresh
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds `github:sinelaw/fresh` as a flake input, following this repo's `nixpkgs-unstable` and shared `flake-parts` inputs where possible.
- Adds `home-manager/_mixins/development/fresh/default.nix` to install Fresh on workstation Home Manager profiles.
- Locks Fresh at `81bab68c01c09ca3b3e3f9ef7a77cb80328761c0`.

## Validation
- `nix eval --impure --raw --expr 'let flake = builtins.getFlake (toString ./.); in flake.inputs.fresh.packages.x86_64-linux.fresh.name'` → `fresh-0.3.8`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); pkgs = flake.homeConfigurations."martin@skrye".config.home.packages; names = map (p: p.name or "") pkgs; in builtins.filter (n: n == "fresh" || builtins.match "fresh-.*" n != null) names'` → `fresh-0.3.8`
- `just eval`
- `nix build --dry-run --impure --expr 'let flake = builtins.getFlake (toString ./.); in flake.inputs.fresh.packages.x86_64-linux.fresh'`
- `nix build --dry-run .#homeConfigurations."martin@skrye".activationPackage`
- `git diff --check`
