### PR TITLE
chore(wavebox): update to 151.2.141-2

### DIFF
--- a/pkgs/wavebox/default.nix
+++ b/pkgs/wavebox/default.nix
@@ -172,11 +172,11 @@ let
 
   linux = stdenvNoCC.mkDerivation (finalAttrs: {
     inherit pname meta passthru;
-    version = "150.2.131-2";
+    version = "151.2.141-2";
 
     src = fetchurl {
       url = "https://download.wavebox.app/stable/linux/deb/amd64/wavebox_${finalAttrs.version}_amd64.deb";
-      hash = "sha256-UJlhs95sKwaBZEZT7SRMuYuhxUT/3i3iXGTDRlSdXD4=";
+      hash = "sha256-TiPf5EggvrgXa2bpHpBWCibWGQ4YMXRG3XqAfluYP58=";
     };
 
     # With strictDeps on, some shebangs were not being patched correctly
@@ -264,11 +264,11 @@ let
 
   darwin = stdenvNoCC.mkDerivation (finalAttrs: {
     inherit pname meta passthru;
-    version = "150.2.131.2";
+    version = "151.2.141.2";
 
     src = fetchurl {
       url = "https://download.wavebox.app/stable/macuniversal/Install%20Wavebox%20${finalAttrs.version}.dmg";
-      hash = "sha256-DliNJUeUiN5suXj5rXDjZraf/d2+gFn+TgXSGeRjLfo=";
+      hash = "sha256-T+k7BWV2ta0VKIYPjWuRBwNfHDt1GCnAOpHGde+uvXo=";
     };
 
     dontPatch = true;


### PR DESCRIPTION
Automated Wavebox update to 151.2.141-2.

Changelog: https://wavebox.io/blog/releases/