### PR TITLE
chore(chainctl): update to 0.2.327

### DIFF
--- a/pkgs/chainctl/default.nix
+++ b/pkgs/chainctl/default.nix
@@ -12,7 +12,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "chainctl";
-  version = "0.2.325";
+  version = "0.2.327";
 
   # Upstream installer: https://edu.chainguard.dev/chainguard/chainctl-usage/how-to-install-chainctl/
   src =
@@ -59,19 +59,19 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     {
       x86_64-linux = fetchurl {
         url = "${base}/chainctl_linux_x86_64";
-        hash = "sha256-4IPx4yk7n7JiO8ag3MboIcXnID4mZBVgYm0XNLRAh8M=";
+        hash = "sha256-MkqF4hOtRGR/8LbvsnqcyTvZq5bip9SBmlo2Z9x2ItA=";
       };
       aarch64-linux = fetchurl {
         url = "${base}/chainctl_linux_arm64";
-        hash = "sha256-zJ+rqDSj65MyBitsjKdQ54+oJyhVHehAGEALwgLh3BE=";
+        hash = "sha256-pfOnlcNhdqc0SXYSD6s6CVDOdFczuwHvSCEyAeT6/So=";
       };
       x86_64-darwin = fetchurl {
         url = "${base}/chainctl_darwin_x86_64";
-        hash = "sha256-yWWb92pa8wuPO1l7U/7yAtvxLa4kSKgkLpjVYpNshkw=";
+        hash = "sha256-lnQqxqYHMyKTKOczlGvZZLasEjvXwZxWneYZjv7g9Ow=";
       };
       aarch64-darwin = fetchurl {
         url = "${base}/chainctl_darwin_arm64";
-        hash = "sha256-8eDBj8KqwEY7yRs0fZUupm3RLjmOrg/NarhfiYLYqUQ=";
+        hash = "sha256-E099a+ggVx3h+M0SIVxRW3mHpSaIMTw40caAjHQxInU=";
       };
     };
 


### PR DESCRIPTION
Automated chainctl update to 0.2.327.

Changelog: https://edu.chainguard.dev/chainguard/chainctl/