### PR TITLE
fix(home-manager): complete Fresh Catppuccin theme coverage

### DIFF
--- a/home-manager/_mixins/development/fresh/themes/catppuccin-frappe.json
+++ b/home-manager/_mixins/development/fresh/themes/catppuccin-frappe.json
@@ -35,6 +35,67 @@
       48,
       52,
       70
+    ],
+    "inactive_cursor": [
+      115,
+      121,
+      148
+    ],
+    "selection_modifier": null,
+    "ruler_bg": [
+      65,
+      69,
+      89
+    ],
+    "whitespace_indicator_fg": [
+      115,
+      121,
+      148
+    ],
+    "after_eof_bg": [
+      48,
+      52,
+      70
+    ],
+    "diff_add_collision_fg": [
+      166,
+      209,
+      137
+    ],
+    "diff_remove_collision_fg": [
+      231,
+      130,
+      132
+    ],
+    "diff_modify_collision_fg": [
+      229,
+      200,
+      144
+    ],
+    "diff_add_bg": [
+      69,
+      80,
+      82
+    ],
+    "diff_add_highlight_bg": [
+      83,
+      99,
+      90
+    ],
+    "diff_remove_bg": [
+      81,
+      66,
+      81
+    ],
+    "diff_remove_highlight_bg": [
+      103,
+      75,
+      89
+    ],
+    "diff_modify_bg": [
+      81,
+      79,
+      83
     ]
   },
   "ui": {
@@ -227,6 +288,197 @@
       65,
       69,
       89
+    ],
+    "tab_close_hover_fg": [
+      231,
+      130,
+      132
+    ],
+    "tab_hover_bg": [
+      65,
+      69,
+      89
+    ],
+    "tab_drop_zone_bg": [
+      140,
+      170,
+      238
+    ],
+    "tab_drop_zone_border": [
+      153,
+      209,
+      219
+    ],
+    "status_palette_fg": [
+      35,
+      38,
+      52
+    ],
+    "status_palette_bg": [
+      202,
+      158,
+      230
+    ],
+    "status_lsp_on_fg": [
+      35,
+      38,
+      52
+    ],
+    "status_lsp_on_bg": [
+      166,
+      209,
+      137
+    ],
+    "status_lsp_actionable_fg": [
+      35,
+      38,
+      52
+    ],
+    "status_lsp_actionable_bg": [
+      229,
+      200,
+      144
+    ],
+    "status_warning_indicator_bg": [
+      229,
+      200,
+      144
+    ],
+    "status_warning_indicator_fg": [
+      35,
+      38,
+      52
+    ],
+    "status_warning_indicator_hover_bg": [
+      239,
+      159,
+      118
+    ],
+    "status_warning_indicator_hover_fg": [
+      35,
+      38,
+      52
+    ],
+    "status_error_indicator_bg": [
+      231,
+      130,
+      132
+    ],
+    "status_error_indicator_fg": [
+      35,
+      38,
+      52
+    ],
+    "status_error_indicator_hover_bg": [
+      234,
+      153,
+      156
+    ],
+    "status_error_indicator_hover_fg": [
+      35,
+      38,
+      52
+    ],
+    "popup_selection_fg": [
+      35,
+      38,
+      52
+    ],
+    "text_input_selection_bg": [
+      140,
+      170,
+      238
+    ],
+    "inline_code_bg": [
+      65,
+      69,
+      89
+    ],
+    "scrollbar_track_fg": [
+      65,
+      69,
+      89
+    ],
+    "scrollbar_thumb_fg": [
+      81,
+      87,
+      109
+    ],
+    "scrollbar_track_hover_fg": [
+      81,
+      87,
+      109
+    ],
+    "scrollbar_thumb_hover_fg": [
+      98,
+      104,
+      128
+    ],
+    "split_separator_hover_fg": [
+      140,
+      170,
+      238
+    ],
+    "compose_margin_bg": [
+      41,
+      44,
+      60
+    ],
+    "semantic_highlight_bg": [
+      65,
+      69,
+      89
+    ],
+    "semantic_highlight_modifier": null,
+    "terminal_bg": [
+      48,
+      52,
+      70
+    ],
+    "terminal_fg": [
+      198,
+      208,
+      245
+    ],
+    "settings_selected_bg": [
+      65,
+      69,
+      89
+    ],
+    "settings_selected_fg": [
+      198,
+      208,
+      245
+    ],
+    "file_status_added_fg": [
+      166,
+      209,
+      137
+    ],
+    "file_status_modified_fg": [
+      229,
+      200,
+      144
+    ],
+    "file_status_deleted_fg": [
+      231,
+      130,
+      132
+    ],
+    "file_status_renamed_fg": [
+      140,
+      170,
+      238
+    ],
+    "file_status_untracked_fg": [
+      239,
+      159,
+      118
+    ],
+    "file_status_conflicted_fg": [
+      202,
+      158,
+      230
     ]
   },
   "search": {
@@ -239,6 +491,16 @@
       48,
       52,
       70
+    ],
+    "label_bg": [
+      202,
+      158,
+      230
+    ],
+    "label_fg": [
+      35,
+      38,
+      52
     ]
   },
   "diagnostic": {
@@ -323,6 +585,16 @@
       153,
       209,
       219
+    ],
+    "punctuation_bracket": [
+      148,
+      156,
+      187
+    ],
+    "punctuation_delimiter": [
+      148,
+      156,
+      187
     ]
   }
 }

--- a/home-manager/_mixins/development/fresh/themes/catppuccin-latte.json
+++ b/home-manager/_mixins/development/fresh/themes/catppuccin-latte.json
@@ -35,6 +35,67 @@
       239,
       241,
       245
+    ],
+    "inactive_cursor": [
+      156,
+      160,
+      176
+    ],
+    "selection_modifier": null,
+    "ruler_bg": [
+      204,
+      208,
+      218
+    ],
+    "whitespace_indicator_fg": [
+      156,
+      160,
+      176
+    ],
+    "after_eof_bg": [
+      239,
+      241,
+      245
+    ],
+    "diff_add_collision_fg": [
+      64,
+      160,
+      43
+    ],
+    "diff_remove_collision_fg": [
+      210,
+      15,
+      57
+    ],
+    "diff_modify_collision_fg": [
+      223,
+      142,
+      29
+    ],
+    "diff_add_bg": [
+      208,
+      226,
+      209
+    ],
+    "diff_add_highlight_bg": [
+      186,
+      217,
+      184
+    ],
+    "diff_remove_bg": [
+      234,
+      200,
+      211
+    ],
+    "diff_remove_highlight_bg": [
+      230,
+      173,
+      189
+    ],
+    "diff_modify_bg": [
+      236,
+      223,
+      206
     ]
   },
   "ui": {
@@ -227,6 +288,197 @@
       204,
       208,
       218
+    ],
+    "tab_close_hover_fg": [
+      210,
+      15,
+      57
+    ],
+    "tab_hover_bg": [
+      204,
+      208,
+      218
+    ],
+    "tab_drop_zone_bg": [
+      30,
+      102,
+      245
+    ],
+    "tab_drop_zone_border": [
+      4,
+      165,
+      229
+    ],
+    "status_palette_fg": [
+      220,
+      224,
+      232
+    ],
+    "status_palette_bg": [
+      136,
+      57,
+      239
+    ],
+    "status_lsp_on_fg": [
+      220,
+      224,
+      232
+    ],
+    "status_lsp_on_bg": [
+      64,
+      160,
+      43
+    ],
+    "status_lsp_actionable_fg": [
+      220,
+      224,
+      232
+    ],
+    "status_lsp_actionable_bg": [
+      223,
+      142,
+      29
+    ],
+    "status_warning_indicator_bg": [
+      223,
+      142,
+      29
+    ],
+    "status_warning_indicator_fg": [
+      220,
+      224,
+      232
+    ],
+    "status_warning_indicator_hover_bg": [
+      254,
+      100,
+      11
+    ],
+    "status_warning_indicator_hover_fg": [
+      220,
+      224,
+      232
+    ],
+    "status_error_indicator_bg": [
+      210,
+      15,
+      57
+    ],
+    "status_error_indicator_fg": [
+      220,
+      224,
+      232
+    ],
+    "status_error_indicator_hover_bg": [
+      230,
+      69,
+      83
+    ],
+    "status_error_indicator_hover_fg": [
+      220,
+      224,
+      232
+    ],
+    "popup_selection_fg": [
+      220,
+      224,
+      232
+    ],
+    "text_input_selection_bg": [
+      30,
+      102,
+      245
+    ],
+    "inline_code_bg": [
+      204,
+      208,
+      218
+    ],
+    "scrollbar_track_fg": [
+      204,
+      208,
+      218
+    ],
+    "scrollbar_thumb_fg": [
+      188,
+      192,
+      204
+    ],
+    "scrollbar_track_hover_fg": [
+      188,
+      192,
+      204
+    ],
+    "scrollbar_thumb_hover_fg": [
+      172,
+      176,
+      190
+    ],
+    "split_separator_hover_fg": [
+      30,
+      102,
+      245
+    ],
+    "compose_margin_bg": [
+      230,
+      233,
+      239
+    ],
+    "semantic_highlight_bg": [
+      204,
+      208,
+      218
+    ],
+    "semantic_highlight_modifier": null,
+    "terminal_bg": [
+      239,
+      241,
+      245
+    ],
+    "terminal_fg": [
+      76,
+      79,
+      105
+    ],
+    "settings_selected_bg": [
+      204,
+      208,
+      218
+    ],
+    "settings_selected_fg": [
+      76,
+      79,
+      105
+    ],
+    "file_status_added_fg": [
+      64,
+      160,
+      43
+    ],
+    "file_status_modified_fg": [
+      223,
+      142,
+      29
+    ],
+    "file_status_deleted_fg": [
+      210,
+      15,
+      57
+    ],
+    "file_status_renamed_fg": [
+      30,
+      102,
+      245
+    ],
+    "file_status_untracked_fg": [
+      254,
+      100,
+      11
+    ],
+    "file_status_conflicted_fg": [
+      136,
+      57,
+      239
     ]
   },
   "search": {
@@ -239,6 +491,16 @@
       239,
       241,
       245
+    ],
+    "label_bg": [
+      136,
+      57,
+      239
+    ],
+    "label_fg": [
+      220,
+      224,
+      232
     ]
   },
   "diagnostic": {
@@ -323,6 +585,16 @@
       4,
       165,
       229
+    ],
+    "punctuation_bracket": [
+      124,
+      127,
+      147
+    ],
+    "punctuation_delimiter": [
+      124,
+      127,
+      147
     ]
   }
 }

--- a/home-manager/_mixins/development/fresh/themes/catppuccin-macchiato.json
+++ b/home-manager/_mixins/development/fresh/themes/catppuccin-macchiato.json
@@ -35,6 +35,67 @@
       36,
       39,
       58
+    ],
+    "inactive_cursor": [
+      110,
+      115,
+      141
+    ],
+    "selection_modifier": null,
+    "ruler_bg": [
+      54,
+      58,
+      79
+    ],
+    "whitespace_indicator_fg": [
+      110,
+      115,
+      141
+    ],
+    "after_eof_bg": [
+      36,
+      39,
+      58
+    ],
+    "diff_add_collision_fg": [
+      166,
+      218,
+      149
+    ],
+    "diff_remove_collision_fg": [
+      237,
+      135,
+      150
+    ],
+    "diff_modify_collision_fg": [
+      238,
+      212,
+      159
+    ],
+    "diff_add_bg": [
+      59,
+      71,
+      74
+    ],
+    "diff_add_highlight_bg": [
+      75,
+      93,
+      85
+    ],
+    "diff_remove_bg": [
+      72,
+      56,
+      75
+    ],
+    "diff_remove_highlight_bg": [
+      96,
+      68,
+      86
+    ],
+    "diff_modify_bg": [
+      72,
+      70,
+      76
     ]
   },
   "ui": {
@@ -227,6 +288,197 @@
       54,
       58,
       79
+    ],
+    "tab_close_hover_fg": [
+      237,
+      135,
+      150
+    ],
+    "tab_hover_bg": [
+      54,
+      58,
+      79
+    ],
+    "tab_drop_zone_bg": [
+      138,
+      173,
+      244
+    ],
+    "tab_drop_zone_border": [
+      145,
+      215,
+      227
+    ],
+    "status_palette_fg": [
+      24,
+      25,
+      38
+    ],
+    "status_palette_bg": [
+      198,
+      160,
+      246
+    ],
+    "status_lsp_on_fg": [
+      24,
+      25,
+      38
+    ],
+    "status_lsp_on_bg": [
+      166,
+      218,
+      149
+    ],
+    "status_lsp_actionable_fg": [
+      24,
+      25,
+      38
+    ],
+    "status_lsp_actionable_bg": [
+      238,
+      212,
+      159
+    ],
+    "status_warning_indicator_bg": [
+      238,
+      212,
+      159
+    ],
+    "status_warning_indicator_fg": [
+      24,
+      25,
+      38
+    ],
+    "status_warning_indicator_hover_bg": [
+      245,
+      169,
+      127
+    ],
+    "status_warning_indicator_hover_fg": [
+      24,
+      25,
+      38
+    ],
+    "status_error_indicator_bg": [
+      237,
+      135,
+      150
+    ],
+    "status_error_indicator_fg": [
+      24,
+      25,
+      38
+    ],
+    "status_error_indicator_hover_bg": [
+      238,
+      153,
+      160
+    ],
+    "status_error_indicator_hover_fg": [
+      24,
+      25,
+      38
+    ],
+    "popup_selection_fg": [
+      24,
+      25,
+      38
+    ],
+    "text_input_selection_bg": [
+      138,
+      173,
+      244
+    ],
+    "inline_code_bg": [
+      54,
+      58,
+      79
+    ],
+    "scrollbar_track_fg": [
+      54,
+      58,
+      79
+    ],
+    "scrollbar_thumb_fg": [
+      73,
+      77,
+      100
+    ],
+    "scrollbar_track_hover_fg": [
+      73,
+      77,
+      100
+    ],
+    "scrollbar_thumb_hover_fg": [
+      91,
+      96,
+      120
+    ],
+    "split_separator_hover_fg": [
+      138,
+      173,
+      244
+    ],
+    "compose_margin_bg": [
+      30,
+      32,
+      48
+    ],
+    "semantic_highlight_bg": [
+      54,
+      58,
+      79
+    ],
+    "semantic_highlight_modifier": null,
+    "terminal_bg": [
+      36,
+      39,
+      58
+    ],
+    "terminal_fg": [
+      202,
+      211,
+      245
+    ],
+    "settings_selected_bg": [
+      54,
+      58,
+      79
+    ],
+    "settings_selected_fg": [
+      202,
+      211,
+      245
+    ],
+    "file_status_added_fg": [
+      166,
+      218,
+      149
+    ],
+    "file_status_modified_fg": [
+      238,
+      212,
+      159
+    ],
+    "file_status_deleted_fg": [
+      237,
+      135,
+      150
+    ],
+    "file_status_renamed_fg": [
+      138,
+      173,
+      244
+    ],
+    "file_status_untracked_fg": [
+      245,
+      169,
+      127
+    ],
+    "file_status_conflicted_fg": [
+      198,
+      160,
+      246
     ]
   },
   "search": {
@@ -239,6 +491,16 @@
       36,
       39,
       58
+    ],
+    "label_bg": [
+      198,
+      160,
+      246
+    ],
+    "label_fg": [
+      24,
+      25,
+      38
     ]
   },
   "diagnostic": {
@@ -323,6 +585,16 @@
       145,
       215,
       227
+    ],
+    "punctuation_bracket": [
+      147,
+      154,
+      183
+    ],
+    "punctuation_delimiter": [
+      147,
+      154,
+      183
     ]
   }
 }

--- a/home-manager/_mixins/development/fresh/themes/catppuccin-mocha.json
+++ b/home-manager/_mixins/development/fresh/themes/catppuccin-mocha.json
@@ -35,6 +35,67 @@
       30,
       30,
       46
+    ],
+    "inactive_cursor": [
+      108,
+      112,
+      134
+    ],
+    "selection_modifier": null,
+    "ruler_bg": [
+      49,
+      50,
+      68
+    ],
+    "whitespace_indicator_fg": [
+      108,
+      112,
+      134
+    ],
+    "after_eof_bg": [
+      30,
+      30,
+      46
+    ],
+    "diff_add_collision_fg": [
+      166,
+      227,
+      161
+    ],
+    "diff_remove_collision_fg": [
+      243,
+      139,
+      168
+    ],
+    "diff_modify_collision_fg": [
+      249,
+      226,
+      175
+    ],
+    "diff_add_bg": [
+      54,
+      65,
+      67
+    ],
+    "diff_add_highlight_bg": [
+      71,
+      89,
+      80
+    ],
+    "diff_remove_bg": [
+      68,
+      50,
+      68
+    ],
+    "diff_remove_highlight_bg": [
+      94,
+      63,
+      83
+    ],
+    "diff_modify_bg": [
+      69,
+      65,
+      69
     ]
   },
   "ui": {
@@ -227,6 +288,197 @@
       49,
       50,
       68
+    ],
+    "tab_close_hover_fg": [
+      243,
+      139,
+      168
+    ],
+    "tab_hover_bg": [
+      49,
+      50,
+      68
+    ],
+    "tab_drop_zone_bg": [
+      137,
+      180,
+      250
+    ],
+    "tab_drop_zone_border": [
+      137,
+      220,
+      235
+    ],
+    "status_palette_fg": [
+      17,
+      17,
+      27
+    ],
+    "status_palette_bg": [
+      203,
+      166,
+      247
+    ],
+    "status_lsp_on_fg": [
+      17,
+      17,
+      27
+    ],
+    "status_lsp_on_bg": [
+      166,
+      227,
+      161
+    ],
+    "status_lsp_actionable_fg": [
+      17,
+      17,
+      27
+    ],
+    "status_lsp_actionable_bg": [
+      249,
+      226,
+      175
+    ],
+    "status_warning_indicator_bg": [
+      249,
+      226,
+      175
+    ],
+    "status_warning_indicator_fg": [
+      17,
+      17,
+      27
+    ],
+    "status_warning_indicator_hover_bg": [
+      250,
+      179,
+      135
+    ],
+    "status_warning_indicator_hover_fg": [
+      17,
+      17,
+      27
+    ],
+    "status_error_indicator_bg": [
+      243,
+      139,
+      168
+    ],
+    "status_error_indicator_fg": [
+      17,
+      17,
+      27
+    ],
+    "status_error_indicator_hover_bg": [
+      235,
+      160,
+      172
+    ],
+    "status_error_indicator_hover_fg": [
+      17,
+      17,
+      27
+    ],
+    "popup_selection_fg": [
+      17,
+      17,
+      27
+    ],
+    "text_input_selection_bg": [
+      137,
+      180,
+      250
+    ],
+    "inline_code_bg": [
+      49,
+      50,
+      68
+    ],
+    "scrollbar_track_fg": [
+      49,
+      50,
+      68
+    ],
+    "scrollbar_thumb_fg": [
+      69,
+      71,
+      90
+    ],
+    "scrollbar_track_hover_fg": [
+      69,
+      71,
+      90
+    ],
+    "scrollbar_thumb_hover_fg": [
+      88,
+      91,
+      112
+    ],
+    "split_separator_hover_fg": [
+      137,
+      180,
+      250
+    ],
+    "compose_margin_bg": [
+      24,
+      24,
+      37
+    ],
+    "semantic_highlight_bg": [
+      49,
+      50,
+      68
+    ],
+    "semantic_highlight_modifier": null,
+    "terminal_bg": [
+      30,
+      30,
+      46
+    ],
+    "terminal_fg": [
+      205,
+      214,
+      244
+    ],
+    "settings_selected_bg": [
+      49,
+      50,
+      68
+    ],
+    "settings_selected_fg": [
+      205,
+      214,
+      244
+    ],
+    "file_status_added_fg": [
+      166,
+      227,
+      161
+    ],
+    "file_status_modified_fg": [
+      249,
+      226,
+      175
+    ],
+    "file_status_deleted_fg": [
+      243,
+      139,
+      168
+    ],
+    "file_status_renamed_fg": [
+      137,
+      180,
+      250
+    ],
+    "file_status_untracked_fg": [
+      250,
+      179,
+      135
+    ],
+    "file_status_conflicted_fg": [
+      203,
+      166,
+      247
     ]
   },
   "search": {
@@ -239,6 +491,16 @@
       30,
       30,
       46
+    ],
+    "label_bg": [
+      203,
+      166,
+      247
+    ],
+    "label_fg": [
+      17,
+      17,
+      27
     ]
   },
   "diagnostic": {
@@ -323,6 +585,16 @@
       137,
       220,
       235
+    ],
+    "punctuation_bracket": [
+      147,
+      153,
+      178
+    ],
+    "punctuation_delimiter": [
+      147,
+      153,
+      178
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Fill the remaining Fresh theme fields in the locally maintained Catppuccin Fresh themes.
- Add explicit Catppuccin colours for after-EOF/dead-space, scrollbars, popup/input selection, terminal panes, status palette/LSP indicators, file status, diff backgrounds, search labels, tab hover/drop zones, settings selection, semantic highlights, and syntax punctuation.
- Ensure all four Catppuccin flavours match Fresh upstream bundled/schema key coverage.

## Screenshot-driven fixes
- `editor.after_eof_bg` now matches `editor.bg`, so the dead space below EOF no longer falls back to a grey built-in default.
- Popup/menu-adjacent fields such as `ui.popup_selection_fg`, `ui.text_input_selection_bg`, and scrollbar/status fields are now explicit instead of inherited.
- Status palette and LSP segments now use Catppuccin palette colours rather than Fresh defaults.

## Validation
- JSON parse and semantic checks for all four local themes.
- Confirmed each local Catppuccin theme has 120 keys and no missing keys versus Fresh upstream bundled/schema coverage.
- `git diff --check`
- Targeted `nix eval` confirms `martin@skrye` resolves local theme files and Mocha has explicit `after_eof_bg`, `terminal_bg`, `popup_selection_fg`, and `status_palette_bg`.
- `just eval`
