### PR TITLE
chore(hermes-agent): update to v2026.7.20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,14 +593,14 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1783473288,
-        "narHash": "sha256-Yk/BXRlNJgfeqjy8hDOT/HbKgevWTH786Df+sQ3g9MU=",
+        "lastModified": 1784572521,
+        "narHash": "sha256-QJEiBOLAVGeYBym4EUtnDgeIyJyDQWgmat70/yujiz4=",
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.7.7.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.7.20.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.7.7.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.7.20.tar.gz"
       }
     },
     "home-manager": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
-    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.7.7.tar.gz";
+    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.7.20.tar.gz";
     hermes-agent.inputs.nixpkgs.follows = "nixpkgs-unstable";
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
Automated Hermes Agent update to v2026.7.20.

Changelog: https://github.com/NousResearch/hermes-agent/releases