### PR TITLE
chore(hermes-agent): update to v2026.8.16

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -511,14 +511,14 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1785776243,
-        "narHash": "sha256-S6TSGgpf37N8YgbTv70dT+LaPiiaQ4/lJV+js2hnCPk=",
+        "lastModified": 1786901573,
+        "narHash": "sha256-TsWcNR6JVj+PaqwodGrtcIgmOG6bzXtIDWw+e2txPdk=",
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.3.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.16.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.3.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.16.tar.gz"
       }
     },
     "home-manager": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
-    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.3.tar.gz";
+    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.16.tar.gz";
     hermes-agent.inputs.nixpkgs.follows = "nixpkgs-unstable";
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
Automated Hermes Agent update to v2026.8.16.

Changelog: https://github.com/NousResearch/hermes-agent/releases