### PR TITLE
chore(hermes-agent): update to v2026.8.27

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -489,14 +489,14 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1787314587,
-        "narHash": "sha256-oeFJlEoFybqKkbuWT4mW8PRauusjt3y44ZJXAcA7TPY=",
+        "lastModified": 1787832401,
+        "narHash": "sha256-4EQ3GD5S3UHItPD/R/0WzSamkmtgDXM3AUq/MWZ7qMo=",
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.19.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.27.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.19.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.27.tar.gz"
       }
     },
     "home-manager": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
-    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.19.tar.gz";
+    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.27.tar.gz";
     hermes-agent.inputs.nixpkgs.follows = "nixpkgs-unstable";
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
Automated Hermes Agent update to v2026.8.27.

Changelog: https://github.com/NousResearch/hermes-agent/releases