### PR TITLE
feat(agentic): add Chromium fence wrapper

### DIFF
--- a/home-manager/_mixins/agentic/claude-code/default.nix
+++ b/home-manager/_mixins/agentic/claude-code/default.nix
@@ -14,6 +14,14 @@ let
   claudePackage = pkgs.claude-code;
   fencePackage = import ../fence/package.nix { inherit inputs pkgs; };
   fenceWaylandBridge = import ../fence/wayland-bridge.nix { inherit pkgs; };
+  fenceChromium =
+    if host.is.server then
+      {
+        runtimeInputs = [ ];
+        setupShell = "";
+      }
+    else
+      import ../fence/chromium.nix { inherit pkgs; };
   fenceLogging = import ../fence/logging.nix { inherit pkgs; };
   ccColor = colorName: "hex:${builtins.substring 1 (-1) (catppuccinPalette.getColor colorName)}";
 
@@ -407,9 +415,11 @@ let
       pkgs.ncurses
     ]
     ++ fenceWaylandBridge.runtimeInputs
+    ++ fenceChromium.runtimeInputs
     ++ fenceLogging.runtimeInputs;
     text = ''
       ${fenceWaylandBridge.setupShell}
+      ${fenceChromium.setupShell}
 
       fence_log_agent="claude"
       ${fenceLogging.setupShell}

--- a/home-manager/_mixins/agentic/claude-code/default.nix
+++ b/home-manager/_mixins/agentic/claude-code/default.nix
@@ -437,6 +437,12 @@ let
       mcp_config=""
       tmp_mcp_config=""
 
+      cleanup_claude_mcp_config() {
+        if [[ -n "$tmp_mcp_config" ]]; then
+          rm -f -- "$tmp_mcp_config"
+        fi
+      }
+
       for candidate in "''${mcp_configs[@]}"; do
         if [[ -f "$candidate" ]]; then
           mcp_config="$candidate"
@@ -450,7 +456,7 @@ let
         chmod 600 "$tmp_mcp_config"
         cp "$mcp_config" "$tmp_mcp_config"
         fence_args+=(--expose-host-path "$tmp_mcp_config")
-        trap 'rm -f "$tmp_mcp_config"; cleanup_fence_wayland_bridge' EXIT
+        add_fence_exit_cleanup_hook cleanup_claude_mcp_config
       fi
 
       ${claudeLaunchDefaults}

--- a/home-manager/_mixins/agentic/codex/default.nix
+++ b/home-manager/_mixins/agentic/codex/default.nix
@@ -6,6 +6,7 @@
   ...
 }:
 let
+  inherit (config.noughty) host;
   inherit (pkgs.stdenv.hostPlatform) system;
 
   # Codex re-execs std::env::current_exe() when launching the Linux sandbox.
@@ -20,6 +21,14 @@ let
   codexPackage = inputs.llm-agents.packages.${system}.codex;
   fencePackage = import ../fence/package.nix { inherit inputs pkgs; };
   fenceWaylandBridge = import ../fence/wayland-bridge.nix { inherit pkgs; };
+  fenceChromium =
+    if host.is.server then
+      {
+        runtimeInputs = [ ];
+        setupShell = "";
+      }
+    else
+      import ../fence/chromium.nix { inherit pkgs; };
   fenceLogging = import ../fence/logging.nix { inherit pkgs; };
   communicationRules = config.agentic.communicationRules;
 
@@ -94,9 +103,11 @@ let
       fencePackage
     ]
     ++ fenceWaylandBridge.runtimeInputs
+    ++ fenceChromium.runtimeInputs
     ++ fenceLogging.runtimeInputs;
     text = ''
       ${fenceWaylandBridge.setupShell}
+      ${fenceChromium.setupShell}
 
       fence_log_agent="codex"
       ${fenceLogging.setupShell}

--- a/home-manager/_mixins/agentic/fence/README.md
+++ b/home-manager/_mixins/agentic/fence/README.md
@@ -36,6 +36,29 @@ as a directory. This is deliberately narrower than binding the host runtime
 wholesale: image paste needs the compositor socket, and the session bus is not
 exposed.
 
+Fenced agents on non-server hosts also get a Chromium wrapper first on `PATH`.
+The wrapper creates private writable browser state under
+`/tmp/fence-chromium.*`, sets `HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`,
+`XDG_DATA_HOME`, `XDG_STATE_HOME`, and `XDG_RUNTIME_DIR` for Chromium only, and
+passes a private `--user-data-dir` when the caller has not set one. This keeps
+Crashpad and profile writes out of the real home directory. The fenced
+environment also sets `NYALA_BROWSER` and `CHROME_PATH` to that wrapper, so
+Nyala and chromedp callers do not bypass it through host browser environment
+variables. Server hosts do not install this bridge.
+
+Chromium should use its user namespace sandbox inside Fence. The wrapper passes
+`--disable-setuid-sandbox` because the Nix store cannot provide a working SUID
+helper inside the sandbox. Do not use `--no-sandbox` as a normal setting. Keep
+Fence's `ptrace` deny in place; Crashpad is disabled with
+`--disable-crash-reporter` and `--disable-breakpad` so browser launch does not
+need a ptrace grant.
+
+For local Nyala debugging on hosts where Chromium user namespaces are blocked,
+set `NYALA_DEBUG_CHROMIUM_NO_SANDBOX=1` before launching the fenced agent. That
+adds `--no-sandbox` for Chromium only. This is a debug workaround, not a
+deployment setting. Unset it after use. It does not grant ptrace, bind host
+`/proc`, expose host `/dev/shm`, or change server policy.
+
 Claude Code's user settings include
 `skipDangerousModePermissionPrompt = true` so `claude-fenced` starts
 directly instead of stopping at the bypass-mode responsibility prompt. Fence

--- a/home-manager/_mixins/agentic/fence/chromium.nix
+++ b/home-manager/_mixins/agentic/fence/chromium.nix
@@ -75,8 +75,17 @@ in
   ];
 
   setupShell = ''
+    fence_chromium_runtime_dir=""
+
+    cleanup_fence_chromium() {
+      if [[ -n "$fence_chromium_runtime_dir" ]]; then
+        rm -rf -- "$fence_chromium_runtime_dir"
+      fi
+    }
+
     fence_chromium_runtime_dir="$(mktemp -d "''${TMPDIR:-/tmp}/fence-chromium.XXXXXX")"
     chmod 700 "$fence_chromium_runtime_dir"
+    add_fence_exit_cleanup_hook cleanup_fence_chromium
 
     fence_args+=(--expose-host-path-rw "$fence_chromium_runtime_dir")
     fence_env+=(

--- a/home-manager/_mixins/agentic/fence/chromium.nix
+++ b/home-manager/_mixins/agentic/fence/chromium.nix
@@ -1,0 +1,92 @@
+{ pkgs }:
+
+let
+  chromiumWrapper = pkgs.writeShellApplication {
+    name = "chromium";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = ''
+      runtime_dir="''${FENCE_CHROMIUM_RUNTIME_DIR:-}"
+      if [ -z "$runtime_dir" ]; then
+        runtime_dir="$(mktemp -d "''${TMPDIR:-/tmp}/fence-chromium.XXXXXX")"
+      fi
+
+      mkdir -p \
+        "$runtime_dir/home" \
+        "$runtime_dir/config" \
+        "$runtime_dir/cache" \
+        "$runtime_dir/data" \
+        "$runtime_dir/state" \
+        "$runtime_dir/runtime" \
+        "$runtime_dir/profile" \
+        "$runtime_dir/crash"
+      chmod 700 \
+        "$runtime_dir" \
+        "$runtime_dir/home" \
+        "$runtime_dir/config" \
+        "$runtime_dir/cache" \
+        "$runtime_dir/data" \
+        "$runtime_dir/state" \
+        "$runtime_dir/runtime" \
+        "$runtime_dir/profile" \
+        "$runtime_dir/crash"
+
+      export HOME="$runtime_dir/home"
+      export XDG_CONFIG_HOME="$runtime_dir/config"
+      export XDG_CACHE_HOME="$runtime_dir/cache"
+      export XDG_DATA_HOME="$runtime_dir/data"
+      export XDG_STATE_HOME="$runtime_dir/state"
+      export XDG_RUNTIME_DIR="$runtime_dir/runtime"
+
+      has_user_data_dir=0
+      for arg in "$@"; do
+        case "$arg" in
+          --user-data-dir | --user-data-dir=*)
+            has_user_data_dir=1
+            break
+            ;;
+        esac
+      done
+
+      user_data_dir_arg=()
+      if [ "$has_user_data_dir" != 1 ]; then
+        user_data_dir_arg=(--user-data-dir="$runtime_dir/profile")
+      fi
+
+      sandbox_arg=(--disable-setuid-sandbox)
+      if [ "''${NYALA_DEBUG_CHROMIUM_NO_SANDBOX:-0}" = "1" ] || [ "''${FENCE_DEBUG_CHROMIUM_NO_SANDBOX:-0}" = "1" ]; then
+        sandbox_arg=(--no-sandbox)
+      fi
+
+      exec ${pkgs.chromium}/bin/chromium \
+        "''${sandbox_arg[@]}" \
+        --disable-crash-reporter \
+        --disable-breakpad \
+        --disable-dev-shm-usage \
+        --crash-dumps-dir="$runtime_dir/crash" \
+        "''${user_data_dir_arg[@]}" \
+        "$@"
+    '';
+  };
+in
+{
+  runtimeInputs = [
+    pkgs.coreutils
+    chromiumWrapper
+  ];
+
+  setupShell = ''
+    fence_chromium_runtime_dir="$(mktemp -d "''${TMPDIR:-/tmp}/fence-chromium.XXXXXX")"
+    chmod 700 "$fence_chromium_runtime_dir"
+
+    fence_args+=(--expose-host-path-rw "$fence_chromium_runtime_dir")
+    fence_env+=(
+      "FENCE_CHROMIUM_RUNTIME_DIR=$fence_chromium_runtime_dir"
+      "NOUGHTY_AGENT_ISOLATION=Fenced"
+      "NYALA_BROWSER=${chromiumWrapper}/bin/chromium"
+      "CHROME_PATH=${chromiumWrapper}/bin/chromium"
+      "NYALA_DEBUG_CHROMIUM_NO_SANDBOX=''${NYALA_DEBUG_CHROMIUM_NO_SANDBOX:-0}"
+      "FENCE_DEBUG_CHROMIUM_NO_SANDBOX=''${FENCE_DEBUG_CHROMIUM_NO_SANDBOX:-0}"
+      "PATH=${chromiumWrapper}/bin:$PATH"
+    )
+  '';
+}

--- a/home-manager/_mixins/agentic/fence/wayland-bridge.nix
+++ b/home-manager/_mixins/agentic/fence/wayland-bridge.nix
@@ -8,7 +8,21 @@
   setupShell = ''
     fence_args=()
     fence_env=()
+    fence_exit_cleanup_hooks=()
     fence_wayland_runtime_dir=""
+
+    run_fence_exit_cleanup_hooks() {
+      local cleanup_hook
+
+      for cleanup_hook in "''${fence_exit_cleanup_hooks[@]}"; do
+        "$cleanup_hook"
+      done
+    }
+
+    add_fence_exit_cleanup_hook() {
+      fence_exit_cleanup_hooks+=("$1")
+      trap run_fence_exit_cleanup_hooks EXIT
+    }
 
     cleanup_fence_wayland_bridge() {
       if [[ -n "$fence_wayland_runtime_dir" ]]; then
@@ -69,7 +83,7 @@
         "XDG_RUNTIME_DIR=$fence_wayland_runtime_dir"
         "WAYLAND_DISPLAY=$wayland_display_name"
       )
-      trap cleanup_fence_wayland_bridge EXIT
+      add_fence_exit_cleanup_hook cleanup_fence_wayland_bridge
     }
 
     setup_fence_wayland_bridge

--- a/home-manager/_mixins/agentic/opencode/default.nix
+++ b/home-manager/_mixins/agentic/opencode/default.nix
@@ -106,6 +106,14 @@ let
       });
   fencePackage = import ../fence/package.nix { inherit inputs pkgs; };
   fenceWaylandBridge = import ../fence/wayland-bridge.nix { inherit pkgs; };
+  fenceChromium =
+    if host.is.server then
+      {
+        runtimeInputs = [ ];
+        setupShell = "";
+      }
+    else
+      import ../fence/chromium.nix { inherit pkgs; };
   fenceLogging = import ../fence/logging.nix { inherit pkgs; };
   opencodeFencedPackage = pkgs.writeShellApplication {
     name = "opencode-fenced";
@@ -113,9 +121,11 @@ let
       fencePackage
     ]
     ++ fenceWaylandBridge.runtimeInputs
+    ++ fenceChromium.runtimeInputs
     ++ fenceLogging.runtimeInputs;
     text = ''
       ${fenceWaylandBridge.setupShell}
+      ${fenceChromium.setupShell}
 
       fence_log_agent="opencode"
       ${fenceLogging.setupShell}

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -14,6 +14,14 @@ let
   piPackage = inputs.llm-agents.packages.${system}.pi;
   fencePackage = import ../fence/package.nix { inherit inputs pkgs; };
   fenceWaylandBridge = import ../fence/wayland-bridge.nix { inherit pkgs; };
+  fenceChromium =
+    if host.is.server then
+      {
+        runtimeInputs = [ ];
+        setupShell = "";
+      }
+    else
+      import ../fence/chromium.nix { inherit pkgs; };
   fenceLogging = import ../fence/logging.nix { inherit pkgs; };
   piMcpAdapterVersion = "2.6.1";
   # When bumping pi-subagents, verify the surface still matches the provider-router and prelude assumptions: the MCP tool name remains `subagent`; the parameter set still includes `agent`, `task`, `context`, `model`, and `thinking`; and `context` still accepts `"fresh"` and `"fork"` with `"fresh"` as the safer non-forking default. If any of these change, update `extensions/provider-router/index.ts` and the agent-launch prelude in `assistants/default.nix` before merging.
@@ -247,9 +255,11 @@ let
       fencePackage
     ]
     ++ fenceWaylandBridge.runtimeInputs
+    ++ fenceChromium.runtimeInputs
     ++ fenceLogging.runtimeInputs;
     text = ''
       ${fenceWaylandBridge.setupShell}
+      ${fenceChromium.setupShell}
 
       fence_log_agent="pi"
       ${fenceLogging.setupShell}


### PR DESCRIPTION
- Add a private Chromium runtime with isolated XDG state and profile data.
  - Wire the wrapper into Claude Code, Codex, OpenCode, and Pi fence launches.
  - Document Chromium sandbox and crash dump handling in the Fence README.