### PR TITLE
chore: bump hermes-agent to v2026.6.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -574,14 +574,14 @@
         "uv2nix": "uv2nix_2"
       },
       "locked": {
-        "lastModified": 1780061757,
-        "narHash": "sha256-0CmNH879jnsAAszo1nkkFm8RNE49xtwUditYdFIYBCM=",
+        "lastModified": 1780707343,
+        "narHash": "sha256-ngpkopVczNrT0bfCXHm38QjgrZT96Bm/rO89NA/ls3Y=",
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.29.2.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.6.5.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.29.2.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.6.5.tar.gz"
       }
     },
     "home-manager": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
-    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.29.2.tar.gz";
+    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.6.5.tar.gz";
     hermes-agent.inputs.nixpkgs.follows = "nixpkgs-unstable";
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
## Summary
- bump Hermes Agent from v2026.5.29.2 to v2026.6.5
- update the flake input tarball tag in `flake.nix`
- refresh `flake.lock` for the `hermes-agent` input only

## Release
- https://github.com/NousResearch/hermes-agent/releases/tag/v2026.6.5

## Version change
- previous tag: `v2026.5.29.2`
- new tag: `v2026.6.5`

## Files changed
- `flake.nix`
- `flake.lock`

## Validation
- `git diff --check` - passed
- `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.package.name --raw` - passed, returned `hermes-agent-host`
- `just eval` - passed
