### PR TITLE
chore(slk): update to 0.16.0

### DIFF
--- a/pkgs/slk/default.nix
+++ b/pkgs/slk/default.nix
@@ -13,13 +13,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "slk";
-  version = "0.15.0";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "gammons";
     repo = "slk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Suno3T4epmXifaEzeJ93w5UWcNMW8+Olg5i8mUxLIUk=";
+    hash = "sha256-gYRG4/Kir4Pn2OLg25Fm834sIJ0KNPoGgf1Rdim1ox8=";
   };
 
   vendorHash = "sha256-deqCUDgRvhe/Bpmy+9bIHjSBo+KTCtAN2XcGMhAj/G0=";


### PR DESCRIPTION
Automated slk update to 0.16.0.

Changelog: https://github.com/gammons/slk/releases