### PR TITLE
chore(concord): update to v2.3.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,16 +162,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1782911436,
-        "narHash": "sha256-KPMSleUuW7B//6dU8dti27Gh730iAqREkfLxQWNqGnU=",
+        "lastModified": 1783343871,
+        "narHash": "sha256-Tw9Gx2bUr5IOUaXXxAoghYNViWVucqIGGlkwNUA+KgA=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "0cb59209b94a3c90cbb14f53d8860b5802ec8836",
+        "rev": "af1f262d08f89203ea9e604643f58420219201a0",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.2.11",
+        "ref": "v2.3.0",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.2.11";
+    concord.url = "github:chojs23/concord/v2.3.0";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to v2.3.0.

Changelog: https://github.com/chojs23/concord/releases