### PR TITLE
chore(concord): update to v2.5.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,16 +138,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786549710,
-        "narHash": "sha256-n5YBLhLK5aGnxRHw6Pc6+0G2fLMzOLuDvmyDyVf5y3s=",
+        "lastModified": 1786959549,
+        "narHash": "sha256-a6+HixqNjt+aHcAuT/trMs/sAaXieoQhbMt56g1u7rM=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "e9105e767124e09cff71acabe107d6e9a414bbb7",
+        "rev": "096f58d4f277dd5f1c2906a475a15062440f86cd",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.5.8",
+        "ref": "v2.5.11",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.5.8";
+    concord.url = "github:chojs23/concord/v2.5.11";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to v2.5.11.

Changelog: https://github.com/chojs23/concord/releases