### PR TITLE
fix(hermes): stamp config schema version in managed settings

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -73,6 +73,11 @@ let
   managedHermesConfig =
     (pkgs.formats.yaml { }).generate "hermes-managed-config.yaml"
       config.services.hermes-agent.settings;
+  # Config schema version expected by the deployed hermes-agent release
+  # (hermes-agent 0.20.5 / 2026.8.19 carries `_config_version: 38` in
+  # DEFAULT_CONFIG). Stamping it in the generated config.yaml keeps
+  # `hermes doctor` from flagging the config as outdated.
+  hermesConfigSchemaVersion = 38;
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the
   # service account and the interactive host user intentionally share one
@@ -906,7 +911,19 @@ in
         # The bundled google_chat-platform plugin auto-loads and fails because
         # google_chat is not a valid Platform here, so deny-list it to silence
         # the startup error.
-        plugins.disabled = [ "google_chat-platform" ];
+        plugins = {
+          enabled = [ ];
+          disabled = [ "google_chat-platform" ];
+        };
+
+        # Stamp the config schema version so `hermes doctor` stops reporting
+        # "Config version outdated (v0 → vN)". Keep this in lockstep with the
+        # `_config_version` in the deployed Hermes' DEFAULT_CONFIG: the value
+        # for a given Hermes release can be read with:
+        #   python3 -c "from hermes_cli.config import DEFAULT_CONFIG; \
+        #     print(DEFAULT_CONFIG['_config_version'])"
+        # run against the deployed hermes-agent package's site-packages.
+        _config_version = hermesConfigSchemaVersion;
       };
     };
 


### PR DESCRIPTION
## Summary

- The Nix-managed `config.yaml` lacked an explicit `_config_version`, so `hermes doctor` reported `Config version outdated (v0 → v38)` against hermes-agent 0.20.5 (2026.8.19)
- A dry run of the upstream v0 → v38 migration ladder against a copy of the live config produced exactly two changes: stamping `_config_version = 38` and adding `plugins.enabled = []`
- Both are now expressed declaratively in `services.hermes-agent.settings`, so the generated config stays in lockstep with the deployed Hermes schema
- `hermesConfigSchemaVersion` is a manual, one-line lockstep point: when the `hermes-agent` flake input is bumped, re-read `DEFAULT_CONFIG['_config_version']` from the new package and update the value (documented in a comment)

## Test Plan

- [x] `just eval` - all configurations evaluate successfully
- [x] `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.settings._config_version` returns `38` (revan is the only host with the `hermes` tag)
- [x] `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.settings.plugins --json` returns `{"disabled":["google_chat-platform"],"enabled":[]}`
- [x] `just lint-registry` passes
- [x] Dry-run of upstream migration ladder confirms no other deltas exist between the managed settings and schema v38

Closes the `hermes doctor` warning observed on revan.