### PR TITLE
fix(nixos): update kernel policy for hosts

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -87,6 +87,14 @@ in
     initrd.includeDefaultModules = true;
     initrd.verbose = false;
     kernelModules = [ "vhost_vsock" ];
+    kernelPackages = lib.mkIf (lib.elem host.name [
+      "atrius"
+      "crawler"
+      "dagger"
+      "felkor"
+      "nihilus"
+      "tanis"
+    ]) (lib.mkDefault pkgs.linuxPackages_latest);
     # Only enable the systemd-boot on installs, not live media (.ISO images)
     loader = lib.mkIf (!host.is.iso) {
       efi.canTouchEfiVariables = true;

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -87,14 +87,16 @@ in
     initrd.includeDefaultModules = true;
     initrd.verbose = false;
     kernelModules = [ "vhost_vsock" ];
-    kernelPackages = lib.mkIf (lib.elem host.name [
-      "atrius"
-      "crawler"
-      "dagger"
-      "felkor"
-      "nihilus"
-      "tanis"
-    ]) (lib.mkDefault pkgs.linuxPackages_latest);
+    kernelPackages = lib.mkIf (
+      !host.is.iso
+      && lib.elem host.name [
+        "atrius"
+        "crawler"
+        "dagger"
+        "felkor"
+        "tanis"
+      ]
+    ) (lib.mkDefault pkgs.linuxPackages_latest);
     # Only enable the systemd-boot on installs, not live media (.ISO images)
     loader = lib.mkIf (!host.is.iso) {
       efi.canTouchEfiVariables = true;

--- a/nixos/maul/default.nix
+++ b/nixos/maul/default.nix
@@ -21,7 +21,7 @@
         "nvidia"
       ];
     };
-    kernelPackages = lib.mkForce pkgs.linuxPackages_6_12;
+    kernelPackages = lib.mkForce pkgs.linuxPackages_6_18;
   };
 
   hardware = {


### PR DESCRIPTION
## Summary
- move Maul from Linux 6.12 to Linux 6.18 LTS
- set the remaining NixOS hosts that were on the 6.12 default to `linuxPackages_latest`
- keep Revan, Malak, Maul, and Bane on Linux 6.18

## Verification
- `nix fmt`
- `git diff --check`
- evaluated all NixOS kernel versions with `nix eval`
- `just eval`

## Evaluated kernel versions
- `atrius`: 7.0.9
- `bane`: 6.18.32
- `crawler`: 7.0.9
- `dagger`: 7.0.9
- `felkor`: 7.0.9
- `malak`: 6.18.32
- `maul`: 6.18.32
- `nihilus`: 7.0.9
- `revan`: 6.18.32
- `shaa`: 6.18.32
- `sidious`: 6.18.32
- `skrye`: 7.0.9
- `tanis`: 7.0.9
- `zannah`: 7.0.9
