### PR TITLE
feat(agentic,fence): sign work commits under ~/Chainguard with gitsign

### DIFF
--- a/home-manager/_mixins/agentic/fence/README.md
+++ b/home-manager/_mixins/agentic/fence/README.md
@@ -92,9 +92,10 @@ sandbox behaviour.
 Command runtime enforcement uses Fence's `path` mode. This permits
 multithreaded tools such as Nix and Go to execute child processes. Single-token
 executable denies remain runtime-enforced. Multi-token denies such as `git
-push`, `just switch-home`, `nix store delete`, and `nh home switch` remain
-preflight-enforced only when they are the initial fenced command. Fence cannot
-enforce them against commands spawned by an agent in this mode.
+push`, `just switch-home`, `nix store delete`, `nh home switch`, and `gitsign
+initialize` remain preflight-enforced only when they are the initial fenced
+command. Fence cannot enforce them against commands spawned by an agent in this
+mode.
 
 The `nix-collect-garbage` deny and some coreutils-backed denies are listed in
 `acceptSharedBinaryCannotRuntimeDeny`. Fence checks them only when they are the
@@ -141,7 +142,9 @@ inject `commit.gpgSign=false` and `tag.gpgSign=false` through `GIT_CONFIG_*`,
 because the base configuration signs with an SSH key that Fence read-denies.
 `~/.sigstore` is writable because every signature, including a cache hit, opens
 the TUF trust store there as a LevelDB database with an exclusive lock.
-`gitsign initialize` is denied so an agent cannot rewrite that trust root.
+`gitsign initialize` is denied because it rewrites that trust root and changes
+what later local verification accepts. The multi-token enforcement limit above
+applies to that deny.
 
 The trade-off is real. An agent that reaches the socket can sign as the work
 identity for a rolling ten-minute window, and every Sigstore signature is

--- a/home-manager/_mixins/agentic/fence/README.md
+++ b/home-manager/_mixins/agentic/fence/README.md
@@ -129,6 +129,24 @@ are protected via on-disk file permissions. The user-facing sops-nix render
 directory at `~/.config/sops-nix` is intentionally read-allowed so API keys are
 exposed inside the sandbox.
 
+Commits in work repositories under `~/Chainguard` are signed with Sigstore
+through gitsign. The `gitsign-credential-cache` daemon runs on the host; only
+its unix socket at `~/.cache/sigstore/gitsign/cache.sock` crosses into the
+sandbox. What crosses that socket is an ephemeral signing key and a Fulcio
+certificate that expires after ten minutes, so no long-lived secret enters the
+fence: no SSH key, no GPG key, and no Google ID token. Signing is scoped by a
+`gitdir:~/Chainguard/*/` include in the Git configuration, so it applies to the
+nested work clones and nowhere else. Outside those clones the fenced wrappers
+inject `commit.gpgSign=false` and `tag.gpgSign=false` through `GIT_CONFIG_*`,
+because the base configuration signs with an SSH key that Fence read-denies.
+`~/.sigstore` is writable because every signature, including a cache hit, opens
+the TUF trust store there as a LevelDB database with an exclusive lock.
+`gitsign initialize` is denied so an agent cannot rewrite that trust root.
+
+The trade-off is real. An agent that reaches the socket can sign as the work
+identity for a rolling ten-minute window, and every Sigstore signature is
+recorded in a public transparency log that is permanent and cannot be removed.
+
 The GitHub CLI needs `~/.config/gh/hosts.yml` at startup, so that file is not
 read-denied. It cannot expose the `gh` credential only to the `gh` process.
 Fence allows the `gh auth` subcommands so the agent can inspect its identity

--- a/home-manager/_mixins/agentic/fence/README.md
+++ b/home-manager/_mixins/agentic/fence/README.md
@@ -140,7 +140,10 @@ fence: no SSH key, no GPG key, and no Google ID token. Signing is scoped by a
 nested work clones and nowhere else. Outside those clones the fenced wrappers
 inject `commit.gpgSign=false` and `tag.gpgSign=false` through `GIT_CONFIG_*`,
 because the base configuration signs with an SSH key that Fence read-denies.
-`~/.sigstore` is writable because every signature, including a cache hit, opens
+The wrappers pick between those two paths once, from the directory they start
+in, so launch a fenced agent inside the work repository you want it to commit
+in. An agent started elsewhere commits unsigned even when it reaches a work
+clone with `git -C`. `~/.sigstore` is writable because every signature, including a cache hit, opens
 the TUF trust store there as a LevelDB database with an exclusive lock.
 `gitsign initialize` is denied because it rewrites that trust root and changes
 what later local verification accepts. The multi-token enforcement limit above

--- a/home-manager/_mixins/agentic/fence/default.nix
+++ b/home-manager/_mixins/agentic/fence/default.nix
@@ -351,11 +351,17 @@ let
         "git config"
         # gitsign: signing and verification stay available so work commits
         # under ~/Chainguard can be signed, because nothing else denies the
-        # command. `initialize` is denied because it rewrites the local TUF
-        # trust root and no agent has a reason to run it. `gitsign` is
-        # deliberately not allow-listed: Fence's allow rules take precedence
-        # over denies, so a bare `gitsign` allow would shadow this longer
-        # prefix.
+        # command. `initialize` rewrites the local TUF trust root, so an
+        # agent that runs it repoints what later local verification trusts.
+        # This is a multi-token deny, so under `path` mode Fence checks it
+        # only when it is the initial fenced command and cannot enforce it
+        # against a command the agent spawns from its own shell. The entry
+        # stops the obvious case and records the intent; it is not a
+        # boundary. Runtime enforcement would mean masking the `gitsign`
+        # binary, which breaks the signing this policy exists to allow.
+        # `gitsign` is deliberately not allow-listed: Fence's allow rules
+        # take precedence over denies, so a bare `gitsign` allow would
+        # shadow this longer prefix.
         "gitsign initialize"
         "home-manager switch"
         "home-manager switch-generation"

--- a/home-manager/_mixins/agentic/fence/default.nix
+++ b/home-manager/_mixins/agentic/fence/default.nix
@@ -11,6 +11,15 @@ let
   inherit (config.home) homeDirectory profileDirectory;
   fencePackage = import ./package.nix { inherit inputs pkgs; };
 
+  # The gitsign credential cache daemon places its socket with Go's
+  # os.UserCacheDir, which ignores XDG variables on Darwin and returns
+  # ~/Library/Caches. Mirror the socket path branches in development/git.
+  gitsignCacheDir =
+    if host.is.darwin then
+      "${homeDirectory}/Library/Caches/sigstore/gitsign"
+    else
+      "${config.xdg.cacheHome}/sigstore/gitsign";
+
   fenceConfig = {
     allowPty = true;
     network = {
@@ -89,12 +98,14 @@ let
         "${homeDirectory}/.sigstore"
         "${homeDirectory}/.sigstore/**"
 
-        # The gitsign credential cache socket is covered by the XDG cache glob
-        # below, but list its directory as well for the same reason as /tmp. If
+        # The gitsign credential cache socket lives under ~/Library/Caches on
+        # Darwin, which no other rule covers, so this entry is the only one
+        # that reaches it there. On Linux the XDG cache glob below also covers
+        # it, but the bare directory is listed for the same reason as /tmp. If
         # the host daemon restarts mid-session it recreates the socket inode
         # after Fence started, and the bare directory keeps the Landlock rule
         # covering the new inode.
-        "${config.xdg.cacheHome}/sigstore/gitsign"
+        gitsignCacheDir
 
         # Package manager caches
         "~/.npm/_cacache"

--- a/home-manager/_mixins/agentic/fence/default.nix
+++ b/home-manager/_mixins/agentic/fence/default.nix
@@ -82,6 +82,20 @@ let
         "${config.xdg.configHome}/herdr"
         "${config.xdg.configHome}/herdr/**"
 
+        # gitsign signs work commits inside the sandbox. Every signature, even
+        # one served from the credential cache, opens the TUF trust store at
+        # ~/.sigstore/root/tuf.db. That is a LevelDB database opened read-write
+        # with an exclusive lock, so read access alone is not enough.
+        "${homeDirectory}/.sigstore"
+        "${homeDirectory}/.sigstore/**"
+
+        # The gitsign credential cache socket is covered by the XDG cache glob
+        # below, but list its directory as well for the same reason as /tmp. If
+        # the host daemon restarts mid-session it recreates the socket inode
+        # after Fence started, and the bare directory keeps the Landlock rule
+        # covering the new inode.
+        "${config.xdg.cacheHome}/sigstore/gitsign"
+
         # Package manager caches
         "~/.npm/_cacache"
         "~/.npm/_npx"
@@ -106,7 +120,9 @@ let
       denyRead = [
         "/etc/shadow"
 
-        # Fenced agents create unsigned commits and do not need signing keys.
+        # Fenced agents never sign with a long-lived key. Commits outside
+        # ~/Chainguard are unsigned, and work commits use gitsign, which needs
+        # neither the SSH key nor a GPG key inside the sandbox.
         "${homeDirectory}/.ssh/id_rsa"
         "${homeDirectory}/.ssh/id_rsa.pub"
         "${config.xdg.configHome}/sops-nix/secrets/ssh_key"
@@ -322,6 +338,14 @@ let
         # subcommands) and every uncarved destination flag
         # (`--file`, `--blob`, etc.) falls through to this deny.
         "git config"
+        # gitsign: signing and verification stay available so work commits
+        # under ~/Chainguard can be signed, because nothing else denies the
+        # command. `initialize` is denied because it rewrites the local TUF
+        # trust root and no agent has a reason to run it. `gitsign` is
+        # deliberately not allow-listed: Fence's allow rules take precedence
+        # over denies, so a bare `gitsign` allow would shadow this longer
+        # prefix.
+        "gitsign initialize"
         "home-manager switch"
         "home-manager switch-generation"
         "nixos-rebuild switch"

--- a/home-manager/_mixins/agentic/fence/git.nix
+++ b/home-manager/_mixins/agentic/fence/git.nix
@@ -22,10 +22,24 @@
         return 1
       fi
 
+      # Work clones live under ~/Chainguard and sign with gitsign, which needs
+      # no key inside the sandbox. Inject nothing there so the `gitdir:` include
+      # in the Git configuration governs signing. Everywhere else the base
+      # configuration signs with an SSH key that Fence read-denies, so turn
+      # signing off or the commit fails. ~/Chainguard itself is a personal
+      # repository and takes the unsigned path.
+      case "$PWD" in
+        "$HOME"/Chainguard/?*)
+          return 0
+          ;;
+      esac
+
       fence_env+=(
-        "GIT_CONFIG_COUNT=$((git_config_index + 1))"
+        "GIT_CONFIG_COUNT=$((git_config_index + 2))"
         "GIT_CONFIG_KEY_$git_config_index=commit.gpgSign"
         "GIT_CONFIG_VALUE_$git_config_index=false"
+        "GIT_CONFIG_KEY_$((git_config_index + 1))=tag.gpgSign"
+        "GIT_CONFIG_VALUE_$((git_config_index + 1))=false"
       )
     }
 

--- a/home-manager/_mixins/agentic/fence/git.nix
+++ b/home-manager/_mixins/agentic/fence/git.nix
@@ -28,6 +28,13 @@
       # configuration signs with an SSH key that Fence read-denies, so turn
       # signing off or the commit fails. ~/Chainguard itself is a personal
       # repository and takes the unsigned path.
+      #
+      # This decision is made once, from the directory the wrapper launches in,
+      # because `GIT_CONFIG_*` is process environment. An agent launched
+      # elsewhere that reaches a work clone through `git -C`, `GIT_DIR`, or a
+      # later `cd` therefore commits unsigned. The opposite direction fails
+      # safe: signing stays on with a personal identity, so the commit fails
+      # rather than signing as the wrong identity.
       case "$PWD" in
         "$HOME"/Chainguard/?*)
           return 0

--- a/home-manager/_mixins/development/git/default.nix
+++ b/home-manager/_mixins/development/git/default.nix
@@ -233,6 +233,14 @@ in
   };
 
   systemd.user = lib.mkIf host.is.linux {
+    # The daemon creates and owns its own socket at GITSIGN_CREDENTIAL_CACHE,
+    # removing any existing file at that path first. A systemd socket unit
+    # would bind the same path and lose the race, so socket activation is not
+    # used here. Activating it properly would need
+    # `--systemd-socket-activation` on ExecStart, which calls log.Fatalf when
+    # LISTEN_PID is absent, so the service could no longer be started
+    # directly. The daemon is wanted from login either way, so the simpler
+    # arrangement wins.
     services.gitsign-credential-cache = {
       Unit = {
         Description = "GitSign credential cache";
@@ -240,30 +248,6 @@ in
       Service = {
         Type = "simple";
         ExecStart = "${pkgs.gitsign}/bin/gitsign-credential-cache";
-      };
-      Install = {
-        WantedBy = [ "default.target" ];
-      };
-    };
-
-    sockets.gitsign-credential-cache = {
-      Unit = {
-        Description = "GitSign credential cache socket";
-      };
-      Socket = {
-        ListenStream = "${gitsignCredentialCache}";
-        DirectoryMode = "0700";
-      };
-      Install = {
-        WantedBy = [ "default.target" ];
-      };
-    };
-
-    # Enable and start the socket by default
-    targets.gitsign-credential-cache = {
-      Unit = {
-        Description = "Start gitsign-credential-cache socket";
-        Requires = [ "gitsign-credential-cache.socket" ];
       };
       Install = {
         WantedBy = [ "default.target" ];

--- a/home-manager/_mixins/users/martin/git.nix
+++ b/home-manager/_mixins/users/martin/git.nix
@@ -15,13 +15,33 @@ lib.mkIf (noughtyLib.isUser [ "martin" ]) {
       '';
       force = true;
     };
-    sessionVariables = {
-      GITSIGN_CONNECTOR_ID = "https://accounts.google.com";
-    };
   };
 
   programs = {
     git = {
+      # Work repositories are clones nested under ~/Chainguard and are signed
+      # with Sigstore rather than the personal SSH key. The `gitdir:` condition
+      # matches one path component before `**`, so it captures the nested
+      # clones at any depth and skips the ~/Chainguard/.git of cg-env itself.
+      includes = [
+        {
+          condition = "gitdir:~/Chainguard/*/";
+          contents = {
+            commit.gpgsign = true;
+            gitsign.connectorID = "https://accounts.google.com";
+            gpg = {
+              format = "x509";
+              # Home Manager defaults the x509 signer to gpgsm, so name gitsign.
+              x509.program = "gitsign";
+            };
+            tag.gpgsign = true;
+            user = {
+              email = "martin.wimpress@chainguard.dev";
+              name = "Martin Wimpress";
+            };
+          };
+        }
+      ];
       settings = {
         gpg = {
           ssh = {


### PR DESCRIPTION
This lets a fenced coding agent create Sigstore-signed commits in work
repositories nested under ~/Chainguard. Unsigned fenced commits and personal
SSH signing continue everywhere else.

No long-lived secret enters the sandbox. A gitsign-credential-cache daemon
runs on the host, and only its unix socket crosses the boundary. The agent
receives an ephemeral key and a Fulcio certificate valid for ten minutes.

Personal repos keep SSH signing on purpose, so they keep GitHub's green
Verified badge. GitHub does not verify gitsign x509 signatures.

gitsign is deliberately absent from command.allow. Fence checks allow before
deny and returns on the first prefix match, so a bare allow would shadow the
"gitsign initialize" deny.

Four host checks passed before implementation: the socket is reachable
inside the sandbox, Fence passes GITSIGN_CREDENTIAL_CACHE through, cg-env's
gitdir is exactly ~/Chainguard/.git, and GIT_CONFIG_* beats includeIf. A
separate commit removes dead gitsign socket activation, a pre-existing
defect found while making fenced signing depend on that daemon.

just format, just eval, 306 scanner fixtures, shellcheck over the four
fenced wrappers, and checks of both the generated Fence policy and the
generated git config all pass. A live signing operation has not run, because
it needs a browser.

Trade-off worth flagging: an agent with access to that socket can sign as
Martin's work identity for a rolling ten-minute window, and Sigstore
signatures land in a public, permanent transparency log.
