### PR TITLE
fix(hermes): survive 429 storms with longer retries and a fallback

### DIFF
--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -769,6 +769,25 @@ in
 
         agent.reasoning_effort = "medium";
 
+        # Baseten's 429 responses carry no Retry-After header, so the retry
+        # loop falls back to the short default backoff (2s doubling to 60s).
+        # Three retries — the upstream default — exhaust in ~20 seconds, well
+        # inside a rate-limit window, which let sessions die on 429 storms.
+        # Eight retries stretch the same schedule to roughly three minutes
+        # before the fallback chain takes over.
+        agent.api_max_retries = 8;
+
+        # Cross-provider failover once the primary model's retries exhaust.
+        # Codex is already authenticated on this host, so a Baseten 429 storm
+        # hands off to it seamlessly; the primary is restored automatically
+        # after its escalating 60s-to-4h cooldown clears.
+        fallback_providers = [
+          {
+            provider = "openai-codex";
+            model = "gpt-5.6-sol";
+          }
+        ];
+
         terminal = {
           backend = "local";
           cwd = "/var/lib/hermes/workspace";


### PR DESCRIPTION
## Summary

- Sessions were dying on rate-limit storms: 424 `Rate limit exceeded` errors in errors.log, calls abandoned with `API call failed after 3 retries`
- Root cause is a three-way gap: Baseten's 429s carry no `Retry-After` header (so Hermes uses its short default backoff of 2s doubling to 60s), the upstream default retry ceiling is 3 (~20s total), and no fallback chain was configured, so the escalating 60s-to-4h provider cooldown never armed
- Raise `agent.api_max_retries` from the default 3 to 8, stretching the same jittered exponential schedule to roughly three minutes before giving up on the primary
- Add `fallback_providers` handing off to `openai-codex` / `gpt-5.6-sol` (already authenticated on this host) when retries still exhaust. Hermes benches the rate-limited primary for 60s → 2m → 4m → ... → 4h cap while serving from the fallback, and restores the primary automatically after the cooldown clears

## Test Plan

- [x] `just eval` — all configurations evaluate successfully
- [x] `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.settings.agent.api_max_retries` returns `8`
- [x] `nix eval .#nixosConfigurations.revan.config.services.hermes-agent.settings.fallback_providers --json` returns `[{"model":"gpt-5.6-sol","provider":"openai-codex"}]`
- [x] Confirmed `fallback_providers` and `api_max_retries` are both read by the deployed hermes-agent 0.20.6 (config_defaults.py and agent/agent_init.py respectively)