### PR TITLE
chore(concord): update to v2.5.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,16 +138,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786108652,
-        "narHash": "sha256-m74ar1ue0Cl7G5QYeuzyzcgt4myQQUIULwLLol23lBA=",
+        "lastModified": 1786549710,
+        "narHash": "sha256-n5YBLhLK5aGnxRHw6Pc6+0G2fLMzOLuDvmyDyVf5y3s=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "be7d750b7793ff2bb6ebc533cb1188e6123393cb",
+        "rev": "e9105e767124e09cff71acabe107d6e9a414bbb7",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.5.6",
+        "ref": "v2.5.8",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.5.6";
+    concord.url = "github:chojs23/concord/v2.5.8";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to v2.5.8.

Changelog: https://github.com/chojs23/concord/releases