### PR TITLE
chore(chainctl): update to 0.2.346

### DIFF
--- a/pkgs/chainctl/default.nix
+++ b/pkgs/chainctl/default.nix
@@ -12,7 +12,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "chainctl";
-  version = "0.2.344";
+  version = "0.2.346";
 
   # Upstream installer: https://edu.chainguard.dev/chainguard/chainctl-usage/how-to-install-chainctl/
   src =
@@ -59,15 +59,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     {
       x86_64-linux = fetchurl {
         url = "${base}/chainctl_linux_x86_64";
-        hash = "sha256-bsj384z8sZ1T73AnvMQhT1jWO053LPGkS0XfNOaiAPc=";
+        hash = "sha256-drV70rychWHhWLH6SDVsw/0ezUJvFYGlMZrRovKeid0=";
       };
       aarch64-linux = fetchurl {
         url = "${base}/chainctl_linux_arm64";
-        hash = "sha256-1h6odYDTYMBCvy/P0LbaaF4yP5TilBB6t8Xpzo7maX8=";
+        hash = "sha256-KA2LjyK9n/W1D0R4+hOtB9AgEQNz2SaJSY7uvQrR2T8=";
       };
       aarch64-darwin = fetchurl {
         url = "${base}/chainctl_darwin_arm64";
-        hash = "sha256-hfAMtB+bjvMr0xPmjg+1OWWb1xT4pygy5pcOKvEn7lI=";
+        hash = "sha256-oHmAbbJZjG1FbDoOvcs8nr2pBUSVfUzD1jA+AHYP+ZA=";
       };
     };
 


### PR DESCRIPTION
Automated chainctl update to 0.2.346.

Changelog: https://edu.chainguard.dev/chainguard/chainctl/