### PR TITLE
chore(chainctl): update to 0.2.344

### DIFF
--- a/pkgs/chainctl/default.nix
+++ b/pkgs/chainctl/default.nix
@@ -12,7 +12,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "chainctl";
-  version = "0.2.342";
+  version = "0.2.344";
 
   # Upstream installer: https://edu.chainguard.dev/chainguard/chainctl-usage/how-to-install-chainctl/
   src =
@@ -59,15 +59,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     {
       x86_64-linux = fetchurl {
         url = "${base}/chainctl_linux_x86_64";
-        hash = "sha256-9Me3uwiZbkru5QU9qIMeW9kmQn/QOdFvydwO9+5r1yw=";
+        hash = "sha256-bsj384z8sZ1T73AnvMQhT1jWO053LPGkS0XfNOaiAPc=";
       };
       aarch64-linux = fetchurl {
         url = "${base}/chainctl_linux_arm64";
-        hash = "sha256-jULJLBxys8xNV/cVcIARavJaGRPOH7J4o6rS9Gef8IM=";
+        hash = "sha256-1h6odYDTYMBCvy/P0LbaaF4yP5TilBB6t8Xpzo7maX8=";
       };
       aarch64-darwin = fetchurl {
         url = "${base}/chainctl_darwin_arm64";
-        hash = "sha256-gscCWB7cGReSz0r4QJVz2tsQXJ67E5F0OMbSbz/BdEY=";
+        hash = "sha256-hfAMtB+bjvMr0xPmjg+1OWWb1xT4pygy5pcOKvEn7lI=";
       };
     };
 


### PR DESCRIPTION
Automated chainctl update to 0.2.344.

Changelog: https://edu.chainguard.dev/chainguard/chainctl/