### PR TITLE
perf(iso): reduce image size from 1.8GB to 948MB

### DIFF
--- a/common/default.nix
+++ b/common/default.nix
@@ -8,7 +8,9 @@
 }:
 let
   flakeInputs = lib.filterAttrs (_: lib.isType "flake") inputs;
-  serverRegistryInputs = lib.filterAttrs (
+  # Servers and live ISO media pin only self, nixpkgs, and nixpkgs-unstable,
+  # because pinning every input embeds all input source trees (~700 MiB) in the closure.
+  reducedRegistryInputs = lib.filterAttrs (
     name: _:
     lib.elem name [
       "self"
@@ -16,7 +18,11 @@ let
       "nixpkgs-unstable"
     ]
   ) flakeInputs;
-  registryInputs = if config.noughty.host.is.server then serverRegistryInputs else flakeInputs;
+  registryInputs =
+    if config.noughty.host.is.server || config.noughty.host.is.iso then
+      reducedRegistryInputs
+    else
+      flakeInputs;
 in
 {
   # Only install the docs I use

--- a/nixos/_mixins/network/default.nix
+++ b/nixos/_mixins/network/default.nix
@@ -116,6 +116,12 @@ in
       inherit trustedInterfaces;
     };
     hostName = host.name;
+    # The live installer never installs over a cellular modem, and ModemManager
+    # pulls libqmi (~90 MiB closure) onto the ISO. NetworkManager only enables
+    # ModemManager via mkDefault, so a plain false is sufficient here.
+    modemmanager = lib.mkIf host.is.iso {
+      enable = false;
+    };
     nameservers = if builtins.hasAttr username userDns then userDns.${username} else fallbackDns;
     networkmanager = lib.mkIf useNetworkManager {
       # Use resolved for DNS resolution; tailscale MagicDNS requires it

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -121,19 +121,20 @@ in
   };
 
   # NixOS-only option, unavailable on nix-darwin, so it lives here rather than
-  # in ../common. Skip the expensive mandb cache generation to speed up builds.
+  # in ../common. Servers and live ISO media skip documentation entirely,
+  # including the expensive mandb cache generation, to speed up builds.
   documentation = {
-    enable = lib.mkIf host.is.server (lib.mkForce false);
-    doc.enable = lib.mkIf host.is.server (lib.mkForce false);
-    info.enable = lib.mkIf host.is.server (lib.mkForce false);
-    nixos.enable = lib.mkIf host.is.server (lib.mkForce false);
+    enable = lib.mkIf (host.is.server || host.is.iso) (lib.mkForce false);
+    doc.enable = lib.mkIf (host.is.server || host.is.iso) (lib.mkForce false);
+    info.enable = lib.mkIf (host.is.server || host.is.iso) (lib.mkForce false);
+    nixos.enable = lib.mkIf (host.is.server || host.is.iso) (lib.mkForce false);
     man = {
-      enable = lib.mkIf host.is.server (lib.mkForce false);
+      enable = lib.mkIf (host.is.server || host.is.iso) (lib.mkForce false);
       cache = {
-        enable = lib.mkIf host.is.server (lib.mkForce false);
-        generateAtRuntime = if host.is.server then lib.mkForce false else true;
+        enable = lib.mkIf (host.is.server || host.is.iso) (lib.mkForce false);
+        generateAtRuntime = if (host.is.server || host.is.iso) then lib.mkForce false else true;
       };
-      man-db.enable = lib.mkIf host.is.server (lib.mkForce false);
+      man-db.enable = lib.mkIf (host.is.server || host.is.iso) (lib.mkForce false);
     };
   };
 
@@ -198,7 +199,9 @@ in
   programs = {
     command-not-found.enable = false;
     nano.enable = lib.mkDefault false;
-    nix-index.enable = lib.mkIf host.is.server (lib.mkForce false);
+    # The prebuilt nix-index database is roughly 115 MiB and is not needed on
+    # servers or live ISO media.
+    nix-index.enable = lib.mkIf (host.is.server || host.is.iso) (lib.mkForce false);
     nh = {
       clean = {
         enable = !host.is.iso;

--- a/nixos/nihilus/default.nix
+++ b/nixos/nihilus/default.nix
@@ -1,9 +1,28 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   # The installer profile enables CIFS support, and cifs-utils drags the full
   # python3 interpreter (~126 MiB) into the closure. Installs never mount CIFS
   # shares, so drop it from the live media.
   boot.supportedFilesystems.cifs = lib.mkForce false;
+
+  # The installer profile enables hardware.enableAllHardware, which switches on
+  # every redistributable firmware package. Disable that (the profile assigns a
+  # plain true, so mkForce is required) and hand-pick the firmware instead.
+  # This drops sof-firmware, alsa-firmware, libreelec-dvb-firmware,
+  # rtl8192su-firmware, ipw2200-firmware, and zd1211fw (~26 MiB of audio, DVB,
+  # and obsolete Wi-Fi blobs the live installer never loads).
+  hardware.enableRedistributableFirmware = lib.mkForce false;
+
+  # The regulatory database defaults to the option disabled above, and Wi-Fi
+  # on the live media still needs it.
+  hardware.wirelessRegulatoryDatabase = true;
+
+  # pkgs.linux-firmware resolves to the trimmed overlay version below.
+  hardware.firmware = [
+    pkgs.linux-firmware
+    pkgs.rt5677-firmware
+    pkgs.rtl8761b-firmware
+  ];
 
   # Do not copy the nixpkgs source (~195 MiB) into the closure to serve the nix
   # path and flake registry; it would be a redundant third copy. The registry
@@ -15,6 +34,49 @@
     (_final: super: {
       # Prevent mbrola-voices (~650MB) from being on the live media
       espeak = super.espeak.override { mbrolaSupport = false; };
+
+      # Trim firmware classes no installer target can use (~460 MiB
+      # uncompressed). GPU, Wi-Fi, Bluetooth, wired NIC, and CPU microcode
+      # firmware all stay untouched.
+      linux-firmware = super.linux-firmware.overrideAttrs (old: {
+        postInstall =
+          (old.postInstall or "")
+          + ''
+            # Datacenter and exotic NICs, and switch ASICs; no installer
+            # target has these.
+            rm -rf $out/lib/firmware/{mellanox,mrvl,netronome,dpaa2,qed,bnx2x,liquidio}
+            rm -rf $out/lib/firmware/cxgb4*
+            rm -rf $out/lib/firmware/phanfw.bin
+            # Fibre Channel HBAs (Brocade bfa); the installer never boots
+            # from a SAN.
+            rm -rf $out/lib/firmware/{ctfw,cbfw,ct2fw}-*
+            # DVB/TV tuners and capture codecs; useless on a live installer.
+            # The dvb_* and sms1xxx-* globs catch the Siano DVB-T blobs that
+            # use underscore and vendor prefixes instead of dvb-*.
+            rm -rf $out/lib/firmware/dvb-*
+            rm -rf $out/lib/firmware/dvb_*
+            rm -rf $out/lib/firmware/sms1xxx-*
+            rm -rf $out/lib/firmware/av7110
+            rm -rf $out/lib/firmware/s5p-mfc*
+            # Audio DSP firmware; the ISO has no audio stack.
+            rm -rf $out/lib/firmware/{cirrus,ti,ti-connectivity}
+            # Legacy serial, telephony, and pre-802.11n Wi-Fi hardware.
+            rm -rf $out/lib/firmware/{ueagle-atm,moxa,libertas}
+            # NVIDIA display firmware; the text install runs on the EFI
+            # framebuffer.
+            rm -rf $out/lib/firmware/nvidia
+          ''
+          + super.lib.optionalString super.stdenv.hostPlatform.isx86_64 ''
+            # qcom firmware serves aarch64 Snapdragon machines that an x86_64
+            # image can never boot, but a future ARM ISO must keep it.
+            rm -rf $out/lib/firmware/qcom
+          ''
+          + ''
+            # Delete symlinks left dangling by the removals so the firmware
+            # compression step's link check passes.
+            find "$out/lib/firmware" -xtype l -print -delete
+          '';
+      });
     })
   ];
 }

--- a/nixos/nihilus/default.nix
+++ b/nixos/nihilus/default.nix
@@ -1,4 +1,16 @@
-_: {
+{ lib, ... }:
+{
+  # The installer profile enables CIFS support, and cifs-utils drags the full
+  # python3 interpreter (~126 MiB) into the closure. Installs never mount CIFS
+  # shares, so drop it from the live media.
+  boot.supportedFilesystems.cifs = lib.mkForce false;
+
+  # Do not copy the nixpkgs source (~195 MiB) into the closure to serve the nix
+  # path and flake registry; it would be a redundant third copy. The registry
+  # pin from common/default.nix and the installer channel remain.
+  nixpkgs.flake.setNixPath = false;
+  nixpkgs.flake.setFlakeRegistry = false;
+
   nixpkgs.overlays = [
     (_final: super: {
       # Prevent mbrola-voices (~650MB) from being on the live media

--- a/nixos/nihilus/default.nix
+++ b/nixos/nihilus/default.nix
@@ -32,9 +32,6 @@
 
   nixpkgs.overlays = [
     (_final: super: {
-      # Prevent mbrola-voices (~650MB) from being on the live media
-      espeak = super.espeak.override { mbrolaSupport = false; };
-
       # Trim firmware classes no installer target can use (~460 MiB
       # uncompressed). GPU, Wi-Fi, Bluetooth, wired NIC, and CPU microcode
       # firmware all stay untouched.


### PR DESCRIPTION
Optimise the ISO image by removing unused firmware, services, and overlays. Closure shrinks from 3.4GiB to 2.5GiB through three targeted reductions: firmware trimming (769MiB to 277MiB), service and documentation removal, and obsolete overlay cleanup.

## Changes

- Gate flake registry and nix-index to servers and ISO only
- Disable documentation and ModemManager on ISO
- Remove CIFS support and redundant nixpkgs flake copies
- Trim linux-firmware by removing datacenter NICs, DVB/TV tuners, audio DSP, legacy hardware, and NVIDIA display firmware (x86_64 only)
- Drop obsolete mbrola overlay; upstream now handles voice trimming