### PR TITLE
fix(home-manager): correct Fresh Catppuccin EOF background

### DIFF
--- a/lib/fresh-catppuccin-themes.nix
+++ b/lib/fresh-catppuccin-themes.nix
@@ -35,10 +35,10 @@ let
       overlayBg = if isDark then c "surface0" else c "mantle";
       deepBg = c "crust";
       raisedBg = c "surface0";
-      currentLineBg = c "surface0";
+      currentLineBg = c "surface1";
       selectionBg = c "surface1";
       activeBg = c "surface1";
-      afterEofBg = c "mantle";
+      afterEofBg = c "surface0";
       faint = c "surface2";
       muted = c "overlay0";
 


### PR DESCRIPTION
## Summary
- Fix Fresh Catppuccin after-EOF background to use the raised surface instead of mantle.
- Restore the Dracula-like current-line rhythm by moving current_line_bg to surface1.

## Validation
- `nix eval` generated all four Catppuccin Fresh theme JSON files through `homeConfigurations."martin@skrye"`.
- Fresh schema coverage check passed for latte, frappe, macchiato, and mocha.
- Verified no Default/Gray/DarkGray/named terminal colours in generated themes.
- Verified Mocha editor values: bg `[30,30,46]`, after_eof_bg `[49,50,68]`, current_line_bg `[69,71,90]`.
- `git diff --check`
- `just eval`

Follow-up from PR #857 review comment: https://github.com/wimpysworld/nix-config/pull/857#discussion_r3289675413
