### PR TITLE
chore(concord): update to v2.4.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,16 +138,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784635348,
-        "narHash": "sha256-OCmg136ZTduwyGfunk/opHAkhnhOXDUS75Q7xO2ybOU=",
+        "lastModified": 1784963912,
+        "narHash": "sha256-L12GeHMaDy/T+ui0V2wu/uWjidbLWGgdHUEm3CeTS3k=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "bdebd86bc3818d245bd042c2921337ba48d19270",
+        "rev": "4e2ff2b8b4dce539a77b581f8d640e0237539cce",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.4.4",
+        "ref": "v2.4.6",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.4.4";
+    concord.url = "github:chojs23/concord/v2.4.6";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to v2.4.6.

Changelog: https://github.com/chojs23/concord/releases