### PR TITLE
feat(chat): add soju and senpai IRC support

### DIFF
--- a/home-manager/_mixins/desktop/apps/chat/default.nix
+++ b/home-manager/_mixins/desktop/apps/chat/default.nix
@@ -16,24 +16,19 @@ let
   halloyConfig = ''
     theme = "catppuccin-mocha"
 
-    [servers.Libera-Soju]
+    [servers.Soju]
     nickname = "Wimpy"
     alt_nicks = ["flexiondotorg", "Wimpress"]
-    username = "flexiondotorg/irc.libera.chat@nixos"
-    server = "irc.squidowl.org"
-    port = 6697
-    password = "${config.sops.placeholder.SOJU_PASSWORD}"
+    username = "${config.noughty.user.name}"
+    server = "revan.${config.noughty.network.tailNet}"
+    port = 443
     use_tls = true
-    on_connect = ["/msg NickServ IDENTIFY Wimpy ${config.sops.placeholder.LIBERA_PASSWORD}", "/nick Wimpy"]
+    use_websocket = true
+    websocket_path = "/socket"
 
-    [servers.OFTC-Soju]
-    nickname = "Wimpress"
-    username = "flexiondotorg/irc.oftc.net@nixos"
-    server = "irc.squidowl.org"
-    port = 6697
+    [servers.Soju.sasl.plain]
+    username = "${config.noughty.user.name}"
     password = "${config.sops.placeholder.SOJU_PASSWORD}"
-    use_tls = true
-    on_connect = ["/msg NickServ IDENTIFY ${config.sops.placeholder.OFTC_PASSWORD} Wimpress"]
 
     [font]
     family = "FiraCode Nerd Font Mono"

--- a/home-manager/_mixins/desktop/apps/chat/default.nix
+++ b/home-manager/_mixins/desktop/apps/chat/default.nix
@@ -110,8 +110,6 @@ lib.mkIf host.is.workstation {
   sops = lib.mkIf (noughtyLib.isUser [ "martin" ] && host.is.linux) {
     secrets = {
       SOJU_PASSWORD.sopsFile = ../../../../../secrets/halloy.yaml;
-      LIBERA_PASSWORD.sopsFile = ../../../../../secrets/halloy.yaml;
-      OFTC_PASSWORD.sopsFile = ../../../../../secrets/halloy.yaml;
     };
     templates."halloy-config.toml" = {
       content = halloyConfig;

--- a/home-manager/_mixins/terminal/default.nix
+++ b/home-manager/_mixins/terminal/default.nix
@@ -49,6 +49,7 @@ in
     ./pueue.nix # Terminal task manager
     ./rclone.nix # Terminal cloud storage sync
     ./ripgrep.nix # Modern Unix `grep`
+    ./senpai.nix # Terminal IRC client
     ./starship.nix # Modern Unix prompt
     ./superfile.nix # Modern terminal file manager
     ./tldr.nix # Modern Unix `man`

--- a/home-manager/_mixins/terminal/senpai.nix
+++ b/home-manager/_mixins/terminal/senpai.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  noughtyLib,
+  pkgs,
+  ...
+}:
+{
+  config =
+    lib.mkIf
+      (
+        noughtyLib.isUser [ "martin" ] && config.noughty.host.is.linux && config.noughty.host.is.workstation
+      )
+      {
+        sops.secrets.SOJU_PASSWORD.sopsFile = ../../../secrets/halloy.yaml;
+
+        programs.senpai = {
+          enable = true;
+          config = {
+            address = "irc+insecure://revan.${config.noughty.network.tailNet}:6667";
+            nickname = "Wimpy";
+            username = config.noughty.user.name;
+            password-cmd = [
+              "${pkgs.coreutils}/bin/cat"
+              config.sops.secrets.SOJU_PASSWORD.path
+            ];
+          };
+        };
+      };
+}

--- a/lib/registry-systems.toml
+++ b/lib/registry-systems.toml
@@ -1,7 +1,7 @@
 # System registry - central definition of all systems and their properties
 #
 # Canonical tag vocabulary:
-#   Host tags: studio, davinci, gamedev, trackball, streamdeck, pci-hdmi-capture, thinkpad, policy, steamdeck, lima, wsl, iso, wayvnc, inference, workspace, scrutiny, dropbox, borgbackup, fprintd, strix-halo, gatus
+#   Host tags: studio, davinci, gamedev, trackball, streamdeck, pci-hdmi-capture, thinkpad, policy, steamdeck, lima, wsl, iso, wayvnc, inference, workspace, scrutiny, dropbox, borgbackup, fprintd, strix-halo, gatus, irc-bouncer
 #   User tags: developer, admin, family
 #
 # Registry fields:
@@ -237,7 +237,7 @@ vram = 24
 [revan]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny", "dropbox", "librechat", "mongodb", "inference", "hermes", "gatus", "postgres", "agentsview"]
+tags = ["scrutiny", "dropbox", "librechat", "mongodb", "inference", "hermes", "gatus", "postgres", "agentsview", "irc-bouncer"]
 
 [revan.gpu]
 vendors = ["intel", "nvidia"]

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -1004,7 +1004,7 @@ in
 
     services.caddy.virtualHosts."${config.noughty.host.name}.${config.noughty.network.tailNet}".extraConfig =
       lib.mkIf (config.services.caddy.enable && config.services.tailscale.enable) ''
-        @hermesDashboard not path /agentsview* /syncthing* /netdata* /scrutiny* /novnc*
+        @hermesDashboard not path /agentsview* /syncthing* /netdata* /scrutiny* /novnc* /socket /uploads*
         reverse_proxy @hermesDashboard ${hermesDashboardHost}:${toString hermesDashboardPort} {
           header_up Host ${hermesDashboardHost}:${toString hermesDashboardPort}
         }

--- a/nixos/_mixins/server/soju/default.nix
+++ b/nixos/_mixins/server/soju/default.nix
@@ -67,13 +67,13 @@ let
       if sojuctl -config "${config.services.soju.configFile}" user status "${username}" >/dev/null 2>&1; then
         sojuctl -config "${config.services.soju.configFile}" user update "${username}" \
           -password "$sojuPassword" \
-          -admin true \
-          -enabled true \
+          -admin=true \
+          -enabled=true \
       else
         sojuctl -config "${config.services.soju.configFile}" user create \
           -username "${username}" \
           -password "$sojuPassword" \
-          -admin true \
+          -admin=true \
           -nick "Wimpy"
       fi
 
@@ -95,14 +95,14 @@ let
             -addr "$address" \
             -username "$upstreamUsername" \
             -nick "$nick" \
-            -enabled true
+            -enabled=true
         else
           sojuctl -config "${config.services.soju.configFile}" user run "${username}" network create \
             -addr "$address" \
             -name "$networkName" \
             -username "$upstreamUsername" \
             -nick "$nick" \
-            -enabled true
+            -enabled=true
         fi
       }
 

--- a/nixos/_mixins/server/soju/default.nix
+++ b/nixos/_mixins/server/soju/default.nix
@@ -8,6 +8,7 @@
 let
   inherit (config.noughty) host;
   username = config.noughty.user.name;
+  sojuAdminSocket = "/run/soju/admin";
   tailnetHost = "${host.name}.${config.noughty.network.tailNet}";
   sojuPort = 7667;
   sojuSopsFile = ../../../../secrets + "/halloy.yaml";
@@ -50,7 +51,7 @@ let
         local attempt=1
 
         while [ "$attempt" -le 30 ]; do
-          if sojuctl -config "${config.services.soju.configFile}" server status >/dev/null 2>&1; then
+          if [ -S "${sojuAdminSocket}" ]; then
             return 0
           fi
 
@@ -64,46 +65,76 @@ let
 
       waitForSojuAdmin
 
-      if sojuctl -config "${config.services.soju.configFile}" user status "${username}" >/dev/null 2>&1; then
-        sojuctl -config "${config.services.soju.configFile}" user update "${username}" \
-          -password "$sojuPassword" \
-          -admin=true \
-          -enabled=true \
-      else
-        sojuctl -config "${config.services.soju.configFile}" user create \
+      commandFailedBecauseExisting() {
+        local errorFile="$1"
+
+        grep -Eiq 'already|duplicate|exist|taken' "$errorFile"
+      }
+
+      ensureUser() {
+        local createError
+        createError="$(mktemp)"
+
+        if sojuctl -config "${config.services.soju.configFile}" user create \
           -username "${username}" \
           -password "$sojuPassword" \
           -admin=true \
-          -nick "Wimpy"
-      fi
+          -nick "Wimpy" 2>"$createError"; then
+          rm -f "$createError"
+          return 0
+        fi
 
-      networkExists() {
-        local networkName="$1"
+        local createStatus=$?
 
-        sojuctl -config "${config.services.soju.configFile}" user run "${username}" network status \
-          | grep -Eq "^[[:space:]]*$networkName([[:space:]]|$)"
+        if commandFailedBecauseExisting "$createError"; then
+          rm -f "$createError"
+          sojuctl -config "${config.services.soju.configFile}" user update "${username}" \
+            -password "$sojuPassword" \
+            -admin=true \
+            -enabled=true
+          return 0
+        fi
+
+        cat "$createError" >&2
+        rm -f "$createError"
+        return "$createStatus"
       }
+
+      ensureUser
 
       ensureNetwork() {
         local networkName="$1"
         local address="$2"
         local nick="$3"
         local upstreamUsername="$4"
+        local createError
+        createError="$(mktemp)"
 
-        if networkExists "$networkName"; then
+        if sojuctl -config "${config.services.soju.configFile}" user run "${username}" network create \
+          -addr "$address" \
+          -name "$networkName" \
+          -username "$upstreamUsername" \
+          -nick "$nick" \
+          -enabled=true 2>"$createError"; then
+          rm -f "$createError"
+          return 0
+        fi
+
+        local createStatus=$?
+
+        if commandFailedBecauseExisting "$createError"; then
+          rm -f "$createError"
           sojuctl -config "${config.services.soju.configFile}" user run "${username}" network update "$networkName" \
             -addr "$address" \
             -username "$upstreamUsername" \
             -nick "$nick" \
             -enabled=true
-        else
-          sojuctl -config "${config.services.soju.configFile}" user run "${username}" network create \
-            -addr "$address" \
-            -name "$networkName" \
-            -username "$upstreamUsername" \
-            -nick "$nick" \
-            -enabled=true
+          return 0
         fi
+
+        cat "$createError" >&2
+        rm -f "$createError"
+        return "$createStatus"
       }
 
       ensureNetwork "libera" "irc.libera.chat" "Wimpy" "flexiondotorg/irc.libera.chat@nixos"

--- a/nixos/_mixins/server/soju/default.nix
+++ b/nixos/_mixins/server/soju/default.nix
@@ -75,6 +75,8 @@ let
         local createError
         createError="$(mktemp)"
 
+        local createStatus
+
         if sojuctl -config "${config.services.soju.configFile}" user create \
           -username "${username}" \
           -password "$sojuPassword" \
@@ -82,9 +84,9 @@ let
           -nick "Wimpy" 2>"$createError"; then
           rm -f "$createError"
           return 0
+        else
+          createStatus=$?
         fi
-
-        local createStatus=$?
 
         if commandFailedBecauseExisting "$createError"; then
           rm -f "$createError"
@@ -110,6 +112,8 @@ let
         local createError
         createError="$(mktemp)"
 
+        local createStatus
+
         if sojuctl -config "${config.services.soju.configFile}" user run "${username}" network create \
           -addr "$address" \
           -name "$networkName" \
@@ -118,9 +122,9 @@ let
           -enabled=true 2>"$createError"; then
           rm -f "$createError"
           return 0
+        else
+          createStatus=$?
         fi
-
-        local createStatus=$?
 
         if commandFailedBecauseExisting "$createError"; then
           rm -f "$createError"

--- a/nixos/_mixins/server/soju/default.nix
+++ b/nixos/_mixins/server/soju/default.nix
@@ -162,7 +162,10 @@ lib.mkIf (noughtyLib.hostHasTag "irc-bouncer") {
     soju = {
       enable = true;
       hostName = lib.mkDefault tailnetHost;
-      listen = lib.mkDefault [ "http://localhost:${toString sojuPort}" ];
+      listen = lib.mkDefault [
+        "http://localhost:${toString sojuPort}"
+        "irc+insecure://${tailnetHost}:6667"
+      ];
       adminSocket.enable = lib.mkDefault true;
       enableMessageLogging = lib.mkDefault false;
       httpOrigins = lib.mkDefault [ "https://${tailnetHost}" ];

--- a/nixos/_mixins/server/soju/default.nix
+++ b/nixos/_mixins/server/soju/default.nix
@@ -1,0 +1,193 @@
+{
+  config,
+  lib,
+  noughtyLib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.noughty) host;
+  username = config.noughty.user.name;
+  tailnetHost = "${host.name}.${config.noughty.network.tailNet}";
+  sojuPort = 7667;
+  sojuSopsFile = ../../../../secrets + "/halloy.yaml";
+  sojuBootstrap = pkgs.writeShellApplication {
+    name = "soju-bootstrap";
+    runtimeInputs = [
+      config.services.soju.package
+      pkgs.coreutils
+      pkgs.gnugrep
+    ];
+    text = ''
+      : "''${SOJU_PASSWORD_FILE:?}"
+      : "''${LIBERA_PASSWORD_FILE:?}"
+      : "''${OFTC_PASSWORD_FILE:?}"
+
+      readSecret() {
+        local secretFile="$1"
+
+        if [ ! -r "$secretFile" ]; then
+          printf 'Required secret file is unavailable: %s\n' "$secretFile" >&2
+          exit 1
+        fi
+
+        local secret
+        secret="$(<"$secretFile")"
+
+        if [ -z "$secret" ]; then
+          printf 'Required secret file is empty: %s\n' "$secretFile" >&2
+          exit 1
+        fi
+
+        printf '%s' "$secret"
+      }
+
+      sojuPassword="$(readSecret "$SOJU_PASSWORD_FILE")"
+      liberaPassword="$(readSecret "$LIBERA_PASSWORD_FILE")"
+      oftcPassword="$(readSecret "$OFTC_PASSWORD_FILE")"
+
+      waitForSojuAdmin() {
+        local attempt=1
+
+        while [ "$attempt" -le 30 ]; do
+          if sojuctl -config "${config.services.soju.configFile}" server status >/dev/null 2>&1; then
+            return 0
+          fi
+
+          sleep 1
+          attempt=$((attempt + 1))
+        done
+
+        printf 'Soju admin socket was unavailable after waiting.\n' >&2
+        exit 1
+      }
+
+      waitForSojuAdmin
+
+      if sojuctl -config "${config.services.soju.configFile}" user status "${username}" >/dev/null 2>&1; then
+        sojuctl -config "${config.services.soju.configFile}" user update "${username}" \
+          -password "$sojuPassword" \
+          -admin true \
+          -enabled true \
+      else
+        sojuctl -config "${config.services.soju.configFile}" user create \
+          -username "${username}" \
+          -password "$sojuPassword" \
+          -admin true \
+          -nick "Wimpy"
+      fi
+
+      networkExists() {
+        local networkName="$1"
+
+        sojuctl -config "${config.services.soju.configFile}" user run "${username}" network status \
+          | grep -Eq "^[[:space:]]*$networkName([[:space:]]|$)"
+      }
+
+      ensureNetwork() {
+        local networkName="$1"
+        local address="$2"
+        local nick="$3"
+        local upstreamUsername="$4"
+
+        if networkExists "$networkName"; then
+          sojuctl -config "${config.services.soju.configFile}" user run "${username}" network update "$networkName" \
+            -addr "$address" \
+            -username "$upstreamUsername" \
+            -nick "$nick" \
+            -enabled true
+        else
+          sojuctl -config "${config.services.soju.configFile}" user run "${username}" network create \
+            -addr "$address" \
+            -name "$networkName" \
+            -username "$upstreamUsername" \
+            -nick "$nick" \
+            -enabled true
+        fi
+      }
+
+      ensureNetwork "libera" "irc.libera.chat" "Wimpy" "flexiondotorg/irc.libera.chat@nixos"
+      sojuctl -config "${config.services.soju.configFile}" user run "${username}" sasl set-plain \
+        -network "libera" \
+        "Wimpy" \
+        "$liberaPassword"
+
+      ensureNetwork "oftc" "irc.oftc.net" "Wimpress" "flexiondotorg/irc.oftc.net@nixos"
+      sojuctl -config "${config.services.soju.configFile}" user run "${username}" sasl set-plain \
+        -network "oftc" \
+        "Wimpress" \
+        "$oftcPassword"
+    '';
+  };
+in
+lib.mkIf (noughtyLib.hostHasTag "irc-bouncer") {
+  environment.systemPackages = [
+    sojuBootstrap
+  ];
+
+  sops.secrets = {
+    SOJU_PASSWORD = {
+      sopsFile = sojuSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    LIBERA_PASSWORD = {
+      sopsFile = sojuSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+
+    OFTC_PASSWORD = {
+      sopsFile = sojuSopsFile;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+  };
+
+  services = {
+    caddy.virtualHosts."${tailnetHost}".extraConfig =
+      lib.mkIf (config.services.caddy.enable && config.services.tailscale.enable)
+        ''
+          @sojuSocket path /socket
+          reverse_proxy @sojuSocket localhost:${toString sojuPort}
+
+          @sojuUploads path /uploads /uploads/*
+          reverse_proxy @sojuUploads localhost:${toString sojuPort}
+        '';
+
+    soju = {
+      enable = true;
+      hostName = lib.mkDefault tailnetHost;
+      listen = lib.mkDefault [ "http://localhost:${toString sojuPort}" ];
+      adminSocket.enable = lib.mkDefault true;
+      enableMessageLogging = lib.mkDefault false;
+      httpOrigins = lib.mkDefault [ "https://${tailnetHost}" ];
+      acceptProxyIP = lib.mkDefault [ "localhost" ];
+      extraConfig = ''
+        message-store db
+      '';
+    };
+  };
+
+  systemd.services.soju-bootstrap = {
+    description = "Bootstrap Soju users and IRC networks";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "soju.service" ];
+    requires = [ "soju.service" ];
+    environment = {
+      SOJU_PASSWORD_FILE = config.sops.secrets.SOJU_PASSWORD.path;
+      LIBERA_PASSWORD_FILE = config.sops.secrets.LIBERA_PASSWORD.path;
+      OFTC_PASSWORD_FILE = config.sops.secrets.OFTC_PASSWORD.path;
+    };
+    serviceConfig = {
+      Type = "oneshot";
+      User = "root";
+      Group = "root";
+      ExecStart = lib.getExe sojuBootstrap;
+    };
+  };
+}


### PR DESCRIPTION
Build out the IRC stack for the desktop and server mixins, with soju on the host side and senpai on the terminal side, then clean up Halloy config to match the new setup.

- Add the soju service and bootstrap flow on `hermes`.
- Add `senpai` to the terminal package set.
- Remove unused Halloy secret declarations.
- Update the system registry entry for the affected host.