### PR TITLE
chore(concord): update to v2.5.13

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,16 +115,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786959549,
-        "narHash": "sha256-a6+HixqNjt+aHcAuT/trMs/sAaXieoQhbMt56g1u7rM=",
+        "lastModified": 1787577303,
+        "narHash": "sha256-nIFzTbRvXtBDywbtXaudgOrkPXAg4HoXkbNT71VtqpE=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "096f58d4f277dd5f1c2906a475a15062440f86cd",
+        "rev": "0bac5125ddbecb34b357c40d0348bf660c6099ba",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.5.11",
+        "ref": "v2.5.13",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.5.11";
+    concord.url = "github:chojs23/concord/v2.5.13";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to v2.5.13.

Changelog: https://github.com/chojs23/concord/releases