### PR TITLE
chore(concord): update to v2.5.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,16 +138,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785856516,
-        "narHash": "sha256-lngW3ZOltQoOp16RGeD2RN94oktnnLDahYpZ8r114qc=",
+        "lastModified": 1786108652,
+        "narHash": "sha256-m74ar1ue0Cl7G5QYeuzyzcgt4myQQUIULwLLol23lBA=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "9a35c09214b9bd8e79c535cf0d3465b14dc69f29",
+        "rev": "be7d750b7793ff2bb6ebc533cb1188e6123393cb",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.5.3",
+        "ref": "v2.5.6",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.5.3";
+    concord.url = "github:chojs23/concord/v2.5.6";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to v2.5.6.

Changelog: https://github.com/chojs23/concord/releases