### PR TITLE
feat: add superfile terminal file manager

### DIFF
--- a/home-manager/_mixins/terminal/default.nix
+++ b/home-manager/_mixins/terminal/default.nix
@@ -45,6 +45,7 @@ in
     ./rclone.nix # Terminal cloud storage sync
     ./ripgrep.nix # Modern Unix `grep`
     ./starship.nix # Modern Unix prompt
+    ./superfile.nix # Modern terminal file manager
     ./tldr.nix # Modern Unix `man`
     ./yazi.nix # Modern Unix `mc`
     ./yt-dlp.nix # Terminal YouTube downloader

--- a/home-manager/_mixins/terminal/superfile.nix
+++ b/home-manager/_mixins/terminal/superfile.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+{
+  programs.superfile = {
+    enable = true;
+    package = pkgs.unstable.superfile;
+
+    settings = {
+      theme = lib.mkDefault "catppuccin-mocha";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Add a Home Manager terminal mixin for Superfile.
- Source Superfile from `pkgs.unstable.superfile`.
- Set Superfile's default theme to the built-in `catppuccin-mocha` theme.

## Notes

- `catppuccin/nix` does not currently expose a Superfile module.
- Superfile ships a `catppuccin-mocha` theme upstream, so this keeps the initial implementation simple.

## Validation

- `nix fmt -- home-manager/_mixins/terminal/default.nix home-manager/_mixins/terminal/superfile.nix`
- `git diff --cached --check`
- `nix eval --raw '.#homeConfigurations."martin@skrye".config.programs.superfile.settings.theme'`
- `nix eval --raw '.#homeConfigurations."martin@skrye".config.programs.superfile.package.version'`
- `just eval`
- `nix build --no-link '.#homeConfigurations."martin@skrye".activationPackage'`

`just format ...` currently fails in this environment after running repository-wide `deadnix --edit`, because `nixfmt-tree` is not available in the dev shell. The unrelated edits it made were reverted.
