### PR TITLE
chore(paseo): update to v0.1.108

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1009,16 +1009,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1783895263,
-        "narHash": "sha256-19Riz8lf63A924s0gQtaWyChjBKj+yrg6BR6/U4dzVw=",
+        "lastModified": 1784153757,
+        "narHash": "sha256-OtelbDgTfbx9OT2qcIAYTwnouqczOMAXhKAW1pr3ydA=",
         "owner": "getpaseo",
         "repo": "paseo",
-        "rev": "9553f4b32864707853723cdf8dcbebcd7bf4a6ea",
+        "rev": "75ea0d4534a2922e6f3072d805008474ac4728bd",
         "type": "github"
       },
       "original": {
         "owner": "getpaseo",
-        "ref": "v0.1.107",
+        "ref": "v0.1.108",
         "repo": "paseo",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";
-    paseo.url = "github:getpaseo/paseo/v0.1.107";
+    paseo.url = "github:getpaseo/paseo/v0.1.108";
     paseo.inputs.nixpkgs.follows = "nixpkgs-unstable";
     voxtype.url = "github:peteonrails/voxtype/v0.7.5";
     voxtype.inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
Automated Paseo update to v0.1.108.

Changelog: https://github.com/getpaseo/paseo/commits