### PR TITLE
feat(voxtype): integrate voice input support with OSD and automation

### DIFF
--- a/.github/workflows/freshener.yml
+++ b/.github/workflows/freshener.yml
@@ -393,3 +393,101 @@ jobs:
 
           PR_NUMBER=$(echo "$PR_URL" | grep -o '[0-9]*$')
           gh pr merge --auto --squash "$PR_NUMBER"
+
+  voxtype:
+    name: Voxtype 📦
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            eval-cores = 0
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+      - name: Check for Voxtype update 🔍
+        id: check
+        run: |
+          set -euo pipefail
+
+          current=$(awk -F/ '/voxtype.url = "github:peteonrails\/voxtype\// { sub(/";$/, "", $NF); print $NF }' flake.nix)
+          latest=$(curl -fsSL "https://api.github.com/repos/peteonrails/voxtype/tags?per_page=100" \
+            | jq -r '.[].name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V \
+            | tail -n 1)
+
+          if [[ -z "$current" ]]; then
+            echo "❌ Could not determine current Voxtype release"
+            exit 1
+          fi
+
+          if [[ -z "$latest" ]]; then
+            echo "❌ Could not determine latest Voxtype release"
+            exit 1
+          fi
+
+          echo "Current Voxtype: ${current}"
+          echo "Latest Voxtype:  ${latest}"
+
+          if [[ "$current" == "$latest" ]]; then
+            echo "✅ Voxtype is up to date"
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+          echo "version=${latest}" >> "$GITHUB_OUTPUT"
+
+      - name: Update Voxtype input 📝
+        if: steps.check.outputs.updated == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          perl -0pi -e 's#voxtype\.url = "github:peteonrails/voxtype/[^"]+";#voxtype.url = "github:peteonrails/voxtype/'"$VERSION"'";#' flake.nix
+          nix flake update voxtype
+          nix fmt flake.nix
+
+          git diff flake.nix flake.lock
+
+      - name: Create pull request 🚀
+        if: steps.check.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="voxtype-${VERSION}"
+
+          if gh pr list --search "head:${BRANCH}" --json number --jq '.[0].number' | grep -q .; then
+            echo "⏭️  PR already exists for ${BRANCH}"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add flake.nix flake.lock
+          git commit -m "chore(voxtype): update to ${VERSION}"
+          git push -u origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --title "chore(voxtype): update to ${VERSION}" \
+            --body "$(cat <<EOF
+          Automated Voxtype update to version ${VERSION}.
+
+          Release: https://github.com/peteonrails/voxtype/releases/tag/${VERSION}
+          EOF
+          )" \
+            --label "dependencies,automated")
+
+          echo "📋 Created PR: ${PR_URL}"
+
+          PR_NUMBER=$(echo "$PR_URL" | grep -o '[0-9]*$')
+          gh pr merge --auto --squash "$PR_NUMBER"

--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -5,3 +5,17 @@ sub-agent
 sub-agents
 retitle
 retitled
+voxtype
+Voxtype
+Omarchy
+Catppuccin
+Quickshell
+quickshell
+swaync
+SwayNC
+avizo
+wgpu
+Hyprland
+dBFS
+Veila
+Waybar

--- a/flake.lock
+++ b/flake.lock
@@ -1170,6 +1170,7 @@
         "sops-nix": "sops-nix",
         "systems": "systems_3",
         "veila": "veila",
+        "voxtype": "voxtype",
         "xdg-override": "xdg-override"
       }
     },
@@ -1400,6 +1401,30 @@
         "owner": "naurissteins",
         "ref": "0.4.2",
         "repo": "Veila",
+        "type": "github"
+      }
+    },
+    "voxtype": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780004034,
+        "narHash": "sha256-zsOG1mBTXN4gdsTb1pUPKXATfhV5ZjgEsIUk07asaGo=",
+        "owner": "peteonrails",
+        "repo": "voxtype",
+        "rev": "8d49248baa53f29cb33007c9625a37281c72e799",
+        "type": "github"
+      },
+      "original": {
+        "owner": "peteonrails",
+        "ref": "v0.7.5",
+        "repo": "voxtype",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,9 @@
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";
+    voxtype.url = "github:peteonrails/voxtype/v0.7.5";
+    voxtype.inputs.nixpkgs.follows = "nixpkgs-unstable";
+    voxtype.inputs.flake-utils.follows = "flake-utils";
     bzmenu.url = "https://github.com/e-tho/bzmenu/archive/refs/tags/v0.4.0.tar.gz";
     bzmenu.inputs.nixpkgs.follows = "nixpkgs";
     bzmenu.inputs.rust-overlay.follows = "rust-overlay";

--- a/home-manager/_mixins/desktop/apps/default.nix
+++ b/home-manager/_mixins/desktop/apps/default.nix
@@ -46,6 +46,7 @@ in
     ./streaming
     ./terminal
     ./utilities
+    ./voice
   ];
 
   dbus = lib.mkIf (host.is.linux && host.is.workstation) {

--- a/home-manager/_mixins/desktop/apps/voice/default.nix
+++ b/home-manager/_mixins/desktop/apps/voice/default.nix
@@ -1,4 +1,5 @@
 {
+  catppuccinPalette,
   config,
   lib,
   noughtyLib,
@@ -7,6 +8,7 @@
 }:
 let
   inherit (config.noughty) host;
+  palette = catppuccinPalette;
   isVoxtypeHost = host.is.linux && host.is.workstation && noughtyLib.hostHasTag "voxtype";
   modelName =
     if host.gpu.compute.vram >= 64 then
@@ -37,15 +39,12 @@ lib.mkIf isVoxtypeHost {
       osd = {
         enabled = true;
         frontend = "gtk4";
-        width_px = 400;
-        height_px = 48;
         position = "bottom-center";
-        margin_px = 24;
-        top_margin = 0.85;
-        opacity = 0.95;
-        waveform_window_secs = 3.0;
-        peak_decay_db_per_sec = 6.0;
-        waveform_gain = 10.0;
+        top_margin = 0.72;
+        width_px = 720;
+        height_px = 120;
+        margin_px = 64;
+        waveform_gain = 2.0;
       };
       whisper = {
         language = "en";
@@ -57,22 +56,29 @@ lib.mkIf isVoxtypeHost {
 
   home.packages = [ pkgs.voxtype-osd-gtk4 ];
 
-  systemd.user.services.voxtype.Service.Environment = "PATH=${
-    lib.makeBinPath [
-      config.programs.voxtype.package
-      pkgs.voxtype-osd-gtk4
-      pkgs.dotool
-      pkgs.wl-clipboard
-      pkgs.wtype
-      pkgs.xclip
-      pkgs.xdotool
-      pkgs.ydotool
-    ]
-  }";
+  # The voxtype GTK4 OSD paints with Cairo and is not GTK-CSS themeable.
+  # It reads colours only from this Omarchy theme file, so map the six keys
+  # it parses to the Catppuccin Mocha palette to match the desktop shell.
+  xdg.configFile."omarchy/current/theme/colors.toml".text = ''
+    background = "${palette.getColor "base"}"
+    foreground = "${palette.getColor "text"}"
+    accent     = "${palette.getColor "blue"}"
+    color1     = "${palette.getColor "red"}"
+    color2     = "${palette.getColor "green"}"
+    color3     = "${palette.getColor "yellow"}"
+  '';
 
   wayland.windowManager.hyprland = lib.mkIf config.wayland.windowManager.hyprland.enable {
+    # Laptops toggle voice with Super+V; desktops use the Pause/Break key.
+    # Bind the Pause key by keycode (xkb 127 = evdev KEY_PAUSE 119 + 8) because
+    # Hyprland does not reliably match the Pause keysym by name.
     settings.bind = [
-      "$mod, V, exec, ${lib.getExe config.programs.voxtype.package} record toggle"
+      (
+        if host.is.laptop then
+          "$mod, V, exec, ${lib.getExe config.programs.voxtype.package} record toggle"
+        else
+          ", code:127, exec, ${lib.getExe config.programs.voxtype.package} record toggle"
+      )
     ];
   };
 }

--- a/home-manager/_mixins/desktop/apps/voice/default.nix
+++ b/home-manager/_mixins/desktop/apps/voice/default.nix
@@ -61,6 +61,12 @@ lib.mkIf isVoxtypeHost {
     lib.makeBinPath [
       config.programs.voxtype.package
       pkgs.voxtype-osd-gtk4
+      pkgs.dotool
+      pkgs.wl-clipboard
+      pkgs.wtype
+      pkgs.xclip
+      pkgs.xdotool
+      pkgs.ydotool
     ]
   }";
 

--- a/home-manager/_mixins/desktop/apps/voice/default.nix
+++ b/home-manager/_mixins/desktop/apps/voice/default.nix
@@ -34,6 +34,19 @@ lib.mkIf isVoxtypeHost {
       state_file = "auto";
       audio.device = "default";
       hotkey.enabled = false;
+      osd = {
+        enabled = true;
+        frontend = "gtk4";
+        width_px = 400;
+        height_px = 48;
+        position = "bottom-center";
+        margin_px = 24;
+        top_margin = 0.85;
+        opacity = 0.95;
+        waveform_window_secs = 3.0;
+        peak_decay_db_per_sec = 6.0;
+        waveform_gain = 10.0;
+      };
       whisper = {
         language = "en";
         translate = false;
@@ -41,6 +54,15 @@ lib.mkIf isVoxtypeHost {
       };
     };
   };
+
+  home.packages = [ pkgs.voxtype-osd-gtk4 ];
+
+  systemd.user.services.voxtype.Service.Environment = "PATH=${
+    lib.makeBinPath [
+      config.programs.voxtype.package
+      pkgs.voxtype-osd-gtk4
+    ]
+  }";
 
   wayland.windowManager.hyprland = lib.mkIf config.wayland.windowManager.hyprland.enable {
     settings.bind = [

--- a/home-manager/_mixins/desktop/apps/voice/default.nix
+++ b/home-manager/_mixins/desktop/apps/voice/default.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  noughtyLib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.noughty) host;
+  isVoxtypeHost = host.is.linux && host.is.workstation && noughtyLib.hostHasTag "voxtype";
+  modelName =
+    if host.gpu.compute.vram >= 64 then
+      "large-v3"
+    else if host.gpu.compute.vram >= 16 then
+      "medium.en"
+    else
+      "small.en";
+  voxtypePackage =
+    if host.gpu.compute.acceleration == "cuda" then
+      pkgs.voxtype-onnx-cuda
+    else if host.gpu.compute.acceleration == "rocm" then
+      pkgs.voxtype-rocm
+    else
+      pkgs.voxtype-vulkan;
+in
+lib.mkIf isVoxtypeHost {
+  programs.voxtype = {
+    enable = true;
+    engine = "whisper";
+    package = voxtypePackage;
+    model.name = modelName;
+    service.enable = true;
+    settings = {
+      state_file = "auto";
+      audio.device = "default";
+      hotkey.enabled = false;
+      whisper = {
+        language = "en";
+        translate = false;
+        on_demand_loading = modelName != "large-v3";
+      };
+    };
+  };
+
+  wayland.windowManager.hyprland = lib.mkIf config.wayland.windowManager.hyprland.enable {
+    settings.bind = [
+      "$mod, V, exec, ${lib.getExe config.programs.voxtype.package} record toggle"
+    ];
+  };
+}

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -25,6 +25,7 @@ in
     inputs.sops-nix.homeManagerModules.sops
     inputs.mac-app-util.homeManagerModules.default
     inputs.nix-index-database.homeModules.nix-index
+    inputs.voxtype.homeManagerModules.default
     ./_mixins/agentic
     ./_mixins/development
     ./_mixins/filesync

--- a/lib/noughty/README.md
+++ b/lib/noughty/README.md
@@ -321,7 +321,11 @@ in
 
 Tags are freeform `listOf str`. The canonical vocabulary is documented in a comment block in `lib/registry-systems.toml`:
 
-- **Host tags:** `studio`, `trackball`, `streamdeck`, `pci-hdmi-capture`, `thinkpad`, `policy`, `steamdeck`, `lima`, `wsl`, `inference`
+- **Host tags:**
+  - `studio`, `davinci`, `gamedev`, `trackball`, `streamdeck`
+  - `pci-hdmi-capture`, `thinkpad`, `policy`, `steamdeck`, `lima`, `wsl`
+  - `iso`, `wayvnc`, `inference`, `workspace`, `scrutiny`, `dropbox`
+  - `borgbackup`, `fprintd`, `strix-halo`, `gatus`, `irc-bouncer`, `voxtype`
 - **User tags:** `developer`, `admin`, `family`
 
 Tags centralise classification that was previously scattered as hostname comparisons across the tree (e.g. `hostname == "phasma" || hostname == "vader"` becomes the `"studio"` tag, set once in the registry).

--- a/lib/registry-systems.toml
+++ b/lib/registry-systems.toml
@@ -1,7 +1,7 @@
 # System registry - central definition of all systems and their properties
 #
 # Canonical tag vocabulary:
-#   Host tags: studio, davinci, gamedev, trackball, streamdeck, pci-hdmi-capture, thinkpad, policy, steamdeck, lima, wsl, iso, wayvnc, inference, workspace, scrutiny, dropbox, borgbackup, fprintd, strix-halo, gatus, irc-bouncer
+#   Host tags: studio, davinci, gamedev, trackball, streamdeck, pci-hdmi-capture, thinkpad, policy, steamdeck, lima, wsl, iso, wayvnc, inference, workspace, scrutiny, dropbox, borgbackup, fprintd, strix-halo, gatus, irc-bouncer, voxtype
 #   User tags: developer, admin, family
 #
 # Registry fields:
@@ -27,10 +27,16 @@
 kind = "computer"
 platform = "x86_64-linux"
 formFactor = "laptop"
-tags = ["policy", "workspace", "dropbox", "fprintd", "wayvnc"]
+tags = ["policy", "workspace", "dropbox", "fprintd", "wayvnc", "voxtype"]
 
 [bane.gpu]
 vendors = ["amd"]
+
+[bane.gpu.compute]
+vendor = "amd"
+vram = 32
+unified = true
+acceleration = "vulkan"
 
 [[bane.displays]]
 output = "eDP-1"
@@ -44,10 +50,16 @@ position = { x = 0, y = 0 }
 kind = "computer"
 platform = "x86_64-linux"
 formFactor = "laptop"
-tags = ["thinkpad", "dropbox", "fprintd"]
+tags = ["thinkpad", "dropbox", "fprintd", "voxtype"]
 
 [tanis.gpu]
 vendors = ["amd"]
+
+[tanis.gpu.compute]
+vendor = "amd"
+vram = 8
+unified = true
+acceleration = "vulkan"
 
 [[tanis.displays]]
 output = "eDP-1"
@@ -134,7 +146,21 @@ position = { x = 0, y = 0 }
 kind = "computer"
 platform = "x86_64-linux"
 formFactor = "desktop"
-tags = ["studio", "davinci", "gamedev", "trackball", "streamdeck", "pci-hdmi-capture", "inference", "wayvnc", "scrutiny", "dropbox", "borgbackup", "strix-halo"]
+tags = [
+  "studio",
+  "davinci",
+  "gamedev",
+  "trackball",
+  "streamdeck",
+  "pci-hdmi-capture",
+  "inference",
+  "wayvnc",
+  "scrutiny",
+  "dropbox",
+  "borgbackup",
+  "strix-halo",
+  "voxtype",
+]
 
 [skrye.gpu]
 vendors = ["amd"]
@@ -167,7 +193,21 @@ position = { x = 2560, y = 0 }
 kind = "computer"
 platform = "x86_64-linux"
 formFactor = "desktop"
-tags = ["studio", "davinci", "gamedev", "trackball", "streamdeck", "pci-hdmi-capture", "inference", "wayvnc", "scrutiny", "dropbox", "borgbackup", "strix-halo"]
+tags = [
+  "studio",
+  "davinci",
+  "gamedev",
+  "trackball",
+  "streamdeck",
+  "pci-hdmi-capture",
+  "inference",
+  "wayvnc",
+  "scrutiny",
+  "dropbox",
+  "borgbackup",
+  "strix-halo",
+  "voxtype",
+]
 
 [zannah.gpu]
 vendors = ["amd"]
@@ -237,7 +277,18 @@ vram = 24
 [revan]
 kind = "server"
 platform = "x86_64-linux"
-tags = ["scrutiny", "dropbox", "librechat", "mongodb", "inference", "hermes", "gatus", "postgres", "agentsview", "irc-bouncer"]
+tags = [
+  "scrutiny",
+  "dropbox",
+  "librechat",
+  "mongodb",
+  "inference",
+  "hermes",
+  "gatus",
+  "postgres",
+  "agentsview",
+  "irc-bouncer",
+]
 
 [revan.gpu]
 vendors = ["intel", "nvidia"]

--- a/nixos/_mixins/hardware/streamdeck/xl/audio-base.deck
+++ b/nixos/_mixins/hardware/streamdeck/xl/audio-base.deck
@@ -70,15 +70,18 @@
   [keys.action]
     exec = "playerctl -p sidra next"
 
-#[[keys]]
-#  index = 7
-#  [keys.widget]
-#    id = "button"
-#    [keys.widget.config]
-#      icon = "~/Studio/StreamDeck/Icons/Nebula/General/multimedia-next-track.jpg"
-#  [keys.action]
-#    exec = ""
-
+[[keys]]
+  index = 7
+  [keys.widget]
+    id = "button"
+    [keys.widget.config]
+      icon = "~/Studio/StreamDeck/Icons/Clarity-Standard/Normal/Mic-On.png"            
+      #label = "Voxtype"
+      #fontsize = 6.0
+      #color = "#fefefe"
+      #flatten = false
+    [keys.action]
+      exec = "voxtype record toggle"
 
 [[keys]]
   index = 8

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -14,6 +14,15 @@
     # theme-key-resolution fix has landed there.
     inherit (inputs.fresh.packages.${final.stdenv.hostPlatform.system}) fresh;
 
+    voxtype = inputs.voxtype.packages.${final.stdenv.hostPlatform.system}.default;
+    voxtype-vulkan = inputs.voxtype.packages.${final.stdenv.hostPlatform.system}.vulkan;
+    voxtype-rocm = inputs.voxtype.packages.${final.stdenv.hostPlatform.system}.rocm;
+    voxtype-onnx = inputs.voxtype.packages.${final.stdenv.hostPlatform.system}.onnx;
+    voxtype-onnx-cuda = inputs.voxtype.packages.${final.stdenv.hostPlatform.system}.onnx-cuda;
+    voxtype-onnx-migraphx = inputs.voxtype.packages.${final.stdenv.hostPlatform.system}.onnx-migraphx;
+    voxtype-osd-native = inputs.voxtype.packages.${final.stdenv.hostPlatform.system}.osd-native;
+    voxtype-osd-gtk4 = inputs.voxtype.packages.${final.stdenv.hostPlatform.system}.osd-gtk4;
+
     # Agent-adjacent tools sourced from the same pinned llm-agents flake as the
     # rest of the agent tooling.
     inherit (inputs.llm-agents.packages.${final.stdenv.hostPlatform.system}) herdr;


### PR DESCRIPTION
Add end-to-end voice input (speech-to-text) via Voxtype to workstations, including real-time OSD visualisation, keyboard bindings, Stream Deck integration, and Catppuccin theming.

- Add voxtype voice app module with GTK4 OSD visualisation
- Implement conditional keyboard bindings: Super+V on laptops, Pause key on desktops
- Integrate Stream Deck buttons for voice control
- Add clipboard and input tool support for transcription workflow
- Apply Catppuccin Mocha theming to the OSD via Omarchy colour mapping
- Add CI workflow for flake freshness checking
- Expand system registry with device-specific configurations