### PR TITLE
feat(agentic): take vocabulary from the project's own words

### DIFF
--- a/home-manager/_mixins/agentic/assistants/skills/communication-rules/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/communication-rules/SKILL.md
@@ -42,9 +42,12 @@ You are an interactive agent that helps users with software engineering tasks. I
 - Avoid the LLM register: pivotal, crucial, vital, testament, seamless, robust, cutting-edge, delve, leverage, multifaceted, foster, realm, tapestry, vibrant, nuanced, intricate, showcasing, streamline, garnered, underpinning, underscores, boasts, landscape (figurative).
   - Keep one only when it is the precise technical term, and be ready to defend it.
 - No metaphors for code, work, or text. Not shape, seam, leg, arm, load-bearing. Use form, boundary, pass, branch, essential.
+  - Keep one only when the project already uses it as its own term.
   - Literal senses are fine: a broken arm, a load-bearing wall.
 - British English spelling.
 - One meaning per word. One term per concept. One verb per action. Do not rotate synonyms.
+- Use the project's own words. Take them from its documentation and its code. If the project calls it a "lesson", never call it a "unit". When the project uses two words for one thing, use the one in the code and say so once. When you need a new term, define it once, in plain words, then use it every time.
+- An identifier stays exact whatever it is called. A project's prose style does not override the register rules above.
 - Do not use contractions. Write "do not", not the short form.
 - Write "for example" and "that is". Do not use Latin abbreviations.
 - Cap a noun cluster at three words. Break a longer one with a preposition.

--- a/home-manager/_mixins/agentic/assistants/styles/house-style/house-style.md
+++ b/home-manager/_mixins/agentic/assistants/styles/house-style/house-style.md
@@ -43,9 +43,12 @@ You are an interactive agent that helps users with software engineering tasks. I
 - Avoid the LLM register: pivotal, crucial, vital, testament, seamless, robust, cutting-edge, delve, leverage, multifaceted, foster, realm, tapestry, vibrant, nuanced, intricate, showcasing, streamline, garnered, underpinning, underscores, boasts, landscape (figurative).
   - Keep one only when it is the precise technical term, and be ready to defend it.
 - No metaphors for code, work, or text. Not shape, seam, leg, arm, load-bearing. Use form, boundary, pass, branch, essential.
+  - Keep one only when the project already uses it as its own term.
   - Literal senses are fine: a broken arm, a load-bearing wall.
 - British English spelling.
 - One meaning per word. One term per concept. One verb per action. Do not rotate synonyms.
+- Use the project's own words. Take them from its documentation and its code. If the project calls it a "lesson", never call it a "unit". When the project uses two words for one thing, use the one in the code and say so once. When you need a new term, define it once, in plain words, then use it every time.
+- An identifier stays exact whatever it is called. A project's prose style does not override the register rules above.
 - Do not use contractions. Write "do not", not the short form.
 - Write "for example" and "that is". Do not use Latin abbreviations.
 - Cap a noun cluster at three words. Break a longer one with a preposition.


### PR DESCRIPTION
Adds a Words rule that takes vocabulary from the project's own documentation and code, and gives the metaphor rule a carve-out for a term the project already uses. The blanket ban collided with vocabulary that is itself metaphorical: Nyala's code and issues use fallback, path, and pass-through as precise terms, so following the rule meant renaming what the source already names. The new rule also settles which word wins when a project uses two for one thing, and keeps identifiers exact regardless of the register list.

Not evaluated locally, so `just eval` and a Home Manager build still need to run.