### PR TITLE
fix(agentic): load Nix project tools inside Fence

### DIFF
--- a/home-manager/_mixins/agentic/claude-code/default.nix
+++ b/home-manager/_mixins/agentic/claude-code/default.nix
@@ -512,16 +512,16 @@ let
       case "$width" in
         "" | *[!0-9]*)
           if [[ -n "$tmp_mcp_config" ]]; then
-            fence "''${fence_args[@]}" -- "''${fence_env[@]}" "NOUGHTY_AGENT_ISOLATION=Fenced" ${claudeEnvironmentArgs} ${lib.getExe' claudePackageWithLsp "claude"} "--mcp-config=$tmp_mcp_config" --dangerously-skip-permissions "''${claude_defaults[@]}" "$@"
+            fence "''${fence_args[@]}" -- "''${fence_env[@]}" "''${fence_direnv[@]}" "NOUGHTY_AGENT_ISOLATION=Fenced" ${claudeEnvironmentArgs} ${lib.getExe' claudePackageWithLsp "claude"} "--mcp-config=$tmp_mcp_config" --dangerously-skip-permissions "''${claude_defaults[@]}" "$@"
           else
-            fence "''${fence_args[@]}" -- "''${fence_env[@]}" "NOUGHTY_AGENT_ISOLATION=Fenced" ${claudeEnvironmentArgs} ${lib.getExe' claudePackageWithLsp "claude"} --dangerously-skip-permissions "''${claude_defaults[@]}" "$@"
+            fence "''${fence_args[@]}" -- "''${fence_env[@]}" "''${fence_direnv[@]}" "NOUGHTY_AGENT_ISOLATION=Fenced" ${claudeEnvironmentArgs} ${lib.getExe' claudePackageWithLsp "claude"} --dangerously-skip-permissions "''${claude_defaults[@]}" "$@"
           fi
           ;;
         *)
           if [[ -n "$tmp_mcp_config" ]]; then
-            fence "''${fence_args[@]}" -- "''${fence_env[@]}" "CCSTATUSLINE_WIDTH=$width" "NOUGHTY_AGENT_ISOLATION=Fenced" ${claudeEnvironmentArgs} ${lib.getExe' claudePackageWithLsp "claude"} "--mcp-config=$tmp_mcp_config" --dangerously-skip-permissions "''${claude_defaults[@]}" "$@"
+            fence "''${fence_args[@]}" -- "''${fence_env[@]}" "''${fence_direnv[@]}" "CCSTATUSLINE_WIDTH=$width" "NOUGHTY_AGENT_ISOLATION=Fenced" ${claudeEnvironmentArgs} ${lib.getExe' claudePackageWithLsp "claude"} "--mcp-config=$tmp_mcp_config" --dangerously-skip-permissions "''${claude_defaults[@]}" "$@"
           else
-            fence "''${fence_args[@]}" -- "''${fence_env[@]}" "CCSTATUSLINE_WIDTH=$width" "NOUGHTY_AGENT_ISOLATION=Fenced" ${claudeEnvironmentArgs} ${lib.getExe' claudePackageWithLsp "claude"} --dangerously-skip-permissions "''${claude_defaults[@]}" "$@"
+            fence "''${fence_args[@]}" -- "''${fence_env[@]}" "''${fence_direnv[@]}" "CCSTATUSLINE_WIDTH=$width" "NOUGHTY_AGENT_ISOLATION=Fenced" ${claudeEnvironmentArgs} ${lib.getExe' claudePackageWithLsp "claude"} --dangerously-skip-permissions "''${claude_defaults[@]}" "$@"
           fi
           ;;
       esac

--- a/home-manager/_mixins/agentic/codex/default.nix
+++ b/home-manager/_mixins/agentic/codex/default.nix
@@ -125,7 +125,7 @@ let
 
       # Pass the bypass through as an env token so the launcher sees the real
       # first user argument and resumes the most recent session by default.
-      fence "''${fence_args[@]}" -- "''${fence_env[@]}" "NOUGHTY_CODEX_BYPASS=1" ${lib.getExe' codexLauncherPackage "codex"} "$@"
+      fence "''${fence_args[@]}" -- "''${fence_env[@]}" "''${fence_direnv[@]}" "NOUGHTY_CODEX_BYPASS=1" ${lib.getExe' codexLauncherPackage "codex"} "$@"
     '';
   };
   codexTripwireCorrectionPromptFile = pkgs.writeTextFile {

--- a/home-manager/_mixins/agentic/fence/README.md
+++ b/home-manager/_mixins/agentic/fence/README.md
@@ -17,8 +17,10 @@ The Fence mixin owns the shared policy and runtime dependencies. Each fenced
 command is declared by the corresponding agent mixin so it appears only when
 the standard agent entry point is also installed.
 
-The wrappers use `fence -- <agent>` so any following flags are passed to the
-agent rather than parsed as Fence flags. `claude-fenced` runs Claude with
+The wrappers use `fence -- direnv exec "$PWD" env <agent>` so project devShell
+tools are available and any following flags are passed to the agent rather than
+parsed as Fence flags. Direnv runs inside Fence, so project-controlled `.envrc`
+files never execute outside the sandbox. `claude-fenced` runs Claude with
 `--dangerously-skip-permissions`; Fence is the permission boundary for that
 entry point. `codex-fenced` runs Codex with
 `--dangerously-bypass-approvals-and-sandbox`, leaving Fence as the only sandbox
@@ -71,15 +73,8 @@ keeps the generated config reviewable: full outbound network access is expressed
 as `allowedDomains = ["*"]`, with no inherited domain deny-list. Filesystem and
 command policy still apply.
 
-The Home Manager mixin builds Fence from the `llm-agents` flake input with a
-single local override in [`package.nix`](./package.nix). The override rewrites
-`linuxArgvExecMaxArgs` in `internal/sandbox/runtime_exec_argv_linux.go` to
-`4096`, raising the per-process argv vector cap that Fence's Linux argv
-runtime-exec policy will inspect. The upstream default is too low for
-long-running native-toolchain builds (C, C++, Go, Rust), whose compile and
-link invocations exceed Fence's argv cap and would otherwise be rejected
-before the policy could decide; raising it lets those builds complete under
-the policy.
+The Home Manager mixin uses the Fence package from the `llm-agents` flake
+input without local source patches.
 
 The launch directory is writable through Fence's `"."` path rule. This matters
 on Linux because Fence may otherwise re-bind the current project read-only while
@@ -88,10 +83,12 @@ reconstructing `/home` across mount boundaries.
 Device handling is pinned to Fence's `minimal` mode for deterministic Linux
 sandbox behaviour.
 
-Command runtime enforcement uses Fence's `argv` mode on Linux. This lets Fence
-inspect descendant process arguments, so multi-token denies such as `git push`,
-`just switch-home`, `nix store delete`, and `nh home switch` remain enforced
-after agent startup.
+Command runtime enforcement uses Fence's `path` mode. This permits
+multithreaded tools such as Nix and Go to execute child processes. Single-token
+executable denies remain runtime-enforced. Multi-token denies such as `git
+push`, `just switch-home`, `nix store delete`, and `nh home switch` remain
+preflight-enforced only when they are the initial fenced command. Fence cannot
+enforce them against commands spawned by an agent in this mode.
 
 Some coreutils-backed denies are listed in
 `acceptSharedBinaryCannotRuntimeDeny`. They remain preflight-denied, but are not

--- a/home-manager/_mixins/agentic/fence/README.md
+++ b/home-manager/_mixins/agentic/fence/README.md
@@ -19,8 +19,11 @@ the standard agent entry point is also installed.
 
 The wrappers use `fence -- direnv exec "$PWD" env <agent>` so project devShell
 tools are available and any following flags are passed to the agent rather than
-parsed as Fence flags. Direnv runs inside Fence, so project-controlled `.envrc`
-files never execute outside the sandbox. `claude-fenced` runs Claude with
+parsed as Fence flags. They also set `BASH_ENV` to load direnv for each
+non-interactive Bash command. This activates the environment for the command's
+working directory when an agent server starts elsewhere and later enters a
+project. Direnv runs inside Fence, so project-controlled `.envrc` files never
+execute outside the sandbox. `claude-fenced` runs Claude with
 `--dangerously-skip-permissions`; Fence is the permission boundary for that
 entry point. `codex-fenced` runs Codex with
 `--dangerously-bypass-approvals-and-sandbox`, leaving Fence as the only sandbox
@@ -90,10 +93,12 @@ push`, `just switch-home`, `nix store delete`, and `nh home switch` remain
 preflight-enforced only when they are the initial fenced command. Fence cannot
 enforce them against commands spawned by an agent in this mode.
 
-Some coreutils-backed denies are listed in
-`acceptSharedBinaryCannotRuntimeDeny`. They remain preflight-denied, but are not
-runtime-masked because Nixpkgs coreutils is a multicall binary and masking it
-also masks essentials such as `env`.
+The `nix-collect-garbage` deny and some coreutils-backed denies are listed in
+`acceptSharedBinaryCannotRuntimeDeny`. Fence checks them only when they are the
+initial fenced command. It does not runtime-mask them because Determinate Nix
+uses one binary for `nix` and its legacy commands, while Nixpkgs coreutils uses
+one binary for tools such as `env`. Masking either shared binary blocks required
+development commands.
 
 Git commits and workflow edits are allowed. Fence has no approval or ask mode.
 Commands are allowed or denied.

--- a/home-manager/_mixins/agentic/fence/README.md
+++ b/home-manager/_mixins/agentic/fence/README.md
@@ -77,7 +77,10 @@ as `allowedDomains = ["*"]`, with no inherited domain deny-list. Filesystem and
 command policy still apply.
 
 The Home Manager mixin uses the Fence package from the `llm-agents` flake
-input without local source patches.
+input with a local shared-binary probe for `nix`. Fence only honours
+`acceptSharedBinaryCannotRuntimeDeny` after it detects a collision with one of
+its critical command names. The probe lets Fence detect that Determinate Nix's
+legacy commands resolve to the same binary as `nix`.
 
 The launch directory is writable through Fence's `"."` path rule. This matters
 on Linux because Fence may otherwise re-bind the current project read-only while

--- a/home-manager/_mixins/agentic/fence/default.nix
+++ b/home-manager/_mixins/agentic/fence/default.nix
@@ -148,6 +148,11 @@ let
       useDefaults = true;
       runtimeExecPolicy = "path";
       acceptSharedBinaryCannotRuntimeDeny = [
+        # Determinate Nix uses one binary for `nix` and the legacy
+        # `nix-collect-garbage` command. Runtime-masking the denied legacy
+        # command also masks `nix`, which prevents all flake development.
+        "nix-collect-garbage"
+
         # Nixpkgs coreutils is a multicall binary. Runtime-masking any of
         # these would also mask `env`, breaking common shebangs.
         "chroot"

--- a/home-manager/_mixins/agentic/fence/default.nix
+++ b/home-manager/_mixins/agentic/fence/default.nix
@@ -146,7 +146,7 @@ let
     };
     command = {
       useDefaults = true;
-      runtimeExecPolicy = "argv";
+      runtimeExecPolicy = "path";
       acceptSharedBinaryCannotRuntimeDeny = [
         # Nixpkgs coreutils is a multicall binary. Runtime-masking any of
         # these would also mask `env`, breaking common shebangs.

--- a/home-manager/_mixins/agentic/fence/logging.nix
+++ b/home-manager/_mixins/agentic/fence/logging.nix
@@ -5,15 +5,20 @@
 # `${XDG_STATE_HOME:-$HOME/.local/state}/fence`, picks a per-launch filename
 # of the form `<agent>-<timestamp>-<pid>.log`, refreshes a
 # `<agent>-current.log` symlink, and appends `-m --fence-log-file <file>` to
-# `fence_args`. The agent name is taken from the wrapper-local variable
-# `fence_log_agent`; only literal `claude|codex|opencode|pi` should be set.
+# `fence_args`. It also prepares the `direnv exec` prefix used to load the
+# project devShell inside Fence. The agent name is taken from the wrapper-local
+# variable `fence_log_agent`; only literal `claude|codex|opencode|pi` should be
+# set.
 #
 # Permissions: the directory is created 0700; Fence opens the file 0600 via
 # the flag path, so the helper deliberately does not pre-create the file.
 { pkgs }:
 
 {
-  runtimeInputs = [ pkgs.coreutils ];
+  runtimeInputs = [
+    pkgs.coreutils
+    pkgs.direnv
+  ];
 
   setupShell = ''
     setup_fence_logging() {
@@ -43,5 +48,12 @@
     }
 
     setup_fence_logging
+
+    fence_direnv=(
+      ${pkgs.lib.getExe pkgs.direnv}
+      exec
+      "$PWD"
+      ${pkgs.lib.getExe' pkgs.coreutils "env"}
+    )
   '';
 }

--- a/home-manager/_mixins/agentic/fence/logging.nix
+++ b/home-manager/_mixins/agentic/fence/logging.nix
@@ -5,15 +5,20 @@
 # `${XDG_STATE_HOME:-$HOME/.local/state}/fence`, picks a per-launch filename
 # of the form `<agent>-<timestamp>-<pid>.log`, refreshes a
 # `<agent>-current.log` symlink, and appends `-m --fence-log-file <file>` to
-# `fence_args`. It also prepares the `direnv exec` prefix used to load the
-# project devShell inside Fence. The agent name is taken from the wrapper-local
-# variable `fence_log_agent`; only literal `claude|codex|opencode|pi` should be
-# set.
+# `fence_args`. It also prepares the `direnv exec` prefix and a `BASH_ENV` hook
+# used to load the project devShell inside Fence. The agent name is taken from
+# the wrapper-local variable `fence_log_agent`; only literal
+# `claude|codex|opencode|pi` should be set.
 #
 # Permissions: the directory is created 0700; Fence opens the file 0600 via
 # the flag path, so the helper deliberately does not pre-create the file.
 { pkgs }:
 
+let
+  fenceDirenvBashEnv = pkgs.writeText "fence-direnv-bash-env" ''
+    eval "$(BASH_ENV= ${pkgs.lib.getExe pkgs.direnv} export bash)"
+  '';
+in
 {
   runtimeInputs = [
     pkgs.coreutils
@@ -54,6 +59,7 @@
       exec
       "$PWD"
       ${pkgs.lib.getExe' pkgs.coreutils "env"}
+      "BASH_ENV=${fenceDirenvBashEnv}"
     )
   '';
 }

--- a/home-manager/_mixins/agentic/fence/package.nix
+++ b/home-manager/_mixins/agentic/fence/package.nix
@@ -1,12 +1,2 @@
 { inputs, pkgs }:
-let
-  inherit (pkgs.stdenv.hostPlatform) system;
-  inherit (pkgs) lib;
-in
-inputs.llm-agents.packages.${system}.fence.overrideAttrs (old: {
-  postPatch =
-    (old.postPatch or "")
-    + lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
-      sed -i -E 's/^[[:space:]]*linuxArgvExecMaxArgs[[:space:]]*=.*/\tlinuxArgvExecMaxArgs        = 4096/' internal/sandbox/runtime_exec_argv_linux.go
-    '';
-})
+inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.fence

--- a/home-manager/_mixins/agentic/fence/package.nix
+++ b/home-manager/_mixins/agentic/fence/package.nix
@@ -1,2 +1,7 @@
 { inputs, pkgs }:
-inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.fence
+inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.fence.overrideAttrs (oldAttrs: {
+  postPatch = (oldAttrs.postPatch or "") + ''
+    substituteInPlace internal/sandbox/runtime_exec_deny.go \
+      --replace-fail $'\t"xargs",' $'\t"xargs",\n\t// Determinate Nix exposes legacy commands as aliases of the nix binary.\n\t"nix",'
+  '';
+})

--- a/home-manager/_mixins/agentic/opencode/default.nix
+++ b/home-manager/_mixins/agentic/opencode/default.nix
@@ -139,7 +139,7 @@ let
       # Exa MCP server. The env var wins on conflicting keys, so the denies are
       # named here explicitly.
       export OPENCODE_PERMISSION='{"*":"allow","webfetch":"deny","websearch":"deny"}'
-      fence "''${fence_args[@]}" -- "''${fence_env[@]}" ${lib.getExe' opencodeLauncherPackage "opencode"} "$@"
+      fence "''${fence_args[@]}" -- "''${fence_env[@]}" "''${fence_direnv[@]}" ${lib.getExe' opencodeLauncherPackage "opencode"} "$@"
     '';
   };
 

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -274,7 +274,7 @@ let
       ${fenceLogging.setupShell}
 
       export NOUGHTY_AGENT_LAUNCH_COMMAND="pi-fenced"
-      fence "''${fence_args[@]}" -- "''${fence_env[@]}" ${lib.getExe' piWrapperPackage "pi"} "$@"
+      fence "''${fence_args[@]}" -- "''${fence_env[@]}" "''${fence_direnv[@]}" ${lib.getExe' piWrapperPackage "pi"} "$@"
     '';
   };
 


### PR DESCRIPTION
## Summary

Make Nix development environments work inside fenced agents.

## Changes

- Keep Determinate Nix available when denied legacy commands share its binary
- Load direnv for each non-interactive command in its project directory
- Allow Nix and Go to start child processes
- Remove the obsolete Fence argv patch
- Document the policy trade-offs

## Tests

- `just format`
- `just eval`
- Home Manager activation package build for `martin@zannah`
- Automatic direnv activation in Nyala
- `command -v gcc gocyclo ineffassign`
- `just lint`
- `go test -race ./internal/ocr`
- `nix develop --no-write-lock-file -c true`
- `nix develop --no-write-lock-file -c just lint`

The direct Nix checks used an unmasked Nix store binary because the running agent retains the old Fence bind mount until it restarts.
