### PR TITLE
fix(home-manager): maintain Fresh Catppuccin themes locally

### DIFF
--- a/home-manager/_mixins/development/fresh/default.nix
+++ b/home-manager/_mixins/development/fresh/default.nix
@@ -8,13 +8,6 @@
 let
   inherit (config.noughty) host;
   inherit (pkgs.stdenv.hostPlatform) system;
-
-  catppuccinFresh = pkgs.fetchFromGitHub {
-    owner = "milon";
-    repo = "catppuccin-fresh";
-    rev = "58093e748cbf90e742c913f469fb20dd6aacba2b";
-    hash = "sha256-C98XNiUtT0/cAbGzjaX+i1vlnFLp1Pf2UpEmk4Qsuoc=";
-  };
 in
 {
   options.fresh.settings = lib.mkOption {
@@ -33,10 +26,10 @@ in
     xdg.configFile = {
       "fresh/config.json".text = lib.mkDefault (builtins.toJSON config.fresh.settings);
 
-      "fresh/themes/catppuccin-frappe.json".source = "${catppuccinFresh}/catppuccin-frappe.json";
-      "fresh/themes/catppuccin-latte.json".source = "${catppuccinFresh}/catppuccin-latte.json";
-      "fresh/themes/catppuccin-macchiato.json".source = "${catppuccinFresh}/catppuccin-macchiato.json";
-      "fresh/themes/catppuccin-mocha.json".source = "${catppuccinFresh}/catppuccin-mocha.json";
+      "fresh/themes/catppuccin-frappe.json".source = ./themes/catppuccin-frappe.json;
+      "fresh/themes/catppuccin-latte.json".source = ./themes/catppuccin-latte.json;
+      "fresh/themes/catppuccin-macchiato.json".source = ./themes/catppuccin-macchiato.json;
+      "fresh/themes/catppuccin-mocha.json".source = ./themes/catppuccin-mocha.json;
     };
   };
 }

--- a/home-manager/_mixins/development/fresh/themes/catppuccin-frappe.json
+++ b/home-manager/_mixins/development/fresh/themes/catppuccin-frappe.json
@@ -1,0 +1,328 @@
+{
+  "name": "catppuccin-frappe",
+  "editor": {
+    "bg": [
+      48,
+      52,
+      70
+    ],
+    "fg": [
+      198,
+      208,
+      245
+    ],
+    "cursor": [
+      242,
+      213,
+      207
+    ],
+    "selection_bg": [
+      81,
+      87,
+      109
+    ],
+    "current_line_bg": [
+      65,
+      69,
+      89
+    ],
+    "line_number_fg": [
+      115,
+      121,
+      148
+    ],
+    "line_number_bg": [
+      48,
+      52,
+      70
+    ]
+  },
+  "ui": {
+    "tab_active_fg": [
+      35,
+      38,
+      52
+    ],
+    "tab_active_bg": [
+      140,
+      170,
+      238
+    ],
+    "tab_inactive_fg": [
+      198,
+      208,
+      245
+    ],
+    "tab_inactive_bg": [
+      81,
+      87,
+      109
+    ],
+    "tab_separator_bg": [
+      48,
+      52,
+      70
+    ],
+    "status_bar_fg": [
+      35,
+      38,
+      52
+    ],
+    "status_bar_bg": [
+      140,
+      170,
+      238
+    ],
+    "prompt_fg": [
+      35,
+      38,
+      52
+    ],
+    "prompt_bg": [
+      166,
+      209,
+      137
+    ],
+    "prompt_selection_fg": [
+      198,
+      208,
+      245
+    ],
+    "prompt_selection_bg": [
+      140,
+      170,
+      238
+    ],
+    "popup_border_fg": [
+      115,
+      121,
+      148
+    ],
+    "popup_bg": [
+      65,
+      69,
+      89
+    ],
+    "popup_selection_bg": [
+      140,
+      170,
+      238
+    ],
+    "popup_text_fg": [
+      198,
+      208,
+      245
+    ],
+    "suggestion_bg": [
+      65,
+      69,
+      89
+    ],
+    "suggestion_selected_bg": [
+      140,
+      170,
+      238
+    ],
+    "help_bg": [
+      48,
+      52,
+      70
+    ],
+    "help_fg": [
+      198,
+      208,
+      245
+    ],
+    "help_key_fg": [
+      153,
+      209,
+      219
+    ],
+    "help_separator_fg": [
+      115,
+      121,
+      148
+    ],
+    "help_indicator_fg": [
+      231,
+      130,
+      132
+    ],
+    "help_indicator_bg": [
+      48,
+      52,
+      70
+    ],
+    "split_separator_fg": [
+      115,
+      121,
+      148
+    ],
+    "menu_bg": [
+      41,
+      44,
+      60
+    ],
+    "menu_fg": [
+      198,
+      208,
+      245
+    ],
+    "menu_active_bg": [
+      81,
+      87,
+      109
+    ],
+    "menu_active_fg": [
+      198,
+      208,
+      245
+    ],
+    "menu_dropdown_bg": [
+      65,
+      69,
+      89
+    ],
+    "menu_dropdown_fg": [
+      198,
+      208,
+      245
+    ],
+    "menu_highlight_bg": [
+      140,
+      170,
+      238
+    ],
+    "menu_highlight_fg": [
+      35,
+      38,
+      52
+    ],
+    "menu_border_fg": [
+      115,
+      121,
+      148
+    ],
+    "menu_separator_fg": [
+      98,
+      104,
+      128
+    ],
+    "menu_hover_bg": [
+      81,
+      87,
+      109
+    ],
+    "menu_hover_fg": [
+      198,
+      208,
+      245
+    ],
+    "menu_disabled_fg": [
+      115,
+      121,
+      148
+    ],
+    "menu_disabled_bg": [
+      65,
+      69,
+      89
+    ]
+  },
+  "search": {
+    "match_bg": [
+      229,
+      200,
+      144
+    ],
+    "match_fg": [
+      48,
+      52,
+      70
+    ]
+  },
+  "diagnostic": {
+    "error_fg": [
+      231,
+      130,
+      132
+    ],
+    "error_bg": [
+      70,
+      52,
+      60
+    ],
+    "warning_fg": [
+      229,
+      200,
+      144
+    ],
+    "warning_bg": [
+      70,
+      62,
+      52
+    ],
+    "info_fg": [
+      153,
+      209,
+      219
+    ],
+    "info_bg": [
+      48,
+      60,
+      75
+    ],
+    "hint_fg": [
+      115,
+      121,
+      148
+    ],
+    "hint_bg": [
+      48,
+      52,
+      70
+    ]
+  },
+  "syntax": {
+    "keyword": [
+      202,
+      158,
+      230
+    ],
+    "string": [
+      166,
+      209,
+      137
+    ],
+    "comment": [
+      115,
+      121,
+      148
+    ],
+    "function": [
+      140,
+      170,
+      238
+    ],
+    "type": [
+      229,
+      200,
+      144
+    ],
+    "variable": [
+      198,
+      208,
+      245
+    ],
+    "constant": [
+      239,
+      159,
+      118
+    ],
+    "operator": [
+      153,
+      209,
+      219
+    ]
+  }
+}

--- a/home-manager/_mixins/development/fresh/themes/catppuccin-latte.json
+++ b/home-manager/_mixins/development/fresh/themes/catppuccin-latte.json
@@ -1,0 +1,328 @@
+{
+  "name": "catppuccin-latte",
+  "editor": {
+    "bg": [
+      239,
+      241,
+      245
+    ],
+    "fg": [
+      76,
+      79,
+      105
+    ],
+    "cursor": [
+      220,
+      138,
+      120
+    ],
+    "selection_bg": [
+      188,
+      192,
+      204
+    ],
+    "current_line_bg": [
+      204,
+      208,
+      218
+    ],
+    "line_number_fg": [
+      156,
+      160,
+      176
+    ],
+    "line_number_bg": [
+      239,
+      241,
+      245
+    ]
+  },
+  "ui": {
+    "tab_active_fg": [
+      220,
+      224,
+      232
+    ],
+    "tab_active_bg": [
+      30,
+      102,
+      245
+    ],
+    "tab_inactive_fg": [
+      76,
+      79,
+      105
+    ],
+    "tab_inactive_bg": [
+      188,
+      192,
+      204
+    ],
+    "tab_separator_bg": [
+      239,
+      241,
+      245
+    ],
+    "status_bar_fg": [
+      220,
+      224,
+      232
+    ],
+    "status_bar_bg": [
+      30,
+      102,
+      245
+    ],
+    "prompt_fg": [
+      220,
+      224,
+      232
+    ],
+    "prompt_bg": [
+      64,
+      160,
+      43
+    ],
+    "prompt_selection_fg": [
+      76,
+      79,
+      105
+    ],
+    "prompt_selection_bg": [
+      30,
+      102,
+      245
+    ],
+    "popup_border_fg": [
+      156,
+      160,
+      176
+    ],
+    "popup_bg": [
+      204,
+      208,
+      218
+    ],
+    "popup_selection_bg": [
+      30,
+      102,
+      245
+    ],
+    "popup_text_fg": [
+      76,
+      79,
+      105
+    ],
+    "suggestion_bg": [
+      204,
+      208,
+      218
+    ],
+    "suggestion_selected_bg": [
+      30,
+      102,
+      245
+    ],
+    "help_bg": [
+      239,
+      241,
+      245
+    ],
+    "help_fg": [
+      76,
+      79,
+      105
+    ],
+    "help_key_fg": [
+      4,
+      165,
+      229
+    ],
+    "help_separator_fg": [
+      156,
+      160,
+      176
+    ],
+    "help_indicator_fg": [
+      210,
+      15,
+      57
+    ],
+    "help_indicator_bg": [
+      239,
+      241,
+      245
+    ],
+    "split_separator_fg": [
+      156,
+      160,
+      176
+    ],
+    "menu_bg": [
+      230,
+      233,
+      239
+    ],
+    "menu_fg": [
+      76,
+      79,
+      105
+    ],
+    "menu_active_bg": [
+      188,
+      192,
+      204
+    ],
+    "menu_active_fg": [
+      76,
+      79,
+      105
+    ],
+    "menu_dropdown_bg": [
+      204,
+      208,
+      218
+    ],
+    "menu_dropdown_fg": [
+      76,
+      79,
+      105
+    ],
+    "menu_highlight_bg": [
+      30,
+      102,
+      245
+    ],
+    "menu_highlight_fg": [
+      220,
+      224,
+      232
+    ],
+    "menu_border_fg": [
+      156,
+      160,
+      176
+    ],
+    "menu_separator_fg": [
+      172,
+      176,
+      190
+    ],
+    "menu_hover_bg": [
+      188,
+      192,
+      204
+    ],
+    "menu_hover_fg": [
+      76,
+      79,
+      105
+    ],
+    "menu_disabled_fg": [
+      156,
+      160,
+      176
+    ],
+    "menu_disabled_bg": [
+      204,
+      208,
+      218
+    ]
+  },
+  "search": {
+    "match_bg": [
+      223,
+      142,
+      29
+    ],
+    "match_fg": [
+      239,
+      241,
+      245
+    ]
+  },
+  "diagnostic": {
+    "error_fg": [
+      210,
+      15,
+      57
+    ],
+    "error_bg": [
+      245,
+      220,
+      225
+    ],
+    "warning_fg": [
+      223,
+      142,
+      29
+    ],
+    "warning_bg": [
+      250,
+      240,
+      220
+    ],
+    "info_fg": [
+      4,
+      165,
+      229
+    ],
+    "info_bg": [
+      220,
+      240,
+      250
+    ],
+    "hint_fg": [
+      156,
+      160,
+      176
+    ],
+    "hint_bg": [
+      239,
+      241,
+      245
+    ]
+  },
+  "syntax": {
+    "keyword": [
+      136,
+      57,
+      239
+    ],
+    "string": [
+      64,
+      160,
+      43
+    ],
+    "comment": [
+      156,
+      160,
+      176
+    ],
+    "function": [
+      30,
+      102,
+      245
+    ],
+    "type": [
+      223,
+      142,
+      29
+    ],
+    "variable": [
+      76,
+      79,
+      105
+    ],
+    "constant": [
+      254,
+      100,
+      11
+    ],
+    "operator": [
+      4,
+      165,
+      229
+    ]
+  }
+}

--- a/home-manager/_mixins/development/fresh/themes/catppuccin-macchiato.json
+++ b/home-manager/_mixins/development/fresh/themes/catppuccin-macchiato.json
@@ -1,0 +1,328 @@
+{
+  "name": "catppuccin-macchiato",
+  "editor": {
+    "bg": [
+      36,
+      39,
+      58
+    ],
+    "fg": [
+      202,
+      211,
+      245
+    ],
+    "cursor": [
+      244,
+      219,
+      214
+    ],
+    "selection_bg": [
+      73,
+      77,
+      100
+    ],
+    "current_line_bg": [
+      54,
+      58,
+      79
+    ],
+    "line_number_fg": [
+      110,
+      115,
+      141
+    ],
+    "line_number_bg": [
+      36,
+      39,
+      58
+    ]
+  },
+  "ui": {
+    "tab_active_fg": [
+      24,
+      25,
+      38
+    ],
+    "tab_active_bg": [
+      138,
+      173,
+      244
+    ],
+    "tab_inactive_fg": [
+      202,
+      211,
+      245
+    ],
+    "tab_inactive_bg": [
+      73,
+      77,
+      100
+    ],
+    "tab_separator_bg": [
+      36,
+      39,
+      58
+    ],
+    "status_bar_fg": [
+      24,
+      25,
+      38
+    ],
+    "status_bar_bg": [
+      138,
+      173,
+      244
+    ],
+    "prompt_fg": [
+      24,
+      25,
+      38
+    ],
+    "prompt_bg": [
+      166,
+      218,
+      149
+    ],
+    "prompt_selection_fg": [
+      202,
+      211,
+      245
+    ],
+    "prompt_selection_bg": [
+      138,
+      173,
+      244
+    ],
+    "popup_border_fg": [
+      110,
+      115,
+      141
+    ],
+    "popup_bg": [
+      54,
+      58,
+      79
+    ],
+    "popup_selection_bg": [
+      138,
+      173,
+      244
+    ],
+    "popup_text_fg": [
+      202,
+      211,
+      245
+    ],
+    "suggestion_bg": [
+      54,
+      58,
+      79
+    ],
+    "suggestion_selected_bg": [
+      138,
+      173,
+      244
+    ],
+    "help_bg": [
+      36,
+      39,
+      58
+    ],
+    "help_fg": [
+      202,
+      211,
+      245
+    ],
+    "help_key_fg": [
+      145,
+      215,
+      227
+    ],
+    "help_separator_fg": [
+      110,
+      115,
+      141
+    ],
+    "help_indicator_fg": [
+      237,
+      135,
+      150
+    ],
+    "help_indicator_bg": [
+      36,
+      39,
+      58
+    ],
+    "split_separator_fg": [
+      110,
+      115,
+      141
+    ],
+    "menu_bg": [
+      30,
+      32,
+      48
+    ],
+    "menu_fg": [
+      202,
+      211,
+      245
+    ],
+    "menu_active_bg": [
+      73,
+      77,
+      100
+    ],
+    "menu_active_fg": [
+      202,
+      211,
+      245
+    ],
+    "menu_dropdown_bg": [
+      54,
+      58,
+      79
+    ],
+    "menu_dropdown_fg": [
+      202,
+      211,
+      245
+    ],
+    "menu_highlight_bg": [
+      138,
+      173,
+      244
+    ],
+    "menu_highlight_fg": [
+      24,
+      25,
+      38
+    ],
+    "menu_border_fg": [
+      110,
+      115,
+      141
+    ],
+    "menu_separator_fg": [
+      91,
+      96,
+      120
+    ],
+    "menu_hover_bg": [
+      73,
+      77,
+      100
+    ],
+    "menu_hover_fg": [
+      202,
+      211,
+      245
+    ],
+    "menu_disabled_fg": [
+      110,
+      115,
+      141
+    ],
+    "menu_disabled_bg": [
+      54,
+      58,
+      79
+    ]
+  },
+  "search": {
+    "match_bg": [
+      238,
+      212,
+      159
+    ],
+    "match_fg": [
+      36,
+      39,
+      58
+    ]
+  },
+  "diagnostic": {
+    "error_fg": [
+      237,
+      135,
+      150
+    ],
+    "error_bg": [
+      58,
+      45,
+      55
+    ],
+    "warning_fg": [
+      238,
+      212,
+      159
+    ],
+    "warning_bg": [
+      58,
+      55,
+      45
+    ],
+    "info_fg": [
+      145,
+      215,
+      227
+    ],
+    "info_bg": [
+      40,
+      50,
+      65
+    ],
+    "hint_fg": [
+      110,
+      115,
+      141
+    ],
+    "hint_bg": [
+      36,
+      39,
+      58
+    ]
+  },
+  "syntax": {
+    "keyword": [
+      198,
+      160,
+      246
+    ],
+    "string": [
+      166,
+      218,
+      149
+    ],
+    "comment": [
+      110,
+      115,
+      141
+    ],
+    "function": [
+      138,
+      173,
+      244
+    ],
+    "type": [
+      238,
+      212,
+      159
+    ],
+    "variable": [
+      202,
+      211,
+      245
+    ],
+    "constant": [
+      245,
+      169,
+      127
+    ],
+    "operator": [
+      145,
+      215,
+      227
+    ]
+  }
+}

--- a/home-manager/_mixins/development/fresh/themes/catppuccin-mocha.json
+++ b/home-manager/_mixins/development/fresh/themes/catppuccin-mocha.json
@@ -1,0 +1,328 @@
+{
+  "name": "catppuccin-mocha",
+  "editor": {
+    "bg": [
+      30,
+      30,
+      46
+    ],
+    "fg": [
+      205,
+      214,
+      244
+    ],
+    "cursor": [
+      245,
+      224,
+      220
+    ],
+    "selection_bg": [
+      69,
+      71,
+      90
+    ],
+    "current_line_bg": [
+      49,
+      50,
+      68
+    ],
+    "line_number_fg": [
+      108,
+      112,
+      134
+    ],
+    "line_number_bg": [
+      30,
+      30,
+      46
+    ]
+  },
+  "ui": {
+    "tab_active_fg": [
+      17,
+      17,
+      27
+    ],
+    "tab_active_bg": [
+      137,
+      180,
+      250
+    ],
+    "tab_inactive_fg": [
+      205,
+      214,
+      244
+    ],
+    "tab_inactive_bg": [
+      69,
+      71,
+      90
+    ],
+    "tab_separator_bg": [
+      30,
+      30,
+      46
+    ],
+    "status_bar_fg": [
+      17,
+      17,
+      27
+    ],
+    "status_bar_bg": [
+      137,
+      180,
+      250
+    ],
+    "prompt_fg": [
+      17,
+      17,
+      27
+    ],
+    "prompt_bg": [
+      166,
+      227,
+      161
+    ],
+    "prompt_selection_fg": [
+      205,
+      214,
+      244
+    ],
+    "prompt_selection_bg": [
+      137,
+      180,
+      250
+    ],
+    "popup_border_fg": [
+      108,
+      112,
+      134
+    ],
+    "popup_bg": [
+      49,
+      50,
+      68
+    ],
+    "popup_selection_bg": [
+      137,
+      180,
+      250
+    ],
+    "popup_text_fg": [
+      205,
+      214,
+      244
+    ],
+    "suggestion_bg": [
+      49,
+      50,
+      68
+    ],
+    "suggestion_selected_bg": [
+      137,
+      180,
+      250
+    ],
+    "help_bg": [
+      30,
+      30,
+      46
+    ],
+    "help_fg": [
+      205,
+      214,
+      244
+    ],
+    "help_key_fg": [
+      137,
+      220,
+      235
+    ],
+    "help_separator_fg": [
+      108,
+      112,
+      134
+    ],
+    "help_indicator_fg": [
+      243,
+      139,
+      168
+    ],
+    "help_indicator_bg": [
+      30,
+      30,
+      46
+    ],
+    "split_separator_fg": [
+      108,
+      112,
+      134
+    ],
+    "menu_bg": [
+      24,
+      24,
+      37
+    ],
+    "menu_fg": [
+      205,
+      214,
+      244
+    ],
+    "menu_active_bg": [
+      69,
+      71,
+      90
+    ],
+    "menu_active_fg": [
+      205,
+      214,
+      244
+    ],
+    "menu_dropdown_bg": [
+      49,
+      50,
+      68
+    ],
+    "menu_dropdown_fg": [
+      205,
+      214,
+      244
+    ],
+    "menu_highlight_bg": [
+      137,
+      180,
+      250
+    ],
+    "menu_highlight_fg": [
+      17,
+      17,
+      27
+    ],
+    "menu_border_fg": [
+      108,
+      112,
+      134
+    ],
+    "menu_separator_fg": [
+      88,
+      91,
+      112
+    ],
+    "menu_hover_bg": [
+      69,
+      71,
+      90
+    ],
+    "menu_hover_fg": [
+      205,
+      214,
+      244
+    ],
+    "menu_disabled_fg": [
+      108,
+      112,
+      134
+    ],
+    "menu_disabled_bg": [
+      49,
+      50,
+      68
+    ]
+  },
+  "search": {
+    "match_bg": [
+      249,
+      226,
+      175
+    ],
+    "match_fg": [
+      30,
+      30,
+      46
+    ]
+  },
+  "diagnostic": {
+    "error_fg": [
+      243,
+      139,
+      168
+    ],
+    "error_bg": [
+      53,
+      42,
+      54
+    ],
+    "warning_fg": [
+      249,
+      226,
+      175
+    ],
+    "warning_bg": [
+      53,
+      50,
+      42
+    ],
+    "info_fg": [
+      137,
+      220,
+      235
+    ],
+    "info_bg": [
+      35,
+      45,
+      55
+    ],
+    "hint_fg": [
+      108,
+      112,
+      134
+    ],
+    "hint_bg": [
+      30,
+      30,
+      46
+    ]
+  },
+  "syntax": {
+    "keyword": [
+      203,
+      166,
+      247
+    ],
+    "string": [
+      166,
+      227,
+      161
+    ],
+    "comment": [
+      108,
+      112,
+      134
+    ],
+    "function": [
+      137,
+      180,
+      250
+    ],
+    "type": [
+      249,
+      226,
+      175
+    ],
+    "variable": [
+      205,
+      214,
+      244
+    ],
+    "constant": [
+      250,
+      179,
+      135
+    ],
+    "operator": [
+      137,
+      220,
+      235
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Vendor the Fresh Catppuccin theme JSON files locally under the Home Manager Fresh mixin.
- Add missing Fresh `ui.menu_*` colour coverage for menu bar, dropdowns, hover, highlight, border, separator, and disabled menu states.
- Remove the external `pkgs.fetchFromGitHub` theme source so nix-config maintains the Fresh theme directly.

## Theme source notes
- The local files are based on `xunzhou/catppuccin-fresh` generated themes.
- `xunzhou/catppuccin-fresh` is the better upstream-ready base: Whiskers template, whiskers-check workflow, licence, and Catppuccin-style structure.
- The missing menu fields are mapped from Catppuccin semantic colours rather than Fresh's hard-coded defaults.

## Menu mapping
- Bar/dropdown surfaces: `mantle`, `surface0`, `surface1`
- Text: `text`
- Highlight: `blue` on `crust`
- Borders/separators: `overlay0`, `surface2`
- Disabled text/background: `overlay0`, `surface0`

## Validation
- JSON check confirmed all four local themes include 14 `ui.menu_*` keys.
- `nix fmt -- home-manager/_mixins/development/fresh/default.nix`
- `git diff --check`
- Targeted `nix eval` of `homeConfigurations."martin@skrye".config.xdg.configFile` confirms all four Catppuccin theme files resolve from local repo sources.
- `just eval`
