### PR TITLE
feat(wayland): use Vecdecor for Wayfire decoration

### DIFF
--- a/home-manager/_mixins/desktop/compositor/wayfire/default.nix
+++ b/home-manager/_mixins/desktop/compositor/wayfire/default.nix
@@ -8,8 +8,6 @@
 let
   inherit (config.noughty) host;
   compositor = (import ../../../../../lib/wayland-compositors.nix).compositors.wayfire;
-  useVecdecor = host.name != "felkor";
-  decoratorPlugin = if useVecdecor then "vecdecor" else "pixdecor";
   toWayfireColor =
     color: alpha:
     let
@@ -59,7 +57,7 @@ in
       enable = true;
       plugins = with pkgs.wayfirePlugins; [
         wcm
-        (wayfire-plugins-extra.override { withPixdecorPlugin = !useVecdecor; })
+        wayfire-plugins-extra
         pkgs.vecdecor
       ];
       systemd = {
@@ -78,7 +76,7 @@ in
           autostart_wf_shell = false;
         };
         core = {
-          plugins = "animate autostart blur command cube expo foreign-toplevel grid gtk-shell idle ipc ipc-rules move ${decoratorPlugin} place resize session-lock shortcuts-inhibit switcher vswipe vswitch winshadows wm-actions wobbly xdg-activation";
+          plugins = "animate autostart blur command cube expo foreign-toplevel grid gtk-shell idle ipc ipc-rules move pixdecor place resize session-lock shortcuts-inhibit switcher vswipe vswitch winshadows wm-actions wobbly xdg-activation";
           preferred_decoration_mode = "server";
           vwidth = 8;
           vheight = 1;

--- a/home-manager/_mixins/desktop/compositor/wayfire/default.nix
+++ b/home-manager/_mixins/desktop/compositor/wayfire/default.nix
@@ -8,6 +8,8 @@
 let
   inherit (config.noughty) host;
   compositor = (import ../../../../../lib/wayland-compositors.nix).compositors.wayfire;
+  useVecdecor = host.name != "felkor";
+  decoratorPlugin = if useVecdecor then "vecdecor" else "pixdecor";
   toWayfireColor =
     color: alpha:
     let
@@ -57,7 +59,8 @@ in
       enable = true;
       plugins = with pkgs.wayfirePlugins; [
         wcm
-        wayfire-plugins-extra
+        (wayfire-plugins-extra.override { withPixdecorPlugin = !useVecdecor; })
+        pkgs.vecdecor
       ];
       systemd = {
         variables = compositor.startupEnvironment;
@@ -75,7 +78,7 @@ in
           autostart_wf_shell = false;
         };
         core = {
-          plugins = "animate autostart blur command cube expo foreign-toplevel grid gtk-shell idle ipc ipc-rules move pixdecor place resize session-lock shortcuts-inhibit switcher vswipe vswitch winshadows wm-actions wobbly xdg-activation";
+          plugins = "animate autostart blur command cube expo foreign-toplevel grid gtk-shell idle ipc ipc-rules move ${decoratorPlugin} place resize session-lock shortcuts-inhibit switcher vswipe vswitch winshadows wm-actions wobbly xdg-activation";
           preferred_decoration_mode = "server";
           vwidth = 8;
           vheight = 1;

--- a/lib/tests/wayland-compositors.nix
+++ b/lib/tests/wayland-compositors.nix
@@ -241,11 +241,11 @@ assert !enableHostIntegration || !(coreHasPlugin felkorHomeWayfire "vecdecor");
 assert !enableHostIntegration || lib.getName baneNixosVecdecor == "vecdecor";
 assert !enableHostIntegration || lib.getName baneHomeVecdecor == "vecdecor";
 assert
-  !enableHostIntegration || builtins.elem "-Denable_pixdecor=false" baneNixosExtraPlugins.mesonFlags;
+  !enableHostIntegration || builtins.elem "-Denable_pixdecor=true" baneNixosExtraPlugins.mesonFlags;
 assert
-  !enableHostIntegration || builtins.elem "-Denable_pixdecor=false" baneHomeExtraPlugins.mesonFlags;
-assert !enableHostIntegration || coreHasPlugin baneHomeWayfire "vecdecor";
-assert !enableHostIntegration || !(coreHasPlugin baneHomeWayfire "pixdecor");
+  !enableHostIntegration || builtins.elem "-Denable_pixdecor=true" baneHomeExtraPlugins.mesonFlags;
+assert !enableHostIntegration || coreHasPlugin baneHomeWayfire "pixdecor";
+assert !enableHostIntegration || !(coreHasPlugin baneHomeWayfire "vecdecor");
 assert
   !enableHostIntegration
   || baneHome.systemd.user.services.reframe-session.Unit.PartOf == [ "wayfire-session.target" ];

--- a/lib/tests/wayland-compositors.nix
+++ b/lib/tests/wayland-compositors.nix
@@ -130,6 +130,8 @@ let
   baneHome = homeConfigurations."martin@bane".config;
   felkorHome = homeConfigurations."martin@felkor".config;
   skryeHome = homeConfigurations."martin@skrye".config;
+  baneNixosWayfirePlugins = nixosConfigurations.bane.config.programs.wayfire.plugins;
+  felkorNixosWayfirePlugins = nixosConfigurations.felkor.config.programs.wayfire.plugins;
   packageNamed =
     name: packages:
     let
@@ -137,6 +139,18 @@ let
     in
     assert builtins.length matches == 1;
     builtins.head matches;
+  baneHomeWayfire = baneHome.wayland.windowManager.wayfire;
+  felkorHomeWayfire = felkorHome.wayland.windowManager.wayfire;
+  baneNixosVecdecor = packageNamed "vecdecor" baneNixosWayfirePlugins;
+  baneHomeVecdecor = packageNamed "vecdecor" baneHomeWayfire.plugins;
+  felkorNixosVecdecor = packageNamed "vecdecor" felkorNixosWayfirePlugins;
+  felkorHomeVecdecor = packageNamed "vecdecor" felkorHomeWayfire.plugins;
+  baneNixosExtraPlugins = packageNamed "wayfire-plugins-extra" baneNixosWayfirePlugins;
+  baneHomeExtraPlugins = packageNamed "wayfire-plugins-extra" baneHomeWayfire.plugins;
+  felkorNixosExtraPlugins = packageNamed "wayfire-plugins-extra" felkorNixosWayfirePlugins;
+  felkorHomeExtraPlugins = packageNamed "wayfire-plugins-extra" felkorHomeWayfire.plugins;
+  coreHasPlugin =
+    wayfire: plugin: builtins.elem plugin (lib.splitString " " wayfire.settings.core.plugins);
   sessionPackage = home: packageNamed "wayland-session" home.home.packages;
   logoutService = home: home.systemd.user.services.wayland-session-logout;
   waylandShim =
@@ -216,6 +230,22 @@ assert
 assert !enableHostIntegration || baneHome.wayland.systemd.target == "wayfire-session.target";
 assert !enableHostIntegration || felkorHome.wayland.systemd.target == "wayfire-session.target";
 assert !enableHostIntegration || skryeHome.wayland.systemd.target == "hyprland-session.target";
+assert !enableHostIntegration || lib.getName felkorNixosVecdecor == "vecdecor";
+assert !enableHostIntegration || lib.getName felkorHomeVecdecor == "vecdecor";
+assert
+  !enableHostIntegration || builtins.elem "-Denable_pixdecor=true" felkorNixosExtraPlugins.mesonFlags;
+assert
+  !enableHostIntegration || builtins.elem "-Denable_pixdecor=true" felkorHomeExtraPlugins.mesonFlags;
+assert !enableHostIntegration || coreHasPlugin felkorHomeWayfire "pixdecor";
+assert !enableHostIntegration || !(coreHasPlugin felkorHomeWayfire "vecdecor");
+assert !enableHostIntegration || lib.getName baneNixosVecdecor == "vecdecor";
+assert !enableHostIntegration || lib.getName baneHomeVecdecor == "vecdecor";
+assert
+  !enableHostIntegration || builtins.elem "-Denable_pixdecor=false" baneNixosExtraPlugins.mesonFlags;
+assert
+  !enableHostIntegration || builtins.elem "-Denable_pixdecor=false" baneHomeExtraPlugins.mesonFlags;
+assert !enableHostIntegration || coreHasPlugin baneHomeWayfire "vecdecor";
+assert !enableHostIntegration || !(coreHasPlugin baneHomeWayfire "pixdecor");
 assert
   !enableHostIntegration
   || baneHome.systemd.user.services.reframe-session.Unit.PartOf == [ "wayfire-session.target" ];

--- a/nixos/_mixins/desktop/wayfire/default.nix
+++ b/nixos/_mixins/desktop/wayfire/default.nix
@@ -8,7 +8,6 @@
 }:
 let
   inherit (config.noughty) host;
-  useVecdecor = host.name != "felkor";
 
   wayfireWithGSettingsSchemas = pkgs.symlinkJoin {
     inherit (pkgs.wayfire) version;
@@ -83,7 +82,7 @@ in
         plugins = with pkgs.wayfirePlugins; [
           wcm
           wf-shell
-          (wayfire-plugins-extra.override { withPixdecorPlugin = !useVecdecor; })
+          wayfire-plugins-extra
           pkgs.vecdecor
         ];
       };

--- a/nixos/_mixins/desktop/wayfire/default.nix
+++ b/nixos/_mixins/desktop/wayfire/default.nix
@@ -8,6 +8,7 @@
 }:
 let
   inherit (config.noughty) host;
+  useVecdecor = host.name != "felkor";
 
   wayfireWithGSettingsSchemas = pkgs.symlinkJoin {
     inherit (pkgs.wayfire) version;
@@ -82,7 +83,8 @@ in
         plugins = with pkgs.wayfirePlugins; [
           wcm
           wf-shell
-          wayfire-plugins-extra
+          (wayfire-plugins-extra.override { withPixdecorPlugin = !useVecdecor; })
+          pkgs.vecdecor
         ];
       };
     };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15,6 +15,7 @@ pkgs: {
   pixdecor-catppuccin-buttons = pkgs.callPackage ./pixdecor-catppuccin-buttons { };
   slk = pkgs.callPackage ./slk { };
   tcount = pkgs.callPackage ./tcount { };
+  vecdecor = pkgs.callPackage ./vecdecor { };
   defold = pkgs.callPackage ./defold { };
   defold-bob = pkgs.callPackage ./defold-bob { };
   defold-gdc = pkgs.callPackage ./defold-gdc { };

--- a/pkgs/vecdecor/default.nix
+++ b/pkgs/vecdecor/default.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
+  cairo,
+  glm,
+  libdrm,
+  libglvnd,
+  librsvg,
+  libxkbcommon,
+  pango,
+  wayfire,
+}:
+let
+  sources = {
+    "0.10.1" = {
+      version = "0.10.0";
+      rev = "fc1eb4ba4c7c479fc1fe740f2d6374d506ea885e";
+      hash = "sha256-Lh/ZidgyLoRza0jOM6xubWCSSifsVkof6Q0Rh57iiPY=";
+      wayfireConstraint = "['>=0.10.1', '<0.11.0']";
+    };
+    "0.11.0" = {
+      version = "0.11.0";
+      rev = "0e5266b78709b51880dc4c08080e2d43cccf9269";
+      hash = "sha256-ZcoidklD72pr8NYf+t81l3XfOlTi6piSdHvdNNiaopI=";
+      wayfireConstraint = "['>=0.11.0', '<0.12.0']";
+    };
+  };
+  source =
+    sources.${wayfire.version}
+      or (throw "vecdecor: unsupported Wayfire version ${wayfire.version}; supported versions are 0.10.1 and 0.11.0");
+in
+stdenv.mkDerivation {
+  pname = "vecdecor";
+  inherit (source) version;
+
+  src = fetchFromGitHub {
+    owner = "wimpysworld";
+    repo = "vecdecor";
+    inherit (source) rev hash;
+  };
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail \
+        "wayfire = dependency('wayfire', version: ${source.wayfireConstraint})" \
+        "wayfire = dependency('wayfire', version: '=${wayfire.version}')" \
+      --replace-fail \
+        "librsvg = dependency('librsvg-2.0')" \
+        $'librsvg = dependency(\'librsvg-2.0\')\npango = dependency(\'pango\')\npangocairo = dependency(\'pangocairo\')'
+
+    substituteInPlace src/meson.build \
+      --replace-fail \
+        "dependencies: [wayfire, deco_geometry_dep, deco_button_renderer_dep]," \
+        "dependencies: [wayfire, cairo, librsvg, pango, pangocairo, deco_geometry_dep, deco_button_renderer_dep],"
+  '';
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    glm
+    libdrm
+    libglvnd
+    librsvg
+    libxkbcommon
+    pango
+    wayfire
+  ];
+
+  env.PKG_CONFIG_WAYFIRE_METADATADIR = "${placeholder "out"}/share/wayfire/metadata";
+
+  doCheck = true;
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    test -f "$out/lib/wayfire/libvecdecor.so"
+    test -f "$out/share/wayfire/metadata/vecdecor.xml"
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Vector window decoration plugin for Wayfire";
+    homepage = "https://github.com/wimpysworld/vecdecor";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ flexiondotorg ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/vecdecor/default.nix
+++ b/pkgs/vecdecor/default.nix
@@ -14,6 +14,7 @@
   libxkbcommon,
   pango,
   wayfire,
+  wf-config,
 }:
 let
   sources = {
@@ -75,6 +76,7 @@ stdenv.mkDerivation {
     libxkbcommon
     pango
     wayfire
+    wf-config
   ];
 
   env.PKG_CONFIG_WAYFIRE_METADATADIR = "${placeholder "out"}/share/wayfire/metadata";


### PR DESCRIPTION
Package Vecdecor for each supported Wayfire version and use it on non-Felkor hosts. Keep Felkor on Pixdecor and check the selected decorator configuration.

Refs: WW-231