### PR TITLE
chore(concord): update to v2.5.14

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,16 +141,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787577303,
-        "narHash": "sha256-nIFzTbRvXtBDywbtXaudgOrkPXAg4HoXkbNT71VtqpE=",
+        "lastModified": 1788101133,
+        "narHash": "sha256-gK7hH9BGM8+f+l6nwkJb3z5bEh0RB2B3mgG6W2QmR7c=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "0bac5125ddbecb34b357c40d0348bf660c6099ba",
+        "rev": "5362743846a86c488168565ad1b865b23ce5c6b6",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.5.13",
+        "ref": "v2.5.14",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.2";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.5.13";
+    concord.url = "github:chojs23/concord/v2.5.14";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to v2.5.14.

Changelog: https://github.com/chojs23/concord/releases