### PR TITLE
chore(paseo): update to v0.4.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,16 +951,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786275033,
-        "narHash": "sha256-m97Pf857LNv871b95cJ2y34OFxoES8JsWsp0wD3Em4I=",
+        "lastModified": 1786649507,
+        "narHash": "sha256-XV38ZFN7wEDkIIEQR/wchASURl9WGA40hNlg7d0/Hf8=",
         "owner": "getpaseo",
         "repo": "paseo",
-        "rev": "bfec7ac3adc5e8835e873ee75c7b325af6c7a8c3",
+        "rev": "b44bb63cf4ce089ab5750b9fc621ed52827b2820",
         "type": "github"
       },
       "original": {
         "owner": "getpaseo",
-        "ref": "v0.3.1",
+        "ref": "v0.4.0",
         "repo": "paseo",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";
-    paseo.url = "github:getpaseo/paseo/v0.3.1";
+    paseo.url = "github:getpaseo/paseo/v0.4.0";
     paseo.inputs.nixpkgs.follows = "nixpkgs-unstable";
     lan-mouse.url = "github:feschber/lan-mouse/v0.11.0";
     lan-mouse.inputs.nixpkgs.follows = "nixpkgs";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -14,13 +14,13 @@
       # Paseo packages come from the upstream Paseo flake; the desktop client
       # reuses the patched daemon npm closure below.
       #
-      # The v0.3.1 tag ships a wrong npm-deps fixed-output hash, which breaks
+      # The v0.4.0 tag ships a wrong npm-deps fixed-output hash, which breaks
       # the build with a hash mismatch. Correct the hash here until the next
       # upstream release carries a good one.
       fixPaseoNpmDeps =
         pkg:
         pkg.override {
-          npmDepsHash = "sha256-oXz8hMk+5DlTYK8OndUAjB+RJMDbPqobVGXLFeoH++o=";
+          npmDepsHash = "sha256-i5PbVUe2Ec+GtghV9IpCJQJ9hcUT5hFhmxneNvoD584=";
         };
       paseoAttrs = prev.lib.optionalAttrs ((paseoPackages ? paseo) || (paseoPackages ? default)) {
         paseo = fixPaseoNpmDeps (paseoPackages.paseo or paseoPackages.default);


### PR DESCRIPTION
Automated Paseo update to v0.4.0.

Changelog: https://github.com/getpaseo/paseo/commits