### PR TITLE
chore(chainctl): update to 0.2.329

### DIFF
--- a/pkgs/chainctl/default.nix
+++ b/pkgs/chainctl/default.nix
@@ -12,7 +12,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "chainctl";
-  version = "0.2.327";
+  version = "0.2.329";
 
   # Upstream installer: https://edu.chainguard.dev/chainguard/chainctl-usage/how-to-install-chainctl/
   src =
@@ -59,19 +59,19 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     {
       x86_64-linux = fetchurl {
         url = "${base}/chainctl_linux_x86_64";
-        hash = "sha256-MkqF4hOtRGR/8LbvsnqcyTvZq5bip9SBmlo2Z9x2ItA=";
+        hash = "sha256-Mje8NQHJXGCGPLn/Jf/sWGJXP3G9IkIa8nt4Q9aUbjE=";
       };
       aarch64-linux = fetchurl {
         url = "${base}/chainctl_linux_arm64";
-        hash = "sha256-pfOnlcNhdqc0SXYSD6s6CVDOdFczuwHvSCEyAeT6/So=";
+        hash = "sha256-Mz2it872a40ib+sz+uYbFccJlail7vPtJ56LrsiCwv0=";
       };
       x86_64-darwin = fetchurl {
         url = "${base}/chainctl_darwin_x86_64";
-        hash = "sha256-lnQqxqYHMyKTKOczlGvZZLasEjvXwZxWneYZjv7g9Ow=";
+        hash = "sha256-jMExFJcKmxYUZuejsTXA2sPZGkWnFJpvjlYSFzI+lXw=";
       };
       aarch64-darwin = fetchurl {
         url = "${base}/chainctl_darwin_arm64";
-        hash = "sha256-E099a+ggVx3h+M0SIVxRW3mHpSaIMTw40caAjHQxInU=";
+        hash = "sha256-bLX1gVQbAK9J1p6q5lXL6wUFqfbPaOJIqLqLGpM42QE=";
       };
     };
 


### PR DESCRIPTION
Automated chainctl update to 0.2.329.

Changelog: https://edu.chainguard.dev/chainguard/chainctl/