### PR TITLE
chore(wavebox): update to 151.2.154-2

### DIFF
--- a/pkgs/wavebox/default.nix
+++ b/pkgs/wavebox/default.nix
@@ -172,11 +172,11 @@ let
 
   linux = stdenvNoCC.mkDerivation (finalAttrs: {
     inherit pname meta passthru;
-    version = "151.2.148-2";
+    version = "151.2.154-2";
 
     src = fetchurl {
       url = "https://download.wavebox.app/stable/linux/deb/amd64/wavebox_${finalAttrs.version}_amd64.deb";
-      hash = "sha256-1Cm8aI3gqWj8JiPiABdF6UruWL3Mn3todsrs1tw638I=";
+      hash = "sha256-A4JGq9uez7eda5g8NpZVISxGhmwUTYIxQb1varxGHk0=";
     };
 
     # With strictDeps on, some shebangs were not being patched correctly
@@ -261,11 +261,11 @@ let
 
   darwin = stdenvNoCC.mkDerivation (finalAttrs: {
     inherit pname meta passthru;
-    version = "151.2.148.2";
+    version = "151.2.154.2";
 
     src = fetchurl {
       url = "https://download.wavebox.app/stable/macuniversal/Install%20Wavebox%20${finalAttrs.version}.dmg";
-      hash = "sha256-52AckeZOGhUx866Vnne/nHR6mmgsf6NumU5B1rfkdO4=";
+      hash = "sha256-Nizjl0zFPX+ffoBn9a9OIE2TNWZePDRh6bLDV9Ch14M=";
     };
 
     dontPatch = true;


### PR DESCRIPTION
Automated Wavebox update to 151.2.154-2.

Changelog: https://wavebox.io/blog/releases/