### PR TITLE
chore(hermes-agent): update to v2026.9.7 (config schema v41)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,14 +556,14 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1788204567,
-        "narHash": "sha256-Ii9xP2fKUpvCcwWZuxJ0g3CZ+IL2UZH14pUNvBfdclc=",
+        "lastModified": 1788819404,
+        "narHash": "sha256-2NuDx7rjsoBDO4I/iMoZsJ+5IaAbiNrDc+sFuzOe08w=",
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.31.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.9.7.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.31.tar.gz"
+        "url": "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.9.7.tar.gz"
       }
     },
     "home-manager": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
-    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.8.31.tar.gz";
+    hermes-agent.url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.9.7.tar.gz";
     hermes-agent.inputs.nixpkgs.follows = "nixpkgs-unstable";
     hermes-agent.inputs.uv2nix.url = "github:pyproject-nix/uv2nix";
     llm-agents.url = "github:numtide/llm-agents.nix";

--- a/nixos/_mixins/server/hermes/default.nix
+++ b/nixos/_mixins/server/hermes/default.nix
@@ -74,10 +74,10 @@ let
     (pkgs.formats.yaml { }).generate "hermes-managed-config.yaml"
       config.services.hermes-agent.settings;
   # Config schema version expected by the deployed hermes-agent release
-  # (hermes-agent 0.20.6 / 2026.8.27 carries `_config_version: 39` in
+  # (hermes-agent 0.21.1 / 2026.9.7 carries `_config_version: 39` in
   # DEFAULT_CONFIG). Stamping it in the generated config.yaml keeps
   # `hermes doctor` from flagging the config as outdated.
-  hermesConfigSchemaVersion = 39;
+  hermesConfigSchemaVersion = 41;
   # Hermes 0.10 started enforcing owner-only chmods in several Python code paths
   # such as auth.json and cron state. That breaks this deployment because the
   # service account and the interactive host user intentionally share one


### PR DESCRIPTION
Automated Hermes Agent update to v2026.9.7 (config schema v41).

Changelog: https://github.com/NousResearch/hermes-agent/releases