### PR TITLE
refactor(agentic): route GitHub commands through gh skill

### DIFF
--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/prompt.md
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/prompt.md
@@ -8,7 +8,7 @@ Invoke named commands with the provider's prefix. Codex uses `$make-commit`; sla
 
 `$ARGUMENTS` is a pull request URL or number, a path to a local file holding review feedback, or the feedback pasted directly as text. If it is blank, ask which of those you have, then wait.
 
-For a pull request, fetch the review comments with dedicated `gh` subcommands such as `gh pr view`. Raw `gh api` is denied; use `gh-api-safe` for raw reads.
+For a pull request, load the `gh` skill before any GitHub access and follow its GitHub policy. Fetch the review comments with dedicated `gh` subcommands such as `gh pr view`.
 
 Thread filtering, replying, and resolving apply to the pull request case only. A local file or pasted text has no threads, so judge, fix, commit, and report.
 
@@ -16,7 +16,7 @@ Thread filtering, replying, and resolving apply to the pull request case only. A
 
 Human invocation of this command is the user's consent for: commit, push, `gh-review-reply`, and `gh-review-resolve`.
 
-Forbidden throughout: merge, close, approve, release, force-push, and raw `gh api`. Use dedicated subcommands, and `gh-api-safe` for raw reads.
+Forbidden throughout: merge, close, approve, release, and force-push. Follow the `gh` skill for every GitHub route.
 
 Restate this authority in every sub-agent packet. Sub-agents run with fresh context and will defer without it.
 

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/make-pr/prompt.md
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/make-pr/prompt.md
@@ -2,7 +2,7 @@
 
 Draft the pull request title and body with `draft-pr-message`, then create a pull request for the current branch. On a work repository, append a reviewer orientation block to the body before the pull request is created.
 
-This command mutates remote Git and GitHub state by pushing only when needed and running `gh pr create`, and it moves any linked Linear issue to In Review. Treat explicit human invocation of this command as consent for those actions. Never use raw `gh api`.
+Load the `gh` skill before any GitHub access and follow its GitHub policy. This command mutates remote Git and GitHub state by pushing only when needed and running `gh pr create`, and it moves any linked Linear issue to In Review. Treat explicit human invocation of this command as consent for those actions.
 
 Command invocation: use the current provider's command prefix when invoking `draft-pr-message`. Codex uses `$draft-pr-message`; slash-command runtimes use `/draft-pr-message`. If the platform cannot expand another command, follow the existing `draft-pr-message` prompt directly for the draft phase only. After its fenced message is produced, this command resumes and creates the pull request.
 
@@ -26,7 +26,7 @@ Run each command separately. Do not chain commands with `&&`, `;`, or `|`.
 6. Append the reviewer orientation block to that temporary file, following **Reviewer orientation** below. The block is part of the pull request from the moment it exists, so never add it later by editing the pull request.
 7. Push with an explicit refspec: `git push origin <branch>`. A bare `git push` depends on tracking configuration that may be absent, and pushes nothing when it is. Never pass `-u`: a sandbox mounts `.git/config` read-only, so the upstream write fails after the push has already landed. Stop if the push requires force, deletion, tags, or a non-fast-forward update.
 8. Verify the push landed. Run `git fetch origin <branch>`, then compare `git rev-parse HEAD` against `git rev-parse FETCH_HEAD`. Report a mismatch and stop rather than creating the pull request. Never trust the exit status alone: a push that matches nothing reports success while doing nothing.
-9. Create the pull request with the dedicated GitHub CLI command: `gh pr create --base main --head <branch> --title <title> --body-file <temp-file>`. Never use raw `gh api`.
+9. Create the pull request with the dedicated GitHub CLI command: `gh pr create --base main --head <branch> --title <title> --body-file <temp-file>`.
 10. Move each linked Linear issue to In Review, following **Linear transition** below. A Linear failure never stops this command.
 11. Report the pull request URL, title, whether the orientation block was included, each Linear outcome, and any uncommitted files left out.
 12. Offer the watch handover, following **Watch handover** below. Print it after the report, as the last thing you say.

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/prompt.md
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/prompt.md
@@ -4,7 +4,7 @@ Draft the comment with the `draft-comment` skill, then post it to the target thr
 
 Target argument: $ARGUMENTS. This is the thread URL. For Slack it may instead be a channel ID, a channel name, or a person's user ID, which starts a new message rather than replying to one. If it is blank, ask which thread and wait.
 
-This command mutates external state and speaks as the user. Treat explicit human invocation of this command as consent for those actions. Never use raw `gh api`.
+This command mutates external state and speaks as the user. Treat explicit human invocation of this command as consent for those actions. For GitHub, load `gh` before resolving the target or making any other GitHub access, and follow it for all GitHub tool and policy choices.
 
 Load `draft-comment` and apply it end-to-end for the draft phase. After it returns the fenced comment, resume this command and post it. Do not duplicate its drafting guidance here.
 
@@ -16,7 +16,7 @@ Run each command separately. Do not chain commands with `&&`, `;`, or `|`.
 2. Apply `draft-comment`. Preserve its fenced comment verbatim as the comment source
 3. Show the exact comment body and the resolved target, and confirm before posting
 4. Post with the dedicated tool for that surface:
-   - GitHub issue or pull request: strip only the Markdown fence lines, write the remaining body text unchanged to a temporary file, then run `gh issue comment <url> --body-file <file>` or `gh pr comment <url> --body-file <file>`. Never use raw `gh api`
+   - GitHub issue or pull request: strip only the Markdown fence lines, write the remaining body text unchanged to a temporary file, then run `gh issue comment <url> --body-file <file>` or `gh pr comment <url> --body-file <file>`
    - GitHub review comment: reply inside the thread with `gh-review-reply <review-comment-url> --body-file <file>`, using the same fence-stripped temporary file. Pass the review comment URL you were given, unchanged; the helper parses the owner, repository, pull request number, and comment id out of it. Both the `#discussion_r<id>` and `#r<id>` anchor forms work. Never use `gh pr comment` here; it posts at the top level, away from the question
    - Linear: the Linear MCP comment tool. Send real newlines in the body, never literal backslash-n
    - Slack: `slack-post <target> --body-file <file>`, using the same fence-stripped temporary file. Pass the target you were given, unchanged. The `slack` skill holds the target forms and the rest of the rules

--- a/home-manager/_mixins/agentic/assistants/skills/draft-comment/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/draft-comment/SKILL.md
@@ -17,7 +17,7 @@ If the target is missing, ask for it and wait. If it does not resolve to a real 
 
 Read context and draft text. Never post, comment, send, edit, or change provider state. Defer writes to `post-comment` or to the write flow that loaded this skill.
 
-For GitHub, load `gh`. Prefer dedicated `gh` reads, then `gh-api-safe`. Otherwise use only documented read-only GitHub MCP operations. Never use raw `gh api`, a GitHub MCP mutation, or a tool whose effect is unclear.
+For GitHub, load `gh` before any GitHub access and follow it for all GitHub tool and policy choices.
 
 Use Linear MCP reads for Linear. Use Slack reads for Slack. Never call their write tools while drafting.
 


### PR DESCRIPTION
- Load the gh skill before GitHub access in comment and review commands
- Keep existing dedicated GitHub command routes

Refs: WW-69
