### PR TITLE
chore(concord): update to v2.2.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,16 +162,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1782743924,
-        "narHash": "sha256-nugA9O+c4FA7pjcjIS70ByqadrZF8jKokhEgLF9aqBU=",
+        "lastModified": 1782911436,
+        "narHash": "sha256-KPMSleUuW7B//6dU8dti27Gh730iAqREkfLxQWNqGnU=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "6aa9b25828c837bb6c016e74a4f846d3618d5bdf",
+        "rev": "0cb59209b94a3c90cbb14f53d8860b5802ec8836",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.2.9",
+        "ref": "v2.2.11",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.2.9";
+    concord.url = "github:chojs23/concord/v2.2.11";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to version v2.2.11.

Release: https://github.com/chojs23/concord/releases/tag/v2.2.11