### PR TITLE
feat(home-manager): configure Fresh language servers

### DIFF
--- a/home-manager/_mixins/development/c/default.nix
+++ b/home-manager/_mixins/development/c/default.nix
@@ -20,6 +20,19 @@ in
     };
   };
 
+  fresh.settings.lsp = {
+    c = {
+      command = "${pkgs.clang-tools}/bin/clangd";
+      enabled = true;
+      auto_start = true;
+    };
+    cpp = {
+      command = "${pkgs.clang-tools}/bin/clangd";
+      enabled = true;
+      auto_start = true;
+    };
+  };
+
   home = {
     packages = with pkgs; [
       bear # Generate compile_commands.json for non-CMake projects

--- a/home-manager/_mixins/development/dart/default.nix
+++ b/home-manager/_mixins/development/dart/default.nix
@@ -13,6 +13,17 @@
     };
   };
 
+  fresh.settings.lsp.dart = {
+    command = "${pkgs.dart}/bin/dart";
+    args = [
+      "language-server"
+      "--protocol=lsp"
+    ];
+    enabled = true;
+    auto_start = true;
+    initialization_options.lineLength = 80;
+  };
+
   home = {
     packages = with pkgs; [
       # lowPrio to avoid bin/resources collision with pkgs.resources (GNOME system monitor)

--- a/home-manager/_mixins/development/fresh/default.nix
+++ b/home-manager/_mixins/development/fresh/default.nix
@@ -16,21 +16,27 @@ let
     hash = "sha256-C98XNiUtT0/cAbGzjaX+i1vlnFLp1Pf2UpEmk4Qsuoc=";
   };
 in
-lib.mkIf host.is.workstation {
-  home.packages = [
-    inputs.fresh.packages.${system}.fresh
-  ];
+{
+  options.fresh.settings = lib.mkOption {
+    type = lib.types.attrsOf lib.types.anything;
+    default = { };
+    description = "Fresh editor settings contributed by development modules, merged into config.json.";
+  };
 
-  xdg.configFile = {
-    "fresh/config.json".text = lib.mkDefault (
-      builtins.toJSON {
-        theme = "catppuccin-mocha.json";
-      }
-    );
+  config = lib.mkIf host.is.workstation {
+    fresh.settings.theme = "catppuccin-mocha.json";
 
-    "fresh/themes/catppuccin-frappe.json".source = "${catppuccinFresh}/catppuccin-frappe.json";
-    "fresh/themes/catppuccin-latte.json".source = "${catppuccinFresh}/catppuccin-latte.json";
-    "fresh/themes/catppuccin-macchiato.json".source = "${catppuccinFresh}/catppuccin-macchiato.json";
-    "fresh/themes/catppuccin-mocha.json".source = "${catppuccinFresh}/catppuccin-mocha.json";
+    home.packages = [
+      inputs.fresh.packages.${system}.fresh
+    ];
+
+    xdg.configFile = {
+      "fresh/config.json".text = lib.mkDefault (builtins.toJSON config.fresh.settings);
+
+      "fresh/themes/catppuccin-frappe.json".source = "${catppuccinFresh}/catppuccin-frappe.json";
+      "fresh/themes/catppuccin-latte.json".source = "${catppuccinFresh}/catppuccin-latte.json";
+      "fresh/themes/catppuccin-macchiato.json".source = "${catppuccinFresh}/catppuccin-macchiato.json";
+      "fresh/themes/catppuccin-mocha.json".source = "${catppuccinFresh}/catppuccin-mocha.json";
+    };
   };
 }

--- a/home-manager/_mixins/development/go/default.nix
+++ b/home-manager/_mixins/development/go/default.nix
@@ -34,6 +34,32 @@
     };
   };
 
+  fresh.settings.lsp.go = [
+    {
+      name = "gopls";
+      command = lib.getExe pkgs.gopls;
+      enabled = true;
+      auto_start = true;
+      root_markers = [
+        "go.mod"
+        "go.work"
+        ".git"
+      ];
+    }
+    {
+      name = "golangci-lint-langserver";
+      command = lib.getExe pkgs.golangci-lint-langserver;
+      enabled = true;
+      auto_start = true;
+      only_features = [ "diagnostics" ];
+      root_markers = [
+        "go.mod"
+        "go.work"
+        ".git"
+      ];
+    }
+  ];
+
   claude-code.lspServers.golangci-lint-langserver = {
     command = lib.getExe pkgs.golangci-lint-langserver;
     extensionToLanguage = {

--- a/home-manager/_mixins/development/harper/default.nix
+++ b/home-manager/_mixins/development/harper/default.nix
@@ -83,6 +83,18 @@ in
     };
   };
 
+  # Fresh Editor - universal grammar and spelling LSP.
+  fresh.settings.universal_lsp.harper = {
+    command = harperLs;
+    args = [ "--stdio" ];
+    enabled = true;
+    auto_start = true;
+    only_features = [ "diagnostics" ];
+    initialization_options = {
+      "harper-ls" = harperSettings;
+    };
+  };
+
   # OpenCode - LSP server.
   programs.opencode.settings.lsp.harper = {
     command = [

--- a/home-manager/_mixins/development/javascript/default.nix
+++ b/home-manager/_mixins/development/javascript/default.nix
@@ -204,4 +204,37 @@
       };
     };
   };
+
+  fresh.settings.lsp = {
+    javascript = {
+      command = lib.getExe pkgs.typescript-language-server;
+      args = [ "--stdio" ];
+      enabled = true;
+      auto_start = true;
+    };
+    typescript = {
+      command = lib.getExe pkgs.typescript-language-server;
+      args = [ "--stdio" ];
+      enabled = true;
+      auto_start = true;
+    };
+    json = {
+      command = "${pkgs.vscode-langservers-extracted}/bin/vscode-json-language-server";
+      args = [ "--stdio" ];
+      enabled = true;
+      auto_start = true;
+    };
+    html = {
+      command = "${pkgs.vscode-langservers-extracted}/bin/vscode-html-language-server";
+      args = [ "--stdio" ];
+      enabled = true;
+      auto_start = true;
+    };
+    css = {
+      command = "${pkgs.vscode-langservers-extracted}/bin/vscode-css-language-server";
+      args = [ "--stdio" ];
+      enabled = true;
+      auto_start = true;
+    };
+  };
 }

--- a/home-manager/_mixins/development/love/default.nix
+++ b/home-manager/_mixins/development/love/default.nix
@@ -18,6 +18,12 @@ lib.mkIf
       };
     };
 
+    fresh.settings.lsp.lua = {
+      command = lib.getExe pkgs.lua-language-server;
+      enabled = true;
+      auto_start = true;
+    };
+
     home = {
       packages = with pkgs; [
         glslang

--- a/home-manager/_mixins/development/nix/default.nix
+++ b/home-manager/_mixins/development/nix/default.nix
@@ -23,6 +23,12 @@
     };
   };
 
+  fresh.settings.lsp.nix = {
+    command = lib.getExe pkgs.nixd;
+    enabled = true;
+    auto_start = true;
+  };
+
   programs = {
     zed-editor = lib.mkIf config.programs.zed-editor.enable {
       userSettings = {

--- a/home-manager/_mixins/development/nix/default.nix
+++ b/home-manager/_mixins/development/nix/default.nix
@@ -8,6 +8,7 @@
   home = {
     packages = with pkgs; [
       deadnix
+      nil
       nixd
       nix-diff
       nixfmt
@@ -24,7 +25,7 @@
   };
 
   fresh.settings.lsp.nix = {
-    command = lib.getExe pkgs.nixd;
+    command = lib.getExe pkgs.nil;
     enabled = true;
     auto_start = true;
   };

--- a/home-manager/_mixins/development/python/default.nix
+++ b/home-manager/_mixins/development/python/default.nix
@@ -25,6 +25,13 @@
     };
   };
 
+  fresh.settings.lsp.python = {
+    command = "${pkgs.basedpyright}/bin/basedpyright-langserver";
+    args = [ "--stdio" ];
+    enabled = true;
+    auto_start = true;
+  };
+
   programs = {
     zed-editor = lib.mkIf config.programs.zed-editor.enable {
       extensions = [

--- a/home-manager/_mixins/development/rust/default.nix
+++ b/home-manager/_mixins/development/rust/default.nix
@@ -18,6 +18,12 @@
     };
   };
 
+  fresh.settings.lsp.rust = {
+    command = lib.getExe pkgs.rust-analyzer;
+    enabled = true;
+    auto_start = true;
+  };
+
   programs = {
     zed-editor = lib.mkIf config.programs.zed-editor.enable {
       extensions = [

--- a/home-manager/_mixins/development/security/default.nix
+++ b/home-manager/_mixins/development/security/default.nix
@@ -86,6 +86,15 @@
     };
   };
 
+  # Fresh Editor - universal static-analysis LSP.
+  fresh.settings.universal_lsp.semgrep = {
+    command = "${pkgs.semgrep}/bin/semgrep";
+    args = [ "lsp" ];
+    enabled = true;
+    auto_start = true;
+    only_features = [ "diagnostics" ];
+  };
+
   # OpenCode - LSP server
   programs.opencode.settings.lsp.semgrep = {
     command = [

--- a/home-manager/_mixins/development/shell/default.nix
+++ b/home-manager/_mixins/development/shell/default.nix
@@ -55,4 +55,11 @@
       ".zsh" = "shellscript";
     };
   };
+
+  fresh.settings.lsp.bash = {
+    command = lib.getExe pkgs.bash-language-server;
+    args = [ "start" ];
+    enabled = true;
+    auto_start = true;
+  };
 }

--- a/home-manager/_mixins/development/svelte/default.nix
+++ b/home-manager/_mixins/development/svelte/default.nix
@@ -55,4 +55,11 @@
       ".svelte" = "svelte";
     };
   };
+
+  fresh.settings.lsp.svelte = {
+    command = lib.getExe pkgs.svelte-language-server;
+    args = [ "--stdio" ];
+    enabled = true;
+    auto_start = true;
+  };
 }

--- a/home-manager/_mixins/development/yaml/default.nix
+++ b/home-manager/_mixins/development/yaml/default.nix
@@ -70,4 +70,12 @@
       ".yml" = "yaml";
     };
   };
+
+  fresh.settings.lsp.yaml = {
+    command = lib.getExe pkgs.yaml-language-server;
+    args = [ "--stdio" ];
+    enabled = true;
+    auto_start = true;
+    initialization_options.yaml.keyOrdering = true;
+  };
 }


### PR DESCRIPTION
## Summary
- Add a Fresh-specific `fresh.settings` collector so language modules can contribute config without competing over `fresh/config.json`.
- Configure Fresh LSPs from the existing Home Manager development ecosystem modules using absolute Nix store paths.
- Add universal Fresh diagnostics for Harper and Semgrep while preserving the existing Catppuccin Fresh theme setup.

## Notes
- This avoids relying on `programs.fresh-editor.extraPackages`, which is not available on the current Home Manager release branch.
- Go keeps Fresh root markers for `go.mod`, `go.work`, and `.git` when using multiple LSP servers.
- Dart keeps Fresh's required `--protocol=lsp` argument.

## Validation
- `nix fmt -- home-manager/_mixins/development/{c,dart,fresh,go,harper,javascript,love,nix,python,rust,security,shell,svelte,yaml}/default.nix`
- `git diff --check`
- `just eval`
- `nix eval --raw '.#homeConfigurations.martin@skrye.config.xdg.configFile."fresh/config.json".text' | jq '. | {theme, lsp_keys:(.lsp|keys), universal_lsp_keys:(.universal_lsp|keys)}'`
