### PR TITLE
chore(concord): update to v2.2.9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,16 +162,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1782132720,
-        "narHash": "sha256-PWy/HOBYxfs2ZQKkLBawgr1i0J/jxAAX3ZVSvzYC/mU=",
+        "lastModified": 1782743924,
+        "narHash": "sha256-nugA9O+c4FA7pjcjIS70ByqadrZF8jKokhEgLF9aqBU=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "5c35057ba1b007fb8236ffe4c3790cc8b76f8155",
+        "rev": "6aa9b25828c837bb6c016e74a4f846d3618d5bdf",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.2.6",
+        "ref": "v2.2.9",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.2.6";
+    concord.url = "github:chojs23/concord/v2.2.9";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to version v2.2.9.

Release: https://github.com/chojs23/concord/releases/tag/v2.2.9