### PR TITLE
feat: add Catppuccin themes for Fresh

### DIFF
--- a/home-manager/_mixins/development/fresh/default.nix
+++ b/home-manager/_mixins/development/fresh/default.nix
@@ -8,9 +8,29 @@
 let
   inherit (config.noughty) host;
   inherit (pkgs.stdenv.hostPlatform) system;
+
+  catppuccinFresh = pkgs.fetchFromGitHub {
+    owner = "milon";
+    repo = "catppuccin-fresh";
+    rev = "58093e748cbf90e742c913f469fb20dd6aacba2b";
+    hash = "sha256-C98XNiUtT0/cAbGzjaX+i1vlnFLp1Pf2UpEmk4Qsuoc=";
+  };
 in
 lib.mkIf host.is.workstation {
   home.packages = [
     inputs.fresh.packages.${system}.fresh
   ];
+
+  xdg.configFile = {
+    "fresh/config.json".text = lib.mkDefault (
+      builtins.toJSON {
+        theme = "catppuccin-mocha.json";
+      }
+    );
+
+    "fresh/themes/catppuccin-frappe.json".source = "${catppuccinFresh}/catppuccin-frappe.json";
+    "fresh/themes/catppuccin-latte.json".source = "${catppuccinFresh}/catppuccin-latte.json";
+    "fresh/themes/catppuccin-macchiato.json".source = "${catppuccinFresh}/catppuccin-macchiato.json";
+    "fresh/themes/catppuccin-mocha.json".source = "${catppuccinFresh}/catppuccin-mocha.json";
+  };
 }


### PR DESCRIPTION
## Summary

- Add all four Catppuccin Fresh themes from `milon/catppuccin-fresh` to Fresh's XDG theme directory.
- Set Fresh's default theme to `catppuccin-mocha.json` via Home Manager.
- Keep the theme source pinned with a fixed-output GitHub fetch.

## Validation

- `nix fmt -- home-manager/_mixins/development/fresh/default.nix`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); cfg = flake.homeConfigurations."martin@skrye".config.xdg.configFile; in { config = cfg."fresh/config.json".text; themes = builtins.sort builtins.lessThan (builtins.filter (name: builtins.match "fresh/themes/catppuccin-.*\\.json" name != null) (builtins.attrNames cfg)); }'`
- `git diff --check`
- `just eval`

## Notes

A direct Home Manager activation build on Linux still hits the existing `dockutil` platform guard while evaluating `home.activation.trampolineApps.data`; this is unrelated to this change. The targeted option evaluation and repository `just eval` both pass.
