### PR TITLE
fix: enable Hermes local speech transcription

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -240,12 +240,16 @@ let
         builtins.__import__ = _managed_import
   '';
   # v2026.5.16 dropped messaging SDKs (python-telegram-bot, discord.py,
-  # slack-bolt, …) from the default install in favour of a runtime
-  # lazy-install path. That path cannot write into the sealed /nix/store
-  # venv, so opt the SDKs back in declaratively via the upstream module's
-  # extraDependencyGroups override (uv resolves them at build time).
+  # slack-bolt, …) and local voice packages (faster-whisper, sounddevice,
+  # numpy) from the default install in favour of a runtime lazy-install path.
+  # That path cannot write into the sealed /nix/store venv, so opt the SDKs
+  # back in declaratively via the upstream module's extraDependencyGroups
+  # override (uv resolves them at build time).
   upstreamHermesAgentPackage = pkgs.hermesAgent.override {
-    extraDependencyGroups = [ "messaging" ];
+    extraDependencyGroups = [
+      "messaging"
+      "voice"
+    ];
   };
   hermesAgentPackage = pkgs.symlinkJoin {
     name = "hermes-agent-host";
@@ -877,6 +881,14 @@ in
             model = "claude-opus-4-7";
           }
         ];
+
+        stt = {
+          enabled = true;
+          provider = "local";
+          local = {
+            model = "base";
+          };
+        };
 
         tts = {
           provider = "piper";


### PR DESCRIPTION
## Summary
- enable Hermes `stt.enabled` with the local faster-whisper provider
- include the upstream `voice` optional dependency group in the sealed Nix venv, alongside `messaging`
- keep the STT model at `base` for the default local transcription path

## Test Plan
- `nix fmt nixos/_mixins/server/hermes/default.nix`
- `git diff --check`
- `nix eval --json '.#nixosConfigurations.revan.config.services.hermes-agent.settings.stt'`
- `nix build --no-link '.#nixosConfigurations.revan.config.services.hermes-agent.package' --print-out-paths`
- built package Python check: `import faster_whisper` and `tools.transcription_tools._HAS_FASTER_WHISPER == True`
- `just eval`

## Notes
- Hermes v0.14.0 moved voice/STT dependencies out of the default install as part of the debloating/lazy-deps release, but the Nix store venv cannot lazy-install at runtime.
