### PR TITLE
chore(paseo): update to v0.7.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1023,16 +1023,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787687424,
-        "narHash": "sha256-NrRSz1oYmN/8KNQjZdFJ/2GxMYB+/6RUPregqkjsCSI=",
+        "lastModified": 1788197132,
+        "narHash": "sha256-LZ97yWff6yYSA5H+Uy8qEA2zDYzoKn26ZvDH4FjKzAE=",
         "owner": "getpaseo",
         "repo": "paseo",
-        "rev": "20d7efc46a316f5a274b9943a5c43b0322269825",
+        "rev": "c56638ea8c2852d722a87e700abf3c966ded617e",
         "type": "github"
       },
       "original": {
         "owner": "getpaseo",
-        "ref": "v0.6.1",
+        "ref": "v0.7.0",
         "repo": "paseo",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";
-    paseo.url = "github:getpaseo/paseo/v0.6.1";
+    paseo.url = "github:getpaseo/paseo/v0.7.0";
     paseo.inputs.nixpkgs.follows = "nixpkgs-unstable";
     lan-mouse.url = "github:feschber/lan-mouse/v0.11.0";
     lan-mouse.inputs.nixpkgs.follows = "nixpkgs";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -14,13 +14,13 @@
       # Paseo packages come from the upstream Paseo flake; the desktop client
       # reuses the patched daemon npm closure below.
       #
-      # The v0.6.1 tag ships a wrong npm-deps fixed-output hash, which breaks
+      # The v0.7.0 tag ships a wrong npm-deps fixed-output hash, which breaks
       # the build with a hash mismatch. Correct the hash here until the next
       # upstream release carries a good one.
       fixPaseoNpmDeps =
         pkg:
         pkg.override {
-          npmDepsHash = "sha256-dUvEe+j2E1ptWtjCAi858TnmugqT/+GrgfYJA74oB5I=";
+          npmDepsHash = "sha256-HFYBrCP62r6ZofazBIGSOnMhk8IIEmv+TFJMpqTIJQ8=";
         };
       paseoAttrs = prev.lib.optionalAttrs ((paseoPackages ? paseo) || (paseoPackages ? default)) {
         paseo = fixPaseoNpmDeps (paseoPackages.paseo or paseoPackages.default);


### PR DESCRIPTION
Automated Paseo update to v0.7.0.

Changelog: https://github.com/getpaseo/paseo/commits