### PR TITLE
feat: add tcount package

### DIFF
--- a/home-manager/_mixins/agentic/default.nix
+++ b/home-manager/_mixins/agentic/default.nix
@@ -23,6 +23,7 @@ in
   config = lib.mkIf (noughtyLib.userHasTag "developer") {
     home.packages = [
       agentPackages.cubic
+      pkgs.tcount
     ]
     ++ lib.optionals browserAutomationEnabled [
       agentPackages.agent-browser

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,6 +6,7 @@ pkgs: {
   davinci-resolve-studio = pkgs.callPackage ./davinci-resolve { studioVariant = true; };
   heynote = pkgs.callPackage ./heynote { };
   openhue-cli = pkgs.callPackage ./openhue-cli { };
+  tcount = pkgs.callPackage ./tcount { };
   defold = pkgs.callPackage ./defold { };
   defold-bob = pkgs.callPackage ./defold-bob { };
   defold-gdc = pkgs.callPackage ./defold-gdc { };

--- a/pkgs/tcount/default.nix
+++ b/pkgs/tcount/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "tcount";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "lancekrogers";
+    repo = "tcount";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-p2p/mZeWiZhWEissNqGKcvWLScspy/0YQxWaTuQppuo=";
+  };
+
+  vendorHash = "sha256-wdHrULL+aHUBJqab8yhJ9IZu+razp5X3N20I/lO2L84=";
+
+  subPackages = [ "cmd/tcount" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Fast, zero-network token counter for LLM workflows";
+    homepage = "https://github.com/lancekrogers/tcount";
+    license = lib.licenses.mit;
+    mainProgram = "tcount";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Summary
- Add `tcount` v0.3.0 as a local `buildGoModule` package from `lancekrogers/tcount`.
- Expose `pkgs.tcount` through the local package overlay.
- Add `pkgs.tcount` to the agentic Home Manager mixin for developer users.

## Test Plan
- `nix build .#tcount --no-link`
- `nix eval --json '.#homeConfigurations."martin@skrye".config.home.packages' --apply 'packages: builtins.any (pkg: (pkg.pname or pkg.name or "") == "tcount") packages'`
- `nix eval --raw '.#homeConfigurations."martin@skrye".pkgs.tcount.version'`
- `just eval`

## Notes
- `just format ...` currently fails in this Hermes shell because `deadnix` is not installed outside the project formatter path, so I used `nix fmt -- ...` for formatting.
