### PR TITLE
chore(concord): update to v2.2.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,16 +194,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761589,
-        "narHash": "sha256-Z0LlcvOaTOgIplmbp1ccCEiFs+9s9xCogD17qXa8fsw=",
+        "lastModified": 1782132720,
+        "narHash": "sha256-PWy/HOBYxfs2ZQKkLBawgr1i0J/jxAAX3ZVSvzYC/mU=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "7cf4a6288a7970b26d8a001fc547ed51cb05b710",
+        "rev": "5c35057ba1b007fb8236ffe4c3790cc8b76f8155",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.2.3",
+        "ref": "v2.2.6",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
     hunk.inputs.bun2nix.inputs.flake-parts.follows = "flake-parts";
     hunk.inputs.bun2nix.inputs.systems.follows = "systems";
     hunk.inputs.bun2nix.inputs.treefmt-nix.follows = "direnv-instant/treefmt-nix";
-    concord.url = "github:chojs23/concord/v2.2.3";
+    concord.url = "github:chojs23/concord/v2.2.6";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to version v2.2.6.

Release: https://github.com/chojs23/concord/releases/tag/v2.2.6