### PR TITLE
fix(hermes): bump config schema version stamp to 39

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -74,10 +74,10 @@ let
     (pkgs.formats.yaml { }).generate "hermes-managed-config.yaml"
       config.services.hermes-agent.settings;
   # Config schema version expected by the deployed hermes-agent release
-  # (hermes-agent 0.20.5 / 2026.8.19 carries `_config_version: 38` in
+  # (hermes-agent 0.20.6 / 2026.8.27 carries `_config_version: 39` in
   # DEFAULT_CONFIG). Stamping it in the generated config.yaml keeps
   # `hermes doctor` from flagging the config as outdated.
-  hermesConfigSchemaVersion = 38;
+  hermesConfigSchemaVersion = 39;
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the
   # service account and the interactive host user intentionally share one


### PR DESCRIPTION
## Summary

- Follow-up to #1013: main now tracks `hermes-agent` v2026.8.27 (0.20.6), which raises `DEFAULT_CONFIG['_config_version']` to 39
- Bumps `hermesConfigSchemaVersion` from 38 to 39 and updates the release reference in the comment
- The only new migration in 38 → 39 strips the retired `bfl` toolset from saved toolset lists, which the managed config does not carry, so the lockstep delta is the stamp itself

## Test Plan

- [x] `just eval` - all configurations evaluate successfully
- [x] `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.settings._config_version` returns `39`