### PR TITLE
fix(transmission): restrict RPC firewall access

### DIFF
--- a/nixos/_mixins/server/transmission/default.nix
+++ b/nixos/_mixins/server/transmission/default.nix
@@ -22,7 +22,7 @@ lib.mkIf
       enable = true;
       home = "/srv/transmission";
       openFirewall = false;
-      openRPCPort = true;
+      openRPCPort = false;
       openPeerPorts = false;
       package = pkgs.transmission_4;
       performanceNetParameters = true;
@@ -68,6 +68,10 @@ lib.mkIf
         watch-dir-enabled = true;
       };
     };
+
+    networking.firewall.extraCommands = ''
+      iptables -A nixos-fw -p tcp -s 10.10.10.0/24 --dport ${toString config.services.transmission.settings.rpc-port} -j nixos-fw-accept
+    '';
 
     sops = {
       secrets = {


### PR DESCRIPTION
## Summary

- Restrict Transmission RPC firewall access to the existing `10.10.10.0/24` LAN.
- Keep RPC available over the trusted Tailscale interface.
- Stop globally opening port 9091 while RPC authentication is disabled.

## Root cause

`openRPCPort` opens the RPC port on every interface. The configured RPC allowlist also matched public addresses in `100.0.0.0/8`.

## Validation

- Traced the pinned NixOS Transmission module and iptables firewall chain behaviour.
- Reviewed Transmission RPC source-address matching.
- Ran `git diff --check`.
