### PR TITLE
chore(concord): update to v2.5.18

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,16 +142,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1788797092,
-        "narHash": "sha256-W/kpLLz9W9e5f4ja85MeaUGHGpOqiZmRIL4rmBvnT0Y=",
+        "lastModified": 1788963794,
+        "narHash": "sha256-D1b4kTAe5Vl4FaauPtwzr2oCU9ikQiBdBzypnwS/sJc=",
         "owner": "chojs23",
         "repo": "concord",
-        "rev": "9b4721ee2140fb1a5dd44da0ef90cc1f074364a9",
+        "rev": "7b761eb664f470e46ca78fd4f9d41029bcd35fcf",
         "type": "github"
       },
       "original": {
         "owner": "chojs23",
-        "ref": "v2.5.17",
+        "ref": "v2.5.18",
         "repo": "concord",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
     sidra.inputs.nixpkgs.follows = "nixpkgs";
     veila.url = "github:naurissteins/Veila/0.4.4";
     veila.inputs.nixpkgs.follows = "nixpkgs";
-    concord.url = "github:chojs23/concord/v2.5.17";
+    concord.url = "github:chojs23/concord/v2.5.18";
     concord.inputs.nixpkgs.follows = "nixpkgs-unstable";
     concord.inputs.rust-overlay.follows = "rust-overlay";
     concord.inputs.flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Automated Concord update to v2.5.18.

Changelog: https://github.com/chojs23/concord/releases