### PR TITLE
chore(chainctl): update to 0.2.348

### DIFF
--- a/pkgs/chainctl/default.nix
+++ b/pkgs/chainctl/default.nix
@@ -12,7 +12,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "chainctl";
-  version = "0.2.346";
+  version = "0.2.348";
 
   # Upstream installer: https://edu.chainguard.dev/chainguard/chainctl-usage/how-to-install-chainctl/
   src =
@@ -59,15 +59,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     {
       x86_64-linux = fetchurl {
         url = "${base}/chainctl_linux_x86_64";
-        hash = "sha256-drV70rychWHhWLH6SDVsw/0ezUJvFYGlMZrRovKeid0=";
+        hash = "sha256-0hFf8vOoFgpm0aazoB3Uby9hUna6wSBNxxgEqZQA81s=";
       };
       aarch64-linux = fetchurl {
         url = "${base}/chainctl_linux_arm64";
-        hash = "sha256-KA2LjyK9n/W1D0R4+hOtB9AgEQNz2SaJSY7uvQrR2T8=";
+        hash = "sha256-yuSvNjL1nPaO5k6fWNwindjLT/+qyfat/kfBtGj0duY=";
       };
       aarch64-darwin = fetchurl {
         url = "${base}/chainctl_darwin_arm64";
-        hash = "sha256-oHmAbbJZjG1FbDoOvcs8nr2pBUSVfUzD1jA+AHYP+ZA=";
+        hash = "sha256-DwQX1HeSm0OtJAHW1XLkUWleqsXKfUFoKl12keqX6Gg=";
       };
     };
 


### PR DESCRIPTION
Automated chainctl update to 0.2.348.

Changelog: https://edu.chainguard.dev/chainguard/chainctl/