### PR TITLE
fix(policy): set Kolide Launcher xdg-open environment via a wrapper

### DIFF
--- a/home-manager/_mixins/desktop/apps/default.nix
+++ b/home-manager/_mixins/desktop/apps/default.nix
@@ -12,6 +12,22 @@ let
   archiveManager = [ "org.gnome.FileRoller.desktop" ];
   webBrowser =
     if noughtyLib.hostHasTag "workspace" then [ "wavebox.desktop" ] else [ "brave-browser.desktop" ];
+  # Browser mimetypes are shared between added associations and default
+  # applications so URL handlers resolve without a desktop session.
+  browserMimeTypes = lib.genAttrs [
+    "application/x-extension-htm"
+    "application/x-extension-html"
+    "application/x-extension-shtml"
+    "application/x-extension-xht"
+    "application/x-extension-xhtml"
+    "application/xhtml+xml"
+    "text/html"
+    "x-scheme-handler/about"
+    "x-scheme-handler/ftp"
+    "x-scheme-handler/http"
+    "x-scheme-handler/https"
+    "x-scheme-handler/unknown"
+  ] (_: webBrowser);
   documentViewer = [ "org.gnome.Papers.desktop" ];
   imageViewer = [ "org.gnome.Loupe.desktop" ];
   videoPlayer = [ "io.github.celluloid_player.Celluloid.desktop" ];
@@ -82,7 +98,7 @@ in
     mime.enable = true;
     mimeApps = {
       enable = true;
-      associations.added = {
+      associations.added = browserMimeTypes // {
         "application/x-7z-compressed" = archiveManager;
         "application/x-7z-compressed-tar" = archiveManager;
         "application/x-bzip" = archiveManager;
@@ -105,19 +121,6 @@ in
         "application/gzip" = archiveManager;
         "application/bzip2" = archiveManager;
         "application/vnd.rar" = archiveManager;
-
-        "application/x-extension-htm" = webBrowser;
-        "application/x-extension-html" = webBrowser;
-        "application/x-extension-shtml" = webBrowser;
-        "application/x-extension-xht" = webBrowser;
-        "application/x-extension-xhtml" = webBrowser;
-        "application/xhtml+xml" = webBrowser;
-        "text/html" = webBrowser;
-        "x-scheme-handler/about" = webBrowser;
-        "x-scheme-handler/ftp" = webBrowser;
-        "x-scheme-handler/http" = webBrowser;
-        "x-scheme-handler/https" = webBrowser;
-        "x-scheme-handler/unknown" = webBrowser;
 
         "application/vnd.comicbook-rar" = documentViewer;
         "application/vnd.comicbook+zip" = documentViewer;
@@ -269,11 +272,10 @@ in
         "x-scheme-handler/icy" = videoPlayer;
         "x-scheme-handler/icyx" = videoPlayer;
       };
-      defaultApplications = {
+      defaultApplications = browserMimeTypes // {
         "audio/*" = audioPlayer;
         "application/pdf" = documentViewer;
         "image/*" = imageViewer;
-        "text/html" = webBrowser;
         "video/*" = videoPlayer;
       };
     };

--- a/nixos/_mixins/policy/default.nix
+++ b/nixos/_mixins/policy/default.nix
@@ -12,15 +12,29 @@
 }:
 let
   username = config.noughty.user.name;
-  userUid =
-    if config.users.users.${username}.uid == null then 1000 else config.users.users.${username}.uid;
-  xdgDataDirs = lib.concatStringsSep ":" [
-    "/home/${username}/.nix-profile/share"
-    "/home/${username}/.local/state/nix/profile/share"
-    "/etc/profiles/per-user/${username}/share"
-    "/nix/var/nix/profiles/default/share"
-    "/run/current-system/sw/share"
-  ];
+
+  # Logging wrapper around xdg-open for the Kolide desktop process. Tray
+  # menu clicks run xdg-open with output discarded and the exit status
+  # unchecked (kolide/launcher issue 2430), so this wrapper logs every
+  # invocation to /tmp/kolide-xdg-open.log before delegating to the real
+  # xdg-open from xdg-utils. The host desktop name is baked in at build
+  # time because only PATH reaches the desktop process.
+  kolideXdgOpen = pkgs.writeShellApplication {
+    name = "xdg-open";
+    runtimeInputs = with pkgs; [
+      coreutils
+      dbus
+      xdg-utils
+    ];
+    runtimeEnv = {
+      KOLIDE_XDG_CURRENT_DESKTOP =
+        {
+          hyprland = "Hyprland";
+        }
+        .${toString config.noughty.host.desktop} or "";
+    };
+    text = builtins.readFile ./kolide-xdg-open.sh;
+  };
 
   # Automates the bootstrap and update process for CrowdStrike Falcon on NixOS.
   # Downloads the sensor RPM, extracts it, copies binaries to /opt/CrowdStrike/,
@@ -66,23 +80,27 @@ lib.mkIf (noughtyLib.hostHasTag "policy") {
     enable = true;
   };
 
-  # Give Kolide longer to flush osquery state on shutdown.
-  # Default systemd TimeoutStopSec=90s is occasionally insufficient for
-  # long-running launcher processes on busy workstations and results in
-  # a SIGKILL of launcher + osqueryd, leaving event-store writes
-  # half-flushed. 180 s gives generous headroom without delaying boot
-  # meaningfully.
+  # The launcher spawns the per-user "launcher desktop" process with a
+  # fresh environment and copies only PATH from this unit (desktopCommand
+  # in ee/desktop/runner/runner.go), so setting any other variable here
+  # has no effect. Everything the AppIndicator needs must therefore
+  # resolve via PATH: the logging xdg-open wrapper comes first, then the
+  # system profiles, then the per-user Home Manager profiles so browsers
+  # referenced by .desktop Exec entries are found, then the unit's own
+  # path list (xdg-utils and glib).
   systemd.services.kolide-launcher = {
     path = [
       pkgs.xdg-utils
       pkgs.glib
     ];
-    environment = {
-      DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/user/${toString userUid}/bus";
-      XDG_DATA_DIRS = xdgDataDirs;
-    };
     serviceConfig = {
-      Environment = lib.mkForce "PATH=/run/wrappers/bin:/bin:/sbin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:${config.systemd.services.kolide-launcher.environment.PATH}";
+      Environment = lib.mkForce "PATH=${kolideXdgOpen}/bin:/run/wrappers/bin:/bin:/sbin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${username}/bin:/home/${username}/.nix-profile/bin:${config.systemd.services.kolide-launcher.environment.PATH}";
+      # Give Kolide longer to flush osquery state on shutdown. The default
+      # TimeoutStopSec of 90 seconds is occasionally insufficient for
+      # long-running launcher processes on busy workstations and results
+      # in a SIGKILL of launcher and osqueryd, leaving event-store writes
+      # half-flushed. 180 seconds gives generous headroom without
+      # delaying shutdown meaningfully.
       TimeoutStopSec = lib.mkDefault 180;
     };
   };

--- a/nixos/_mixins/policy/default.nix
+++ b/nixos/_mixins/policy/default.nix
@@ -16,7 +16,8 @@ let
   # Logging wrapper around xdg-open for the Kolide desktop process. Tray
   # menu clicks run xdg-open with output discarded and the exit status
   # unchecked (kolide/launcher issue 2430), so this wrapper logs every
-  # invocation to /tmp/kolide-xdg-open.log before delegating to the real
+  # invocation to a private log in XDG_RUNTIME_DIR (falling back to /tmp,
+  # created 0600) before delegating to the real
   # xdg-open from xdg-utils. The host desktop name is baked in at build
   # time because only PATH reaches the desktop process.
   kolideXdgOpen = pkgs.writeShellApplication {

--- a/nixos/_mixins/policy/kolide-xdg-open.sh
+++ b/nixos/_mixins/policy/kolide-xdg-open.sh
@@ -3,7 +3,16 @@
 # (kolide/launcher issue 2430), so failures are silent. Each invocation is
 # logged with its arguments and environment to aid diagnosis. Logging must
 # never break the open itself; the log file may be owned by another user.
-LOG_FILE="/tmp/kolide-xdg-open.log"
+# The log captures auth tokens from the environment and one-time codes
+# from URL arguments, so it must stay private: prefer the user-only
+# XDG_RUNTIME_DIR (mode 0700) and create the file 0600 via umask even on
+# the /tmp fallback.
+umask 077
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  LOG_FILE="${XDG_RUNTIME_DIR}/kolide-xdg-open.log"
+else
+  LOG_FILE="/tmp/kolide-xdg-open.log"
+fi
 
 {
   printf '=== %s ===\n' "$(date --iso-8601=seconds)"

--- a/nixos/_mixins/policy/kolide-xdg-open.sh
+++ b/nixos/_mixins/policy/kolide-xdg-open.sh
@@ -1,0 +1,36 @@
+# Logging wrapper around xdg-open for the Kolide launcher desktop process.
+# The launcher discards xdg-open output and never checks its exit status
+# (kolide/launcher issue 2430), so failures are silent. Each invocation is
+# logged with its arguments and environment to aid diagnosis. Logging must
+# never break the open itself; the log file may be owned by another user.
+LOG_FILE="/tmp/kolide-xdg-open.log"
+
+{
+  printf '=== %s ===\n' "$(date --iso-8601=seconds)"
+  printf 'args: %s\n' "$*"
+  env
+  printf '\n'
+} >>"${LOG_FILE}" 2>/dev/null || true
+
+# The desktop process environment lacks a session bus address; derive the
+# conventional one from the runtime directory so portals and gio work.
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ] && [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+fi
+
+# xdg-open picks its handler strategy from XDG_CURRENT_DESKTOP, which the
+# desktop process does not inherit. KOLIDE_XDG_CURRENT_DESKTOP is baked in
+# at build time from the host registry; leave the variable unset when the
+# desktop is unknown so xdg-open falls back to its generic path.
+if [ -z "${XDG_CURRENT_DESKTOP:-}" ] && [ -n "${KOLIDE_XDG_CURRENT_DESKTOP}" ]; then
+  export XDG_CURRENT_DESKTOP="${KOLIDE_XDG_CURRENT_DESKTOP}"
+fi
+
+# runtimeInputs prepends the real xdg-utils to PATH inside this script, so
+# exec resolves to it rather than looping back into this wrapper. Only
+# append stderr to the log when the log is writable by this user.
+if { true >>"${LOG_FILE}"; } 2>/dev/null; then
+  exec xdg-open "$@" 2>>"${LOG_FILE}"
+else
+  exec xdg-open "$@"
+fi


### PR DESCRIPTION
The Kolide Launcher AppIndicator spawns xdg-open with a fresh environment
that copies only PATH from the systemd unit, so setting
DBUS_SESSION_BUS_ADDRESS and XDG_DATA_DIRS on the unit was a no-op
(kolide/launcher#2430, previously attempted in PR #973). This replaces
that approach with a logging xdg-open wrapper placed first on the
launcher's PATH: it derives DBUS_SESSION_BUS_ADDRESS from
XDG_RUNTIME_DIR, sets XDG_CURRENT_DESKTOP from the host registry when
unset, then execs the real xdg-open. The PATH also gains per-user Home
Manager profile bins so installed browsers resolve.

Verified with `just format`, `just eval`, and `just build-host bane`;
shellcheck passes via writeShellApplication. Manual confirmation on the
affected laptop, via "About this Device" in the Kolide tray icon, happens
after merge.

Refs: WW-185
