### PR TITLE
feat(deploy): push local builds to remote hosts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Run `just --list --unsorted` before inventing commands.
 | Build one host or Home config | `just build-host hostname=<host>`; `just build-home username=<user> hostname=<host>`                                                     |
 | Build a package               | `just build-pkg pkg=<pkg> hostname=<host>`                                                                                               |
 | Switch or apply configs       | `just switch`; `just apply`; `just apply-home`; `just apply-host`                                                                        |
+| Push configs to a remote host | `just push <host> [target]`; `just push-host <host> [target]`; `just push-host-boot <host> [target]`; `just push-home <host> [target]`   |
 | Update flake inputs           | `just update`                                                                                                                            |
 | ISO and install               | `just iso`; `just inject-tokens remote=<host> user=nixos`; `just install host=<host> remote=<target> keep_disks="false" vm_test="false"` |
 

--- a/README.md
+++ b/README.md
@@ -229,10 +229,9 @@ See [install-system documentation](./nixos/_mixins/scripts/install-system/README
 
 ### Installing to a remote host 🌍
 
-As [Disko] is used to declare the disk layout for all my NixOS hosts, each NixOS configuration can be deployed to a remote host using [nixos-anywhere].
-The justfile includes an `install` recipe that wraps `nixos-anywhere` to simplify remote deployments.
+Use `just install` for the first installation of a remote NixOS host. It wraps [nixos-anywhere] and uses the [Disko] layout declared by the host configuration.
 For example, `malak` is a Hetzner dedicated server.
-To deploy it, enable the Hetzner Rescue system and then run the following from one of my workstations:
+To install it, enable the Hetzner Rescue system and then run the following from one of my workstations:
 
 ```bash
 just install malak <ip-address>
@@ -240,7 +239,7 @@ just install malak <ip-address>
 
 Optional parameters: `keep_disks="true"` preserves existing disk partitions, and `vm_test="true"` runs a local VM test instead of deploying.
 
-When the deployment is complete, the remote host will be automatically rebooted.
+When the installation is complete, the remote host will be automatically rebooted.
 The `just install` recipe handles SOPS age keys (user and host), initrd SSH keys, and per-host SSH host keys automatically, decrypting them from sops secrets and injecting them into the target.
 
 I keep my Home Manager configuration separate from my NixOS configuration, so after the NixOS configuration has been deployed, I SSH in to the remote host and activate the Home Manager configuration:
@@ -250,6 +249,8 @@ git clone https://github.com/wimpysworld/nix-config "$HOME/Zero/nix-config"
 cd "$HOME/Zero/nix-config"
 just switch-home
 ```
+
+For later configuration changes, use the remote push recipes from the workstation instead of running the installer again.
 
 ## Applying Changes ✨
 
@@ -271,6 +272,18 @@ This flake includes a [justfile](./justfile) that provides convenient commands f
 - 🌍️ **All:**
   - `just build` to build both NixOS/nix-darwin and Home Manager configurations.
   - `just switch` to switch to both NixOS/nix-darwin and Home Manager configurations.
+
+For day-to-day changes on a remote NixOS host, the push recipes build on the workstation and copy the closures to the target. The target defaults to `root@<hostname>`; pass the target as the second argument to override it:
+
+```bash
+just push cognus
+just push cognus root@<ip-address>
+```
+
+- `just push <hostname> [target]` switches NixOS, then activates Home Manager.
+- `just push-host <hostname> [target]` switches NixOS immediately.
+- `just push-host-boot <hostname> [target]` selects the NixOS generation for the next boot without activating it on the live system.
+- `just push-home <hostname> [target]` activates Home Manager only.
 
 #### The fast path: FlakeHub Cache
 

--- a/justfile
+++ b/justfile
@@ -519,6 +519,66 @@ build-host hostname=current_hostname: prefetch
       echo "Unsupported OS: $(uname)"
     fi
 
+# Push NixOS and Home Manager configurations to a remote host
+push hostname target=("root@" + hostname):
+    @just push-host {{ quote(hostname) }} {{ quote(target) }}
+    @just push-home {{ quote(hostname) }} {{ quote(target) }}
+
+# Push NixOS configuration to a remote host
+push-host hostname target=("root@" + hostname):
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    hostname={{ quote(hostname) }}
+    target={{ quote(target) }}
+
+    echo "NixOS 󱄅 Pushing: ${hostname} to ${target}"
+    nixos-rebuild switch --flake ".#${hostname}" --target-host "${target}" --build-host "" --print-build-logs
+
+# Push NixOS configuration to activate on the remote host's next boot
+push-host-boot hostname target=("root@" + hostname):
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    hostname={{ quote(hostname) }}
+    target={{ quote(target) }}
+
+    echo "NixOS ♺  Pushing: ${hostname} to ${target}"
+    nixos-rebuild boot --flake ".#${hostname}" --target-host "${target}" --build-host "" --print-build-logs
+
+# Push Home Manager configuration to a remote host
+push-home hostname target=("root@" + hostname):
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    hostname={{ quote(hostname) }}
+    target={{ quote(target) }}
+
+    username=$(nix eval --raw ".#nixosConfigurations.\"${hostname}\".config.noughty.user.name")
+    home_directory="/home/${username}"
+    activation_path=$(nix build --no-link --print-out-paths ".#homeConfigurations.\"${username}@${hostname}\".activationPackage")
+
+    echo "Home Manager  Pushing: ${username}@${hostname} to ${target}"
+    nix copy --to "ssh://${target}" "${activation_path}"
+
+    printf -v quoted_username '%q' "${username}"
+    printf -v quoted_home_directory '%q' "${home_directory}"
+    printf -v quoted_profile_directory '%q' "/nix/var/nix/profiles/per-user/${username}"
+    printf -v quoted_state_directory '%q' "${home_directory}/.local/state/nix/profiles"
+    printf -v quoted_data_directory '%q' "${home_directory}/.local/share/home-manager"
+    printf -v quoted_activation_path '%q' "${activation_path}"
+    activation_command=$(printf 'target_uid=$(id -u) && cd %s && env -u DBUS_SESSION_BUS_ADDRESS USER=%s LOGNAME=%s HOME=%s XDG_STATE_HOME=%s/.local/state XDG_RUNTIME_DIR="/run/user/${target_uid}" HOME_MANAGER_BACKUP_EXT=backup %s/activate --driver-version 1' \
+        "${quoted_home_directory}" \
+        "${quoted_username}" \
+        "${quoted_username}" \
+        "${quoted_home_directory}" \
+        "${quoted_home_directory}" \
+        "${quoted_activation_path}")
+    printf -v quoted_activation_command '%q' "${activation_command}"
+
+    remote_command="install -d -o ${quoted_username} -g users ${quoted_profile_directory} ${quoted_state_directory} ${quoted_data_directory} && su -s /bin/sh ${quoted_username} -c ${quoted_activation_command}"
+    printf '%s\n' "${remote_command}" | ssh -- "${target}" bash
+
 # Switch OS configuration
 switch-host hostname=current_hostname: prefetch
     #!/usr/bin/env bash

--- a/nixos/_mixins/network/ssh/default.nix
+++ b/nixos/_mixins/network/ssh/default.nix
@@ -27,6 +27,7 @@ in
       openFirewall = openSSHFirewall;
       settings = {
         PasswordAuthentication = false;
+        PermitRootLogin = lib.mkIf host.is.server "prohibit-password";
       };
     };
     sshguard = {


### PR DESCRIPTION
Adds local-build push recipes for NixOS and Home Manager, including next-boot
activation. Remote server updates can now avoid slow on-host builds, while
first installation remains unchanged.

Verified with `just --fmt --check`, hostile-input dry runs, ShellCheck of
rendered scripts, an activation environment mock, `just eval`, and real runs
of `just push-home skrye` and `just push-host skrye`.

Refs: WW-65
