### PR TITLE
fix(brow6el): drop aarch64-linux from platforms

### DIFF
--- a/pkgs/brow6el/default.nix
+++ b/pkgs/brow6el/default.nix
@@ -154,9 +154,12 @@ stdenv.mkDerivation (finalAttrs: {
       binaryNativeCode
     ];
     mainProgram = "brow6el";
+    # The aarch64-linux build fails deterministically because the CEF
+    # distribution's libcef_dll_wrapper CMake project passes the x86-only
+    # '-m64' flag to g++. The aarch64 CEF selection above is kept so that a
+    # future fix only has to restore this platform.
     platforms = [
       "x86_64-linux"
-      "aarch64-linux"
     ];
   };
 })


### PR DESCRIPTION
Two unrelated CI blockers, both failing deterministically on main rather
than only on pull request branches, so both block the auto-merge gate on
every pull request.

## brow6el: drop aarch64-linux from platforms

The "Packages 📦 (aarch64-linux)" job fails deterministically on main at
f0f993a8, not only on pull request branches, so it blocks the auto-merge
gate on every pull request. The CEF distribution's libcef_dll_wrapper build
passes the x86-only '-m64' flag to g++ in preConfigure, which g++ on
ubuntu-24.04-arm rejects. Restricting meta.platforms to x86_64-linux makes
mkPackages exclude brow6el from the aarch64-linux matrix, so no workflow
edit is needed. The aarch64 CEF distribution selection stays in the
package, so a future aarch64 fix only has to restore the platform; this is
a stop-gap, not a real aarch64 fix.

Verified packages.aarch64-linux ? brow6el is now false and
packages.x86_64-linux ? brow6el is still true, with just eval passing and
just format reporting no change.

## voxtype-vulkan: patch the ggml Vulkan shader generator

The five "Home 🏠 martin@{bane,ravi,skrye,tanis,zannah}" jobs fail when
voxtype-vulkan links, with hundreds of undefined matmul_id_* and
matmul_*_cm1_* symbols.

The defect is upstream, in ggml's vulkan-shaders-gen, vendored through
whisper-rs-sys 0.15.0 inside the voxtype flake input. The generator
discards the glslc child exit status and only inspects stderr, so a child
that dies without printing anything counts as a success. The shader is then
absent from the generated source while the header still declares it, and
the breakage only appears at link time. fork() also fails transiently with
EAGAIN or ENOMEM on small CI runners, which takes the same silent path.

That explains why the identical derivation, 5il1dclqq0w15hh6amk6fa75cr6i5dpq,
builds on a workstation but not on a GitHub runner, and why three CI jobs of
that same derivation dropped different symbol sets: 434, 310 and 445 names.
It is not a version mismatch. All four ggml glslc feature tests pass with
the pinned shaderc 2026.1.

overlays/patches/vulkan-shaders-gen-fail-and-retry.patch carries the
exit-code check from llama.cpp PR 24450, reports the shader name, attempt,
exit code, terminating signal and captured glslc output on every failure,
retries fork() with backoff on EAGAIN and ENOMEM, retries a child killed by
a signal or one that failed while saying nothing, and reports any shader
left without SPIR-V. A genuine compile error writes real stderr and fails
identically each time, so it is reported once and not retried. The patch
also honours GGML_VK_SHADER_JOBS, which upstream fixes at
min(16, hardware_concurrency); the overlay sets it to 2, since each glslc
costs a few hundred MB and CMake already runs several generators at once.

The overlay applies the patch via postPatch on voxtype-vulkan-unwrapped and
re-points the upstream symlinkJoin wrapper at the patched build, so
upstream's runtime dependency list is not duplicated. Drop the override once
voxtype ships a whisper.cpp carrying PR 24450.

The first iteration, e7506cc3, already proved itself on CI: undefined
references went from 2729 to 0 and the build failed honestly with
"vulkan-shaders-gen: one or more shaders failed to compile" instead of
producing a broken binary. It stayed red and named no shader, because
per-shader glslc stderr was swallowed. The second iteration, 0565bb88, adds
the diagnosis and covers glslc being killed after it starts, which the
fork()-only retry did not.

Verified in a harness built from the vendored generator and the pinned
glslc. A clean run emits 1170 shader definitions for mul_mm.comp, of which
720 matmul_id and 360 _cm1, matching the unpatched baseline exactly. With a
glslc that exits non-zero and prints nothing, the unpatched generator exits
0 while emitting only 450 definitions and dropping every matmul_id, which
reproduces the CI failure; the patched generator exits 1. Under RLIMIT_NPROC
the unpatched generator exits 0 after 1170 fork failures and writes no
definitions at all. just eval passes, just format reports no change, and
nix build .#nixosConfigurations.bane.pkgs.voxtype-vulkan succeeds with the
patch applied cleanly and the crate test suite passing.

Refs: https://github.com/ggml-org/llama.cpp/issues/24393
Refs: https://github.com/ggml-org/llama.cpp/issues/20868
Refs: https://github.com/ggml-org/llama.cpp/pull/24450
Refs: https://github.com/peteonrails/voxtype/issues/550

