### PR TITLE
feat: add Ferdium to workspace systems

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -2,5 +2,6 @@
 # - https://wiki.nixos.org/wiki/NixOS_modules
 {
   falcon-sensor = import ./falcon-sensor.nix;
+  ferdium = import ./ferdium.nix;
   wavebox = import ./wavebox.nix;
 }

--- a/modules/nixos/ferdium.nix
+++ b/modules/nixos/ferdium.nix
@@ -1,0 +1,54 @@
+# Ferdium browser extension management module
+# Based on NixOS's programs.chromium module
+{ config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.ferdium;
+
+  extensionJson = extensions: {
+    ExtensionInstallForcelist = map (
+      id: "${id};https://clients2.google.com/service/update2/crx"
+    ) extensions;
+  };
+in
+{
+  options.programs.ferdium = {
+    enable = mkEnableOption "Ferdium policy deployment";
+
+    extensions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        List of Ferdium extensions to install.
+        Extension IDs from the Chrome Web Store.
+      '';
+      example = literalExpression ''
+        [
+          "mdkgfdijbhbcbajcdlebbodoppgnmhab" # GoLinks
+          "glnpjglilkicbckjpbgcfkogebgllemb" # Okta
+        ]
+      '';
+    };
+
+    extraOpts = mkOption {
+      type = types.attrs;
+      default = { };
+      description = ''
+        Additional Ferdium policy options.
+      '';
+      example = literalExpression ''
+        {
+          "PromptForDownloadLocation" = true;
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."ferdium/policies/managed/extensions.json" = {
+      text = builtins.toJSON (extensionJson cfg.extensions // cfg.extraOpts);
+    };
+  };
+}

--- a/nixos/_mixins/desktop/apps/workspace/default.nix
+++ b/nixos/_mixins/desktop/apps/workspace/default.nix
@@ -64,6 +64,30 @@ let
     ];
   } pkgs.slack;
 
+  workspaceBrowserOpts = {
+    "AutofillAddressEnabled" = false;
+    "AutofillCreditCardEnabled" = false;
+    "PasswordManagerEnabled" = false;
+    "PromptForDownloadLocation" = true;
+    "SpellcheckEnabled" = true;
+    "SpellcheckLanguage" = [
+      "en-GB"
+      "en-US"
+    ];
+  };
+
+  workspaceBrowserExtensions = [
+    "hdokiejnpimakedhajhdlcegeplioahd" # LastPass
+    "lodbfhdipoipcjmlebjbgmmgekckhpfb" # Harper
+    "mdpfkohgfpidohkakdbpmnngaocglmhl" # Disable Ctrl + Scroll Zoom
+    "aeblfdkhhhdcdjpifhhbdiojplfjncoa" # 1Password
+    "mdkgfdijbhbcbajcdlebbodoppgnmhab" # GoLinks
+    "glnpjglilkicbckjpbgcfkogebgllemb" # Okta
+    "cfpdompphcacgpjfbonkdokgjhgabpij" # Glean
+    "idefohglmnkliiadgfofeokcpjobdeik" # Ramp
+    "mfmabgokainekahncfnijjpcfhjendmb" # Meet Linky
+  ];
+
   # Global xdg-open proxy to route specific URLs to Wavebox
   waveboxXdgOpen = inputs.xdg-override.lib.proxyPkg {
     inherit pkgs;
@@ -98,6 +122,7 @@ in
 lib.mkIf (noughtyLib.hostHasTag "workspace") {
   environment.systemPackages = [
     pkgs._1password-gui
+    pkgs.ferdium
     wavebox
     googleMeetDesktopItem
     slackWavebox
@@ -106,27 +131,13 @@ lib.mkIf (noughtyLib.hostHasTag "workspace") {
 
   programs.wavebox = {
     enable = true;
-    extraOpts = {
-      "AutofillAddressEnabled" = false;
-      "AutofillCreditCardEnabled" = false;
-      "PasswordManagerEnabled" = false;
-      "PromptForDownloadLocation" = true;
-      "SpellcheckEnabled" = true;
-      "SpellcheckLanguage" = [
-        "en-GB"
-        "en-US"
-      ];
-    };
-    extensions = [
-      "hdokiejnpimakedhajhdlcegeplioahd" # LastPass
-      "lodbfhdipoipcjmlebjbgmmgekckhpfb" # Harper
-      "mdpfkohgfpidohkakdbpmnngaocglmhl" # Disable Ctrl + Scroll Zoom
-      "aeblfdkhhhdcdjpifhhbdiojplfjncoa" # 1Password
-      "mdkgfdijbhbcbajcdlebbodoppgnmhab" # GoLinks
-      "glnpjglilkicbckjpbgcfkogebgllemb" # Okta
-      "cfpdompphcacgpjfbonkdokgjhgabpij" # Glean
-      "idefohglmnkliiadgfofeokcpjobdeik" # Ramp
-      "mfmabgokainekahncfnijjpcfhjendmb" # Meet Linky
-    ];
+    extraOpts = workspaceBrowserOpts;
+    extensions = workspaceBrowserExtensions;
+  };
+
+  programs.ferdium = {
+    enable = true;
+    extraOpts = workspaceBrowserOpts;
+    extensions = workspaceBrowserExtensions;
   };
 }

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -20,6 +20,7 @@ in
     ../lib/noughty
     # Use modules this flake exports; from modules/nixos
     outputs.nixosModules.falcon-sensor
+    outputs.nixosModules.ferdium
     outputs.nixosModules.wavebox
     # Use modules from other flakes
     inputs.catppuccin.nixosModules.catppuccin

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -10,6 +10,25 @@
   modifiedPackages = final: prev: rec {
     hermesAgent = inputs.hermes-agent.packages.${final.stdenv.hostPlatform.system}.default;
 
+    ferdium = prev.ferdium.overrideAttrs (_old: rec {
+      version = "7.1.3-nightly.3";
+      src = prev.fetchurl {
+        url = "https://github.com/ferdium/ferdium-app/releases/download/v${version}/Ferdium-linux-${version}-${
+          {
+            x86_64-linux = "amd64";
+            aarch64-linux = "arm64";
+          }
+          .${final.stdenv.hostPlatform.system}
+        }.deb";
+        hash =
+          {
+            x86_64-linux = "sha256-FauUQO3FucLpIKxGAalCaD5jPAajXPR1X4yXHBmzqMI=";
+            aarch64-linux = "sha256-wAz2Z0QAkcR/oWdE4AaH9kQoMvOSdWHpLGYjqTJIui4=";
+          }
+          .${final.stdenv.hostPlatform.system};
+      };
+    });
+
     ollama = final.unstable.ollama;
     ollama-cuda = final.unstable.ollama-cuda;
     ollama-rocm = final.unstable.ollama-rocm;


### PR DESCRIPTION
## Summary
- add Ferdium to workspace-tagged systems alongside Wavebox
- add a local `programs.ferdium` policy module mirroring Wavebox extension/policy deployment
- override `pkgs.ferdium` to upstream nightly `7.1.3-nightly.3` for Linux x86_64/aarch64 assets

## Test Plan
- [x] `nix fmt -- nixos/_mixins/desktop/apps/workspace/default.nix overlays/default.nix modules/nixos/ferdium.nix modules/nixos/default.nix nixos/default.nix`
- [x] `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); cfg = flake.nixosConfigurations.bane.config; in { packageMatches = builtins.filter (name: builtins.match ".*[Ff]erdium.*" name != null) (map (p: p.name or "") cfg.environment.systemPackages); policy = builtins.fromJSON cfg.environment.etc."ferdium/policies/managed/extensions.json".text; }' | jq .`
- [x] `nix build --impure --expr 'let flake = builtins.getFlake (toString ./.); pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; overlays = builtins.attrValues flake.outputs.overlays; config.allowUnfree = true; }; in pkgs.ferdium'`
- [x] `git diff --check`
- [x] `just eval`
