### PR TITLE
ci(freshener): keep Hermes config schema stamp in lockstep

### DIFF
--- a/.github/freshener/hermes-agent.sh
+++ b/.github/freshener/hermes-agent.sh
@@ -33,8 +33,19 @@ nix fmt flake.nix
 
 git diff flake.nix flake.lock
 
+# Keep the managed config's schema stamp in lockstep with the new release. The
+# helper appends its own outputs; when it stamps a new version its files land
+# in the same pull request as the flake input bump.
+.github/freshener/hermes-schema.sh || true
+if [[ -f "$GITHUB_OUTPUT" ]] && grep -q "^updated=true" <(tail -n 4 "$GITHUB_OUTPUT"); then
+  SCHEMA_FILES=$(tail -n 4 "$GITHUB_OUTPUT" | sed -n 's/^files=//p')
+  SCHEMA_VERSION=$(tail -n 4 "$GITHUB_OUTPUT" | sed -n 's/^version=//p')
+  FILES="$FILES $SCHEMA_FILES"
+  VERSION="${VERSION} (config schema v${SCHEMA_VERSION})"
+fi
+
 {
   echo "updated=true"
-  echo "version=${latest}"
-  echo "files=flake.nix flake.lock"
+  echo "version=${VERSION}"
+  echo "files=${FILES}"
 } >> "$GITHUB_OUTPUT"

--- a/.github/freshener/hermes-agent.sh
+++ b/.github/freshener/hermes-agent.sh
@@ -34,18 +34,20 @@ nix fmt flake.nix
 git diff flake.nix flake.lock
 
 # Keep the managed config's schema stamp in lockstep with the new release. The
-# helper appends its own outputs; when it stamps a new version its files land
-# in the same pull request as the flake input bump.
-.github/freshener/hermes-schema.sh || true
-if [[ -f "$GITHUB_OUTPUT" ]] && grep -q "^updated=true" <(tail -n 4 "$GITHUB_OUTPUT"); then
-  SCHEMA_FILES=$(tail -n 4 "$GITHUB_OUTPUT" | sed -n 's/^files=//p')
-  SCHEMA_VERSION=$(tail -n 4 "$GITHUB_OUTPUT" | sed -n 's/^version=//p')
-  FILES="$FILES $SCHEMA_FILES"
-  VERSION="${VERSION} (config schema v${SCHEMA_VERSION})"
+# helper writes updated=true plus version/files outputs when it stamps a new
+# version, and those files join the flake bump in the same pull request. A
+# helper failure aborts the freshener: publishing a flake bump without its
+# schema stamp would leave `hermes doctor` reporting the config as outdated.
+SCHEMA_VERSION="$latest"
+SCHEMA_FILES=""
+.github/freshener/hermes-schema.sh
+SCHEMA_FILES=$(sed -n 's/^files=//p' "$GITHUB_OUTPUT")
+if [[ -n "$SCHEMA_FILES" ]]; then
+  SCHEMA_VERSION=$(sed -n 's/^version=//p' "$GITHUB_OUTPUT")
 fi
 
 {
   echo "updated=true"
-  echo "version=${VERSION}"
-  echo "files=${FILES}"
+  echo "version=${latest} (config schema v${SCHEMA_VERSION})"
+  echo "files=flake.nix flake.lock${SCHEMA_FILES:+ ${SCHEMA_FILES}}"
 } >> "$GITHUB_OUTPUT"

--- a/.github/freshener/hermes-agent.sh
+++ b/.github/freshener/hermes-agent.sh
@@ -2,6 +2,8 @@
 # Update the Hermes Agent flake input, which pins a tag inside its tarball URL.
 set -euo pipefail
 
+MODULE_SCHEMA="nixos/_mixins/server/hermes/default.nix"
+
 current=$(awk -F/ '/hermes-agent.url = "https:\/\/github.com\/NousResearch\/hermes-agent\// { sub(/\.tar\.gz";$/, "", $NF); print $NF }' flake.nix)
 latest=$(curl -fsSL "https://api.github.com/repos/NousResearch/hermes-agent/tags?per_page=100" \
   | jq -r '.[].name' \
@@ -38,7 +40,10 @@ git diff flake.nix flake.lock
 # version, and those files join the flake bump in the same pull request. A
 # helper failure aborts the freshener: publishing a flake bump without its
 # schema stamp would leave `hermes doctor` reporting the config as outdated.
-SCHEMA_VERSION="$latest"
+# The fallback stamp is the version currently in the module: when the new
+# release keeps the existing schema the helper emits no outputs, and the title
+# must still name a schema number, not the release tag.
+SCHEMA_VERSION=$(awk '/hermesConfigSchemaVersion = / { sub(/.*= /, ""); sub(/;.*/, ""); print; exit }' "$MODULE_SCHEMA")
 SCHEMA_FILES=""
 .github/freshener/hermes-schema.sh
 SCHEMA_FILES=$(sed -n 's/^files=//p' "$GITHUB_OUTPUT")

--- a/.github/freshener/hermes-schema.sh
+++ b/.github/freshener/hermes-schema.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# After bumping the Hermes Agent flake input, keep the managed config's schema
+# version stamp in lockstep with the new release.
+#
+# The Hermes mixin stamps `_config_version` into the Nix-generated config.yaml
+# (nixos/_mixins/server/hermes/default.nix, `hermesConfigSchemaVersion`). That
+# value must match `DEFAULT_CONFIG["_config_version"]` from the pinned Hermes
+# release, or `hermes doctor` reports the managed config as outdated.
+#
+# This script extracts the version from the pinned tarball, compares it to the
+# stamp, and when they drift, updates the stamp and exports the extra files to
+# stage. It runs after the flake input bump, so the same pull request carries
+# both changes and the stamp never lags.
+set -euo pipefail
+
+MODULE="nixos/_mixins/server/hermes/default.nix"
+
+current=$(awk '
+  /hermesConfigSchemaVersion = / {
+    sub(/.*= /, ""); sub(/;.*/, ""); print; exit
+  }' "$MODULE")
+
+if [[ -z "$current" ]]; then
+  echo "❌ Could not determine hermesConfigSchemaVersion in $MODULE"
+  exit 1
+fi
+
+# Resolve the pinned Hermes release from flake.nix, then read
+# DEFAULT_CONFIG["_config_version"] straight out of the pinned source tree.
+pinned=$(awk -F/ '/hermes-agent.url = "https:\/\/github.com\/NousResearch\/hermes-agent\// { sub(/\.tar\.gz";$/, "", $NF); print $NF }' flake.nix)
+
+if [[ -z "$pinned" ]]; then
+  echo "❌ Could not determine pinned Hermes Agent release from flake.nix"
+  exit 1
+fi
+
+latest=$(curl -fsSL "https://github.com/NousResearch/hermes-agent/archive/refs/tags/${pinned}.tar.gz" \
+  | tar xzO "hermes-agent-${pinned#v}/hermes_cli/config_defaults.py" \
+  | grep -oE '"_config_version": [0-9]+' \
+  | grep -oE '[0-9]+')
+
+if [[ -z "$latest" ]]; then
+  echo "❌ Could not extract _config_version from Hermes Agent ${pinned}"
+  exit 1
+fi
+
+echo "Pinned Hermes Agent:        ${pinned}"
+echo "Config schema in release:   ${latest}"
+echo "hermesConfigSchemaVersion:  ${current}"
+
+if [[ "$current" == "$latest" ]]; then
+  echo "✅ Config schema stamp is in lockstep"
+  exit 0
+fi
+
+perl -0pi -e "s/hermesConfigSchemaVersion = ${current};/hermesConfigSchemaVersion = ${latest};/" "$MODULE"
+
+# Keep the release reference in the adjacent comment accurate.
+perl -0pi -e "s/\\(hermes-agent [0-9.]+ \\/ [0-9.]+ carries/\\(hermes-agent HPLACEHOLDER\\/ ${pinned} carries/" "$MODULE"
+release_ver=$(curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${pinned}/pyproject.toml" \
+  | grep -oE '^version = "[0-9.]+"' \
+  | grep -oE '[0-9.]+' || true)
+if [[ -n "$release_ver" ]]; then
+  perl -0pi -e "s/\\(hermes-agent HPLACEHOLDER\\/ ${pinned} carries/\\(hermes-agent ${release_ver} \\/ ${pinned#v} carries/" "$MODULE"
+else
+  # Leave a clean value even when pyproject.toml cannot be fetched.
+  perl -0pi -e "s/\\(hermes-agent HPLACEHOLDER\\/ ${pinned} carries/\\(hermes-agent ${pinned#v} carries/" "$MODULE"
+fi
+
+git diff "$MODULE"
+
+{
+  echo "updated=true"
+  echo "version=${latest}"
+  echo "files=${MODULE}"
+} >> "$GITHUB_OUTPUT"

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -74,10 +74,10 @@ let
     (pkgs.formats.yaml { }).generate "hermes-managed-config.yaml"
       config.services.hermes-agent.settings;
   # Config schema version expected by the deployed hermes-agent release
-  # (hermes-agent 0.20.5 / 2026.8.19 carries `_config_version: 38` in
+  # (hermes-agent 0.20.6 / 2026.8.27 carries `_config_version: 39` in
   # DEFAULT_CONFIG). Stamping it in the generated config.yaml keeps
   # `hermes doctor` from flagging the config as outdated.
-  hermesConfigSchemaVersion = 38;
+  hermesConfigSchemaVersion = 39;
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the
   # service account and the interactive host user intentionally share one


### PR DESCRIPTION
## Summary

- The Hermes Agent freshener (Current Hermes Agent: v2026.8.27
Latest Hermes Agent:  v2026.8.27
✅ Hermes Agent is up to date) bumps the flake input, but the managed config's schema stamp (`hermesConfigSchemaVersion` in the Hermes mixin) had to be updated by hand - #1014 exists because that stamp lagged behind the v2026.8.27 bump
- Adds `.github/freshener/hermes-schema.sh`, which:
  - extracts `DEFAULT_CONFIG["_config_version"]` from the pinned release's source tarball (`hermes_cli/config_defaults.py`)
  - compares it to the stamp in `nixos/_mixins/server/hermes/default.nix`
  - on drift, rewrites the stamp and the release-reference comment (comment keeps the `X.Y.Z / vX.Y.Z` format by reading `pyproject.toml` from the pinned tag)
  - on lockstep, exits cleanly and writes nothing to `GITHUB_OUTPUT`
- Wires the helper into `hermes-agent.sh` so the schema bump rides in the same automated PR: outputs are merged, the mixin joins the staged files, and the PR version becomes e.g. `v2026.9.3 (config schema v40)`

## Test Plan

- [x] `bash -n` and `shellcheck` pass on both scripts
- [x] Lockstep path: helper exits 0, `GITHUB_OUTPUT` untouched, no file changes
- [x] Drift path (stamp forced to 38 against pinned v2026.8.27/39): stamp and comment rewritten correctly, outputs `updated=true / version=39 / files=nixos/_mixins/server/hermes/default.nix`
- [x] Output-merge simulation: freshener would stage `flake.nix flake.lock nixos/_mixins/server/hermes/default.nix` and title the PR `v2026.8.27 (config schema v39)`