### PR TITLE
fix(agentic): permit fenced unsigned Git workflows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,29 +1,5 @@
 {
   "nodes": {
-    "blueprint": {
-      "inputs": {
-        "nixpkgs": [
-          "llm-agents",
-          "nixpkgs"
-        ],
-        "systems": [
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776249299,
-        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
-        "owner": "numtide",
-        "repo": "blueprint",
-        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "blueprint",
-        "type": "github"
-      }
-    },
     "brew-src": {
       "flake": false,
       "locked": {
@@ -700,7 +676,6 @@
     },
     "llm-agents": {
       "inputs": {
-        "blueprint": "blueprint",
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts_4",
         "nixpkgs": [
@@ -713,11 +688,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783107085,
-        "narHash": "sha256-PM88b2XXEp3LeChw1uAPHjsz6AFjpZaRkr3/XJNqt1Y=",
+        "lastModified": 1783939066,
+        "narHash": "sha256-aDocx3RpWOqQuNlhQ3QqwSs4RgtnejMrZcGecYdwEvo=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "8147c632655dcc2407defd1f68b3759241331375",
+        "rev": "b53169a26763398fad1e3ca27b85b0abfd837268",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     nix-darwin.url = "github:LnL7/nix-darwin/nix-darwin-26.05";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
 
-    # Shared transitive inputs; most flake-utils and blueprint depend on nix-systems/default.
+    # Shared transitive inputs; most flake-utils users depend on nix-systems/default.
     systems.url = "github:nix-systems/default";
     flake-utils.url = "github:numtide/flake-utils";
     flake-utils.inputs.systems.follows = "systems";
@@ -24,7 +24,6 @@
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";
     llm-agents.inputs.treefmt-nix.follows = "direnv-instant/treefmt-nix";
-    llm-agents.inputs.blueprint.inputs.systems.follows = "systems";
     fresh.url = "github:sinelaw/fresh";
     fresh.inputs.nixpkgs.follows = "nixpkgs-unstable";
     fresh.inputs.flake-parts.follows = "flake-parts";

--- a/home-manager/_mixins/agentic/assistants/instructions/global.md
+++ b/home-manager/_mixins/agentic/assistants/instructions/global.md
@@ -24,7 +24,7 @@ Use LSP diagnostics and navigation when available, including grammar and formatt
 
 - Never destroy what cannot be recovered. Do not delete or overwrite data or backups, and do not disrupt or take down production services, without explicit consent. Confirm before irreversible or destructive commands. Routine local file edits in trusted directories need no confirmation.
 - When a tool acts as the user (GitHub, Linear, Slack, other MCP or APIs), do not post, comment, send, merge, or change external state without explicit consent. Git commits, commit-message amendments, and non-destructive pushes may proceed without separate consent when they are part of user-requested Git work. Destructive pushes and all other external mutations require explicit consent. These speak as the user.
-- Make Git commits and commit-message amendments with the configured user identity and a valid signature. Never disable or bypass signing. Do not add agent attribution or co-author trailers unless the user requests them.
+- Make Git commits and commit-message amendments with the user's configured identity. Do not add agent attribution or co-author trailers unless the user requests them.
 - Never expose or leak secrets, tokens, or credentials.
 
 ## Communication Rules

--- a/home-manager/_mixins/agentic/assistants/instructions/global.md
+++ b/home-manager/_mixins/agentic/assistants/instructions/global.md
@@ -23,8 +23,8 @@ Use LSP diagnostics and navigation when available, including grammar and formatt
 ## Safety
 
 - Never destroy what cannot be recovered. Do not delete or overwrite data or backups, and do not disrupt or take down production services, without explicit consent. Confirm before irreversible or destructive commands. Routine local file edits in trusted directories need no confirmation.
-- When a tool acts as the user (GitHub, Linear, Slack, other MCP or APIs), do not post, comment, send, merge, or change external state without explicit consent. These speak as the user.
-- Never create git commits. The repo requires SSH-signed commits and you lack the signing key, so the commit fails. Stage changes and prepare the commit message; the user runs the commit.
+- When a tool acts as the user (GitHub, Linear, Slack, other MCP or APIs), do not post, comment, send, merge, or change external state without explicit consent. Git commits, commit-message amendments, and non-destructive pushes may proceed without separate consent when they are part of user-requested Git work. Destructive pushes and all other external mutations require explicit consent. These speak as the user.
+- Make Git commits and commit-message amendments with the configured user identity and a valid signature. Never disable or bypass signing. Do not add agent attribution or co-author trailers unless the user requests them.
 - Never expose or leak secrets, tokens, or credentials.
 
 ## Communication Rules

--- a/home-manager/_mixins/agentic/claude-code/default.nix
+++ b/home-manager/_mixins/agentic/claude-code/default.nix
@@ -14,6 +14,7 @@ let
   # overlays/default.nix.
   claudePackage = pkgs.claude-code;
   fencePackage = import ../fence/package.nix { inherit inputs pkgs; };
+  fenceGit = import ../fence/git.nix;
   fenceWaylandBridge = import ../fence/wayland-bridge.nix { inherit pkgs; };
   fenceChromium =
     if !(host.is.linux && fencedEnabled) then
@@ -464,6 +465,7 @@ let
     ++ fenceLogging.runtimeInputs;
     text = ''
       ${fenceWaylandBridge.setupShell}
+      ${fenceGit.setupShell}
       ${fenceChromium.setupShell}
 
       fence_log_agent="claude"

--- a/home-manager/_mixins/agentic/codex/default.nix
+++ b/home-manager/_mixins/agentic/codex/default.nix
@@ -23,6 +23,7 @@ let
   # so current_exe re-exec keeps working after Home Manager generation changes.
   codexPackage = inputs.llm-agents.packages.${system}.codex;
   fencePackage = import ../fence/package.nix { inherit inputs pkgs; };
+  fenceGit = import ../fence/git.nix;
   fenceWaylandBridge = import ../fence/wayland-bridge.nix { inherit pkgs; };
   fenceChromium =
     if !(host.is.linux && fencedEnabled) then
@@ -110,6 +111,7 @@ let
     ++ fenceLogging.runtimeInputs;
     text = ''
       ${fenceWaylandBridge.setupShell}
+      ${fenceGit.setupShell}
       ${fenceChromium.setupShell}
 
       fence_log_agent="codex"

--- a/home-manager/_mixins/agentic/default.nix
+++ b/home-manager/_mixins/agentic/default.nix
@@ -30,7 +30,7 @@ in
       agentPackages.cubic
     ]
     ++ lib.optionals browserAutomationEnabled [
-      agentPackages.agent-browser
+      # agentPackages.agent-browser
     ];
   };
 }

--- a/home-manager/_mixins/agentic/fence/default.nix
+++ b/home-manager/_mixins/agentic/fence/default.nix
@@ -29,6 +29,11 @@ let
         "${profileDirectory}/**"
         "${config.xdg.configHome}/sops-nix"
         "${config.xdg.configHome}/sops-nix/**"
+
+        # Git reads these files when signing commits and verifying SSH signatures.
+        "${homeDirectory}/.ssh/id_rsa"
+        "${homeDirectory}/.ssh/id_rsa.pub"
+        "${homeDirectory}/.ssh/allowed_signers"
       ];
       allowExecute = [
         # Keep the Nix store executable as one tree. Binding a single store
@@ -101,11 +106,10 @@ let
       ];
 
       denyRead = [
-        "/etc/passwd"
         "/etc/shadow"
 
-        # SSH private keys and config
-        "~/.ssh/**"
+        # Keep every other SSH child and subtree unreadable.
+        "~/.ssh/{a,al,all,allo,allow,allowe,allowed,allowed_,allowed_s,allowed_si,allowed_sig,allowed_sign,allowed_signe,allowed_signer,i,id,id_,id_r,id_rs,[^ai]*,a[^l]*,al[^l]*,all[^o]*,allo[^w]*,allow[^e]*,allowe[^d]*,allowed[^_]*,allowed_[^s]*,allowed_s[^i]*,allowed_si[^g]*,allowed_sig[^n]*,allowed_sign[^e]*,allowed_signe[^r]*,allowed_signer[^s]*,allowed_signers?*,i[^d]*,id[^_]*,id_[^r]*,id_r[^s]*,id_rs[^a]*,id_rsa.,id_rsa.p,id_rsa.pu,id_rsa[^.]*,id_rsa.[^p]*,id_rsa.p[^u]*,id_rsa.pu[^b]*,id_rsa.pub?*}"
 
         # GPG keys
         "~/.gnupg/**"
@@ -282,7 +286,6 @@ let
         "just switch"
         "just switch-home"
         "just switch-host"
-        "git push"
         "git reset"
         "git clean"
         "git rebase"

--- a/home-manager/_mixins/agentic/fence/default.nix
+++ b/home-manager/_mixins/agentic/fence/default.nix
@@ -30,9 +30,7 @@ let
         "${config.xdg.configHome}/sops-nix"
         "${config.xdg.configHome}/sops-nix/**"
 
-        # Git reads these files when signing commits and verifying SSH signatures.
-        "${homeDirectory}/.ssh/id_rsa"
-        "${homeDirectory}/.ssh/id_rsa.pub"
+        # Git reads this file when verifying SSH signatures.
         "${homeDirectory}/.ssh/allowed_signers"
       ];
       allowExecute = [
@@ -107,6 +105,12 @@ let
 
       denyRead = [
         "/etc/shadow"
+
+        # Fenced agents create unsigned commits and do not need signing keys.
+        "${homeDirectory}/.ssh/id_rsa"
+        "${homeDirectory}/.ssh/id_rsa.pub"
+        "${config.xdg.configHome}/sops-nix/secrets/ssh_key"
+        "${config.xdg.configHome}/sops-nix/secrets/ssh_pub"
 
         # Keep every other SSH child and subtree unreadable.
         "~/.ssh/{a,al,all,allo,allow,allowe,allowed,allowed_,allowed_s,allowed_si,allowed_sig,allowed_sign,allowed_signe,allowed_signer,i,id,id_,id_r,id_rs,[^ai]*,a[^l]*,al[^l]*,all[^o]*,allo[^w]*,allow[^e]*,allowe[^d]*,allowed[^_]*,allowed_[^s]*,allowed_s[^i]*,allowed_si[^g]*,allowed_sig[^n]*,allowed_sign[^e]*,allowed_signe[^r]*,allowed_signer[^s]*,allowed_signers?*,i[^d]*,id[^_]*,id_[^r]*,id_r[^s]*,id_rs[^a]*,id_rsa.,id_rsa.p,id_rsa.pu,id_rsa[^.]*,id_rsa.[^p]*,id_rsa.p[^u]*,id_rsa.pu[^b]*,id_rsa.pub?*}"

--- a/home-manager/_mixins/agentic/fence/git.nix
+++ b/home-manager/_mixins/agentic/fence/git.nix
@@ -1,0 +1,34 @@
+{
+  setupShell = ''
+    setup_fence_git() {
+      local git_config_index
+
+      git_config_index="''${GIT_CONFIG_COUNT:-0}"
+      case "$git_config_index" in
+        *[!0-9]*)
+          printf 'fence: GIT_CONFIG_COUNT must be a decimal integer from 0 to 1024.\n' >&2
+          return 1
+          ;;
+      esac
+
+      if (( ''${#git_config_index} > 4 )); then
+        printf 'fence: GIT_CONFIG_COUNT must be a decimal integer from 0 to 1024.\n' >&2
+        return 1
+      fi
+
+      git_config_index=$((10#$git_config_index))
+      if (( git_config_index > 1024 )); then
+        printf 'fence: GIT_CONFIG_COUNT must be a decimal integer from 0 to 1024.\n' >&2
+        return 1
+      fi
+
+      fence_env+=(
+        "GIT_CONFIG_COUNT=$((git_config_index + 1))"
+        "GIT_CONFIG_KEY_$git_config_index=commit.gpgSign"
+        "GIT_CONFIG_VALUE_$git_config_index=false"
+      )
+    }
+
+    setup_fence_git
+  '';
+}

--- a/home-manager/_mixins/agentic/opencode/default.nix
+++ b/home-manager/_mixins/agentic/opencode/default.nix
@@ -107,6 +107,7 @@ let
         };
       });
   fencePackage = import ../fence/package.nix { inherit inputs pkgs; };
+  fenceGit = import ../fence/git.nix;
   fenceWaylandBridge = import ../fence/wayland-bridge.nix { inherit pkgs; };
   fenceChromium =
     if !(host.is.linux && fencedEnabled) then
@@ -127,6 +128,7 @@ let
     ++ fenceLogging.runtimeInputs;
     text = ''
       ${fenceWaylandBridge.setupShell}
+      ${fenceGit.setupShell}
       ${fenceChromium.setupShell}
 
       fence_log_agent="opencode"

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -14,6 +14,7 @@ let
   fencedEnabled = !host.is.server;
   piPackage = inputs.llm-agents.packages.${system}.pi;
   fencePackage = import ../fence/package.nix { inherit inputs pkgs; };
+  fenceGit = import ../fence/git.nix;
   fenceWaylandBridge = import ../fence/wayland-bridge.nix { inherit pkgs; };
   fenceChromium =
     if !(host.is.linux && fencedEnabled) then
@@ -266,6 +267,7 @@ let
     ++ fenceLogging.runtimeInputs;
     text = ''
       ${fenceWaylandBridge.setupShell}
+      ${fenceGit.setupShell}
       ${fenceChromium.setupShell}
 
       fence_log_agent="pi"

--- a/home-manager/_mixins/users/martin/ssh.nix
+++ b/home-manager/_mixins/users/martin/ssh.nix
@@ -38,7 +38,7 @@ in
 lib.mkIf (noughtyLib.isUser [ "martin" ]) {
   home = {
     # SSH allowed signers for Git verification
-    file.".ssh/allowed_signers".text = ''
+    file.".ssh/allowed_signers".text = "${config.programs.git.settings.user.email} " + ''
       ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAywaYwPN4LVbPqkc+kUc7ZVazPBDy4LCAud5iGJdr7g9CwLYoudNjXt/98Oam5lK7ai6QPItK6ECj5+33x/iFpWb3Urr9SqMc/tH5dU1b9N/9yWRhE2WnfcvuI0ms6AXma8QGp1pj/DoLryPVQgXvQlglHaDIL1qdRWFqXUO2u30X5tWtDdOoR02UyAtYBttou4K0rG7LF9rRaoLYP9iCBLxkMJbCIznPD/pIYa6Fl8V8/OVsxYiFy7l5U0RZ7gkzJv8iNz+GG8vw2NX4oIJfAR4oIk3INUvYrKvI2NSMSw5sry+z818fD1hK+soYLQ4VZ4hHRHcf4WV4EeVa5ARxdw== Martin Wimpress
     '';
     # Darwin openssh for FIDO2 support

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -11,17 +11,17 @@
     final: prev:
     let
       paseoPackages = inputs.paseo.packages.${prev.stdenv.hostPlatform.system} or { };
-      # Only the Paseo daemon and CLI come from the upstream Paseo flake now; the
-      # desktop client is sourced separately from the llm-agents flake below.
+      # Paseo packages come from the upstream Paseo flake; the desktop client
+      # reuses the patched daemon npm closure below.
       #
-      # The v0.1.103 tag ships a wrong npm-deps fixed-output hash, which breaks
+      # The v0.1.107 tag ships a wrong npm-deps fixed-output hash, which breaks
       # the build with a hash mismatch. Correct the hash here until the next
       # upstream release carries a good one.
       fixPaseoNpmDeps =
         pkg:
         pkg.overrideAttrs (oldAttrs: {
           npmDeps = oldAttrs.npmDeps.overrideAttrs {
-            outputHash = "sha256-o+VzG7lK0qpyUXF4F5Hk08ooW5CPoZSsOG7DyIReUKQ=";
+            outputHash = "sha256-A9/bukljfvGyfv6TTP8xfdDA8+J2WLzsUiwqqHisfN8=";
           };
         });
       paseoAttrs = prev.lib.optionalAttrs ((paseoPackages ? paseo) || (paseoPackages ? default)) {
@@ -93,12 +93,14 @@
         else
           throw "claude-desktop is only available on Linux";
 
-      # The Paseo desktop client comes from the llm-agents flake for its numtide
-      # cache, so it tracks that pin independently of the upstream paseo daemon.
-      # https://github.com/numtide/llm-agents.nix
+      # The upstream desktop client reuses the patched paseo npm closure above.
+      # The llm-agents package builds a separate large npm-deps derivation that
+      # is brittle against registry fetch failures.
       paseo-desktop =
         if final.stdenv.hostPlatform.isLinux then
-          inputs.llm-agents.packages.${final.stdenv.hostPlatform.system}.paseo-desktop
+          inputs.paseo.packages.${final.stdenv.hostPlatform.system}.desktop.override {
+            inherit (final) paseo;
+          }
         else
           throw "paseo-desktop is only available on Linux";
 


### PR DESCRIPTION
## Summary
Allow fenced agents to commit and push with the user's Git identity without access to private signing keys, while updating the affected agent packages.

## Changes
- Add a fenced Git wrapper that creates unsigned commits and permits non-destructive pushes
- Preserve signed commits outside Fence and remove private signing-key access from fenced assistants
- Keep agent-browser enabled only on Hermes
- Fix Paseo and Paseo Desktop 0.1.107 builds with patched upstream packages
- Update the llm-agents flake input

## Testing
- Passed Nix formatting and diff checks
- Passed `just eval`
- Passed the full x86_64-linux `just check`
- Built the relevant Home Manager configurations
- Built the Paseo and Paseo Desktop packages
- Inspected the generated fenced wrapper
- Verified unsigned disposable Git commit, amend, and push flows
- Verified existing signed commits remain valid
