### PR TITLE
feat(agentic): unify headers and track generated file ownership

### DIFF
--- a/home-manager/_mixins/agentic/assistants/README.md
+++ b/home-manager/_mixins/agentic/assistants/README.md
@@ -440,7 +440,7 @@ model = "gemini-3-flash"
 
 The inference-provider name must match Pi exactly, including hyphens. The default provider is `openai-codex`, not `openai`.
 
-`thinking` accepts `off`, `minimal`, `low`, `medium`, `high`, or `xhigh`. Invalid values fail evaluation.
+`thinking` accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Invalid values fail evaluation. The runtime also checks that the selected model supports the thinking level.
 
 When both fields exist, Pi receives `provider/modelId:thinking`. A thinking-only entry reuses the active session model ID. Model and effort pins are independent. An omitted table preserves session inheritance.
 

--- a/home-manager/_mixins/agentic/assistants/README.md
+++ b/home-manager/_mixins/agentic/assistants/README.md
@@ -41,7 +41,7 @@ The Nix composition is the delivery mechanism, not the strategy. Everything belo
 
 Pi Agent resources are rendered here and consumed by `../pi`, which owns the Pi package, runtime wrapper, settings, MCP adapter, subagent extension config, and theme files.
 
-Agent, command, prompt, and skill files use Markdown with YAML frontmatter. Pi and Codex global instruction files are plain Markdown; Codex agent definitions are TOML. No agent pins a model on any platform except Garfield; every other agent inherits the model selected in the coding tool. OpenCode headers intentionally omit `model` on every agent, so users can switch Anthropic and OpenAI models manually. In frontmatter files, the prompt body follows the `---` delimiters. No build step is required - drop the files in and they work.
+The repository stores metadata in `header.toml` and bodies in Markdown. The composer generates native client files through Home Manager. Agent and command names derive from their directories. Skills declare `[common] name`, which must match the directory. Generated skill files contain YAML frontmatter. Pi and Codex global instructions are plain Markdown, and Codex agents are TOML.
 
 ## Contents
 
@@ -376,7 +376,7 @@ Garfield is the sole pinned agent. His two message-drafting commands also set a 
 | Pi (Google)         | `gemini-3-flash`                                            |
 | Codex               | `gpt-5.6-terra`, reasoning `medium`                         |
 
-No other agent or command sets a model on any platform. The ten remaining agents have no `header.pi.yaml` and no `header.codex.toml` at all, and their `header.claude.yaml` omits `model`.
+No other agent or command sets a model on any platform. The ten remaining agents omit model and effort overrides from `header.toml`.
 
 **Command-level model pins:** `draft-commit-message` and `draft-pr-message` set `model: sonnet` in Claude Code. No other command sets a model. The standalone `make-commit` and `make-pr` commands run in the caller's context and inherit the root session model.
 
@@ -384,7 +384,25 @@ No other agent or command sets a model on any platform. The ten remaining agents
 
 ## Platform Delivery
 
-`compose.nix` reads the source tree and generates platform-specific output. Each agent has one `prompt.md` and optional per-platform headers: `header.claude.yaml`, `header.opencode.yaml`, `header.codex.toml`, and `header.pi.yaml`. Only Garfield carries the Codex and Pi headers today. Codex agents use `header.codex.toml` for role-local config, and Codex command skills can use `header.codex.toml` with `spawn-agent = true` to delegate through `spawn_agent`.
+`compose.nix` reads one `header.toml` per agent, command, skill, or instruction source. It projects metadata into each client's native format.
+
+| Table | Purpose |
+| --- | --- |
+| `[common]` | Shared description and argument hint. Skills also declare `name`, optional `license`, `compatibility`, and `metadata`. |
+| `[claude]`, `[opencode]`, `[codex]`, `[pi]` | Native non-model fields, such as permissions, tools, and context settings. |
+| `[compose]` | Repository agent binding through `agent`. |
+| `[compose.claude]`, `[compose.codex]` | Repository controls `use-task` and `spawn-agent`. |
+| `[routing.claude]`, `[routing.opencode]`, `[routing.codex]` | Native model and effort overrides. |
+| `[routing.pi.<inference-provider>]` | Pi model and thinking overrides for the named inference provider. |
+
+Common hints apply to Claude Code, OpenCode, and Pi. Provider-specific hints preserve differences in presence or value. Missing tables mean no overrides, not disabled output. Omit unset values because TOML has no null.
+
+Ordinary OpenCode and Codex skills do not support model or effort routes in this composer. Such routes fail evaluation. Use an agent-backed command when the workflow needs a model pin.
+
+Keep agent and command bodies in `prompt.md`. Keep skill bodies in frontmatter-free `SKILL.md`, including nested API skills. The composer rebuilds native frontmatter for each client. Encrypted `SKILL.sops` files remain complete native skills.
+
+Retired provider headers are removed. Retired `description.txt` files remain in the repository but are not consumed. Edit only `header.toml` for live metadata.
+
 
 Pi composition routes through `compose.composeAgentFromPrompt "pi"` and `compose.composeCommand "pi"`. The agent-scoped command prelude is assembled in `default.nix` and wraps `composePiCommandFromPrompt`. The Codex output uses the same pattern with a `spawn_agent` wrapper around command-derived skills.
 
@@ -392,7 +410,7 @@ Pi composition routes through `compose.composeAgentFromPrompt "pi"` and `compose
 
 Codex CLI invokes generated commands with `$name` or the `/skills` picker. Custom `/name` commands are unsupported. Every generated command is manual-only, including standalone, agent-owned, and encrypted commands.
 
-The shared `mkCodexCommandOpenAiYaml` helper emits `policy.allow_implicit_invocation: false` in each command's `agents/openai.yaml`. Existing `allow-implicit-invocation = false` headers remain valid. A `true` override fails evaluation. Ordinary reusable skills retain their existing policies, and other providers retain their command formats.
+The shared `mkCodexCommandOpenAiYaml` helper emits `policy.allow_implicit_invocation: false` in each command's `agents/openai.yaml`. Do not duplicate this constant policy in source metadata. Ordinary skill companion policy belongs under `[codex.policy]`. Ordinary reusable skills retain their existing policies, and other providers retain their command formats.
 
 User invocation and workflow composition are separate. A nested `$child` reference does not invoke a command. Load its generated `SKILL.md` from the configured Codex skills root, then pass the arguments, authority, and return contract explicitly. The root follows `home.preferXdgDirectories`: `~/.codex/skills` or `${XDG_CONFIG_HOME}/codex/skills`.
 
@@ -400,60 +418,42 @@ The calling workflow must name the executor: the current agent or a specialist d
 
 ### Pi headers
 
-`header.pi.yaml` is optional. When absent, Pi subagents inherit three generated defaults: `systemPromptMode: append`, `inheritProjectContext: false`, and `inheritSkills: true`. The header file may carry any Pi-native frontmatter field: `model`, `thinking`, `tools`, `defaultContext`, `output`, `fallbackModels`, `maxSubagentDepth`, plus per-command `argument-hint`. Fields present in the file are appended verbatim, so explicit per-agent depth limits are preserved.
+`[pi]` holds native non-model fields such as `tools`, `defaultContext`, `output`, `fallbackModels`, and `maxSubagentDepth`. Pi agents retain three generated defaults: `systemPromptMode: append`, `inheritProjectContext: false`, and `inheritSkills: true`. Explicit values override these defaults.
 
 OpenCode `permission` headers are not mapped to Pi. Pi supports an explicit `tools` allowlist for subagents, but OpenCode's allow/deny permission model is not equivalent.
 
 ### Provider routing
 
-Pi can route a subagent to a provider-specific model and/or reasoning effort
-through extra `model-<provider>` and `thinking-<provider>` keys in the agent's
-`header.pi.yaml`:
+Pi routes subagents through inference-provider tables in each agent's `header.toml`. Garfield declares:
 
-```yaml
-model-anthropic: claude-sonnet-5
-model-openai-codex: gpt-5.6-terra
-model-google: 'gemini-3-flash'
-thinking-openai-codex: medium
+```toml
+[routing.pi.anthropic]
+model = "claude-sonnet-5"
+
+[routing.pi.openai-codex]
+model = "gpt-5.6-terra"
+thinking = "medium"
+
+[routing.pi.google]
+model = "gemini-3-flash"
 ```
 
-That is Garfield's live header, quoted verbatim. He is the only agent with a
-`header.pi.yaml`, so he is the only agent the router matches.
+The inference-provider name must match Pi exactly, including hyphens. The default provider is `openai-codex`, not `openai`.
 
-The suffix after `model-` or `thinking-` must match the active Pi provider
-name exactly, including hyphens (this repo's default provider is
-`openai-codex`, not `openai`). The value must be a plain scalar, with optional
-matching single or double quotes. The Nix harvester uses a regex-only parser,
-so block scalars, anchors, aliases, unmatched quotes, and unquoted values
-containing `:` are ignored.
+`thinking` accepts `off`, `minimal`, `low`, `medium`, `high`, or `xhigh`. Invalid values fail evaluation.
 
-`thinking-<provider>` values are validated at evaluation time against
-`off|minimal|low|medium|high|xhigh`; invalid values fail `nix eval` rather than
-silently entering the generated map.
-
-When both keys are present, Pi receives `provider/modelId:thinking`. When only
-`thinking-<provider>` is set, the runtime reuses the active session model id
-as the bare model, so the agent keeps the parent model and only its reasoning
-effort changes.
-
-This repo's convention is **no headers by default**. Only Garfield declares
-`model-<provider>` and `thinking-<provider>` keys; every other agent ships
-without a `header.pi.yaml` and inherits the model selected in the session. Any
-agent that does need a pin should declare `model-anthropic`,
-`model-openai-codex`, and `thinking-openai-codex` together, so the active model
-and reasoning effort are readable from the agent's own header. Additional
-providers (e.g. `model-google`) are added per-agent where relevant. The router
-also supports thinking-only entries, where the runtime reuses the active
-session model id.
+When both fields exist, Pi receives `provider/modelId:thinking`. A thinking-only entry reuses the active session model ID. Model and effort pins are independent. An omitted table preserves session inheritance.
 
 Pi's global `defaultThinkingLevel = "medium"` and `defaultModel = "gpt-5.6-sol"`
 set the session default for the unnamed global prompt. Agents that omit a
 header do not fall back to them per-agent; they inherit whatever model the
 session is running.
 
-Provider routing covers Pi's LLM tool-call path only. Slash commands such as
-`/run`, `/chain`, `/parallel`, `/run-chain`, and prompt-template bridge calls
-keep their normal Pi and `pi-subagents` model resolution.
+Pi validates and stages routes for direct `/command` and `/skill:name` invocations before prompt expansion. The display extension uses the same dispatcher before it consumes TUI input. The router applies the route at `before_agent_start`, after prompt preflight. At `agent_settled`, after retries and recovery, Pi restores the previous session model and thinking level.
+
+An explicit `--model` or a user model selection takes precedence for the rest of the session. A routed invocation during streaming fails with an error. Supporting skill reads do not change the model.
+
+Subagent workflows route explicit command or direct-skill targets before agent routes. Children inherit the active direct invocation route when no more specific route applies. The router removes routing fields before child launch.
 
 Runtime behaviour lives in
 [`../pi/extensions/provider-router/README.md`](../pi/extensions/provider-router/README.md).
@@ -466,7 +466,7 @@ Pi exposes two surfaces that can take user input, and they handle arguments diff
 
 **Skills** (`/skill:<name>`) do not substitute. Trailing arguments after the skill invocation become a follow-up `User:` message appended after the skill body. A skill is reference content the model loads for context; trailing args are the user request that follows.
 
-This split keeps the surfaces semantically clean: prompts take inputs, skills provide guidance. `argument-hint` in `header.pi.yaml` documents the expected positional arguments for prompt autocomplete; skills carry no equivalent because they do not pattern-match arguments.
+This split keeps the surfaces semantically clean: prompts take inputs, skills provide guidance. `argument-hint` in `[common]` or `[pi]` documents the expected positional arguments for prompt autocomplete; skills carry no equivalent because they do not pattern-match arguments.
 
 | Platform    | Agents                                 | Commands                                  | Global rules                      | Skills                                 |
 | ----------- | -------------------------------------- | ----------------------------------------- | --------------------------------- | -------------------------------------- |
@@ -479,11 +479,39 @@ This split keeps the surfaces semantically clean: prompts take inputs, skills pr
 
 A few command and skill bodies must not enter git or the Nix store. Those directories ship a marker file instead of the plaintext: `prompt.sops` for a command, `SKILL.sops` for a skill. The marker holds one thing, the name of a top-level key in `secrets/assistant-prompts.yaml` whose value is the body. A secret skill's supporting files follow the same convention under the general rule that any `<name>.sops` marker renders to `<name>`, so `references/cycle-mechanics.md.sops` renders to `references/cycle-mechanics.md`; `SKILL.sops` and `prompt.sops` are the two fixed, named exceptions to that rule.
 
-`compose.nix` detects the marker and composes the file with a sops placeholder where the body would go. Claude Code, OpenCode, and Pi receive a sops template that sops-nix renders at activation. Codex gets an activation script that appends the decrypted body, because the Codex skill step clears its own output directory first. Either way the plaintext lives only in the activated file, never in the store.
+`compose.nix` detects the marker and composes the file with a sops placeholder where the body belongs. Claude Code, OpenCode, and Pi use helper-owned links to private sops templates. Codex receives regular files that combine the generated prefix with the decrypted body. Activation checks the refreshed secret sources before the helper writes client files. Plaintext stays outside the Nix store.
 
 A directory holding both the marker and its plaintext counterpart fails evaluation, so the two can never drift apart.
 
-`description.txt` and the `header.*.yaml` files stay plaintext and are composed normally. Keep them free of whatever the encrypted body protects.
+`header.toml` stays plaintext and is composed normally. Keep them free of whatever the encrypted body protects.
+
+### Activation ownership and cleanup
+
+The shared helper updates generated Codex files and custom links that Home Manager does not own. It records ownership in `${XDG_STATE_HOME:-$HOME/.local/state}/agentic/assistants/manifest.json`.
+
+The private manifest stores file hashes, link targets, helper-created directories, and completed one-off retirements. It stores no file bodies or secret history.
+
+| Destination state | Activation action |
+| --- | --- |
+| Unchanged owned output remains in the configuration | Replace it with the new output. |
+| Unchanged owned output leaves the configuration | Remove that exact file or link. |
+| Modified former output leaves the configuration | Preserve it and stop tracking it. |
+| Unknown or modified path conflicts with a desired output | Stop before helper writes and report the path. |
+| Unrelated manual file, plugin, or backup | Leave it untouched. |
+
+Review each reported conflict before the next activation. Keep local changes outside generated destinations. Do not remove the manifest to bypass a conflict.
+
+Cleanup still runs when a client is disabled. It removes only unchanged recorded outputs and empty directories that the helper created, not whole client trees.
+
+On the first migration, activation reads the previous immutable generation and sops records to establish ownership. It never executes an old activation script. Unverified files remain outside ownership.
+
+The approved one-off exception retires the regular file `~/.pi/agent/agents/traya.md` on the next successful activation. Completion is recorded, so later files at that path are not repeatedly removed. A symlink or other non-regular path stays untouched.
+
+Activation captures migration evidence before the final secret refresh. The helper then checks every required source and stages regular-file content before it changes client destinations. A caught apply failure restores the helper's previous files and links. The manifest changes only after successful application.
+
+This transaction does not include public Home Manager links, the sops refresh, or other activation steps. File replacement is atomic per file, not across the whole activation after a machine crash.
+
+Old unverified MCP backups and Nix rollback generations remain outside this cleanup. See [the helper README](owned-files/README.md) for safe tests.
 
 ### Skills
 

--- a/home-manager/_mixins/agentic/assistants/agents/batfink/commands/audit-infra-security/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/batfink/commands/audit-infra-security/header.claude.yaml
@@ -1,1 +1,0 @@
-use-task: true

--- a/home-manager/_mixins/agentic/assistants/agents/batfink/commands/audit-infra-security/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/batfink/commands/audit-infra-security/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: batfink
-subtask: true

--- a/home-manager/_mixins/agentic/assistants/agents/batfink/commands/audit-infra-security/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/batfink/commands/audit-infra-security/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Audit Infrastructure Security 🛡️"
+
+[compose]
+agent = "batfink"
+
+[compose.claude]
+use-task = true
+
+[opencode]
+subtask = true

--- a/home-manager/_mixins/agentic/assistants/agents/batfink/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/batfink/header.claude.yaml
@@ -1,1 +1,0 @@
-name: batfink

--- a/home-manager/_mixins/agentic/assistants/agents/batfink/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/batfink/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/batfink/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/batfink/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "Infrastructure security auditor for cloud, Kubernetes, Docker, CI/CD, network, secrets, and supply-chain config, focused on exploitability and blast radius."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/brain/commands/project-tests-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/brain/commands/project-tests-review/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: brain

--- a/home-manager/_mixins/agentic/assistants/agents/brain/commands/project-tests-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/brain/commands/project-tests-review/header.toml
@@ -1,0 +1,5 @@
+[common]
+description = "Project Tests Review 🧪"
+
+[compose]
+agent = "brain"

--- a/home-manager/_mixins/agentic/assistants/agents/brain/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/brain/header.claude.yaml
@@ -1,1 +1,0 @@
-name: brain

--- a/home-manager/_mixins/agentic/assistants/agents/brain/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/brain/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/brain/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/brain/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "A pragmatic test engineer who analyses code and coverage to suggest high-impact unit tests that catch real bugs while following existing patterns and maintaining simplicity."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-blog-post/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-blog-post/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-blog-post/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-blog-post/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: casper

--- a/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-blog-post/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-blog-post/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-blog-post/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-blog-post/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Draft Blog Post ✍️"
+
+[claude]
+argument-hint = "[topic]"
+
+[compose]
+agent = "casper"
+
+[pi]
+argument-hint = "[topic]"

--- a/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-video-script/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-video-script/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-video-script/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-video-script/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: casper

--- a/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-video-script/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-video-script/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-video-script/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/commands/draft-video-script/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Draft Video Script 🎬"
+
+[claude]
+argument-hint = "[topic]"
+
+[compose]
+agent = "casper"
+
+[pi]
+argument-hint = "[topic]"

--- a/home-manager/_mixins/agentic/assistants/agents/casper/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/header.claude.yaml
@@ -1,1 +1,0 @@
-name: casper

--- a/home-manager/_mixins/agentic/assistants/agents/casper/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/casper/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/casper/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "A technical writer who crafts engaging Linux and open-source content in Martin Wimpress's distinctive British style, blending technical accuracy with personality and humour."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/dibble/commands/audit-code-security/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/dibble/commands/audit-code-security/header.claude.yaml
@@ -1,1 +1,0 @@
-use-task: true

--- a/home-manager/_mixins/agentic/assistants/agents/dibble/commands/audit-code-security/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/dibble/commands/audit-code-security/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: dibble
-subtask: true

--- a/home-manager/_mixins/agentic/assistants/agents/dibble/commands/audit-code-security/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/dibble/commands/audit-code-security/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Audit Code Security 🔍"
+
+[compose]
+agent = "dibble"
+
+[compose.claude]
+use-task = true
+
+[opencode]
+subtask = true

--- a/home-manager/_mixins/agentic/assistants/agents/dibble/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/dibble/header.claude.yaml
@@ -1,1 +1,0 @@
-name: dibble

--- a/home-manager/_mixins/agentic/assistants/agents/dibble/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/dibble/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/dibble/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/dibble/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "Use for explicit code security audits of application source, dependencies, secrets, and LLM app risks when present."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-agentic-repo-capability/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-agentic-repo-capability/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[capability]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-agentic-repo-capability/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-agentic-repo-capability/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: donatello
-argument-hint: "[capability]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-agentic-repo-capability/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-agentic-repo-capability/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[capability]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-agentic-repo-capability/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-agentic-repo-capability/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Add Agentic Repo Capability 🧰"
+argument-hint = "[capability]"
+
+[compose]
+agent = "donatello"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-enricher-capability/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-enricher-capability/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[capability]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-enricher-capability/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-enricher-capability/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: donatello

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-enricher-capability/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-enricher-capability/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[capability]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-enricher-capability/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/add-enricher-capability/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Add manifest-gen enricher capability 🧬"
+
+[claude]
+argument-hint = "[capability]"
+
+[compose]
+agent = "donatello"
+
+[pi]
+argument-hint = "[capability]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|file|text]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: donatello

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|file|text]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/address-code-review/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Address Code Review 👀"
+
+[claude]
+argument-hint = "[pr|file|text]"
+
+[compose]
+agent = "donatello"
+
+[pi]
+argument-hint = "[pr|file|text]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/babysit-pr/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/babysit-pr/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr-url]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/babysit-pr/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/babysit-pr/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: donatello
-argument-hint: "[pr-url]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/babysit-pr/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/babysit-pr/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr-url]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/babysit-pr/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/babysit-pr/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Babysit a PR to the finish line 🍼"
+argument-hint = "[pr-url]"
+
+[compose]
+agent = "donatello"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/create-plan/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/create-plan/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[task]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/create-plan/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/create-plan/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: donatello

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/create-plan/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/create-plan/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[task]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/create-plan/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/create-plan/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Create Plan 💾"
+
+[claude]
+argument-hint = "[task]"
+
+[compose]
+agent = "donatello"
+
+[pi]
+argument-hint = "[task]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/draft-code-review/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/draft-code-review/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/draft-code-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/draft-code-review/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: donatello
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/draft-code-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/draft-code-review/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Draft Code Review ✍️"
+
+[claude]
+argument-hint = "[pr|branch|worktree|commit]"
+
+[compose]
+agent = "donatello"
+
+[opencode]
+argument-hint = "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/implement-plan/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/implement-plan/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[plan-file] [phase]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/implement-plan/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/implement-plan/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: donatello

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/implement-plan/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/implement-plan/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[plan-file] [phase]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/implement-plan/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/implement-plan/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Implement Plan 👨‍💻"
+
+[claude]
+argument-hint = "[plan-file] [phase]"
+
+[compose]
+agent = "donatello"
+
+[pi]
+argument-hint = "[plan-file] [phase]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/post-code-review/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/post-code-review/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[approve|comment] [text]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/post-code-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/post-code-review/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: donatello
-argument-hint: "[approve|comment] [text]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/post-code-review/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/post-code-review/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[approve|comment] [text]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/post-code-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/post-code-review/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Post Code Review 📮"
+argument-hint = "[approve|comment] [text]"
+
+[compose]
+agent = "donatello"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-peer-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-peer-review/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: donatello

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-peer-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-peer-review/header.toml
@@ -1,0 +1,5 @@
+[common]
+description = "Project Peer Review 👁️"
+
+[compose]
+agent = "donatello"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-polish-comments/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-polish-comments/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[paths] [scope]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-polish-comments/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-polish-comments/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: donatello

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-polish-comments/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-polish-comments/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[paths] [scope]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-polish-comments/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/commands/project-polish-comments/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Project Polish Comments ✨"
+
+[claude]
+argument-hint = "[paths] [scope]"
+
+[compose]
+agent = "donatello"
+
+[pi]
+argument-hint = "[paths] [scope]"

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/header.claude.yaml
@@ -1,1 +1,0 @@
-name: donatello

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/donatello/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/donatello/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "A methodical implementation engineer who precisely executes code changes from improvement plans while maintaining existing style, verifying tests pass, and seeking clarification when obstacles arise."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-commit-message/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-commit-message/header.claude.yaml
@@ -1,2 +1,0 @@
-model: sonnet
-use-task: true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-commit-message/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-commit-message/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: garfield
-subtask: true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-commit-message/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-commit-message/header.toml
@@ -1,0 +1,16 @@
+[common]
+description = "Draft Commit Message ✍️"
+
+[routing]
+
+[routing.claude]
+model = "sonnet"
+
+[compose]
+agent = "garfield"
+
+[compose.claude]
+use-task = true
+
+[opencode]
+subtask = true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-pr-message/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-pr-message/header.claude.yaml
@@ -1,2 +1,0 @@
-model: sonnet
-use-task: true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-pr-message/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-pr-message/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: garfield
-subtask: true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-pr-message/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/draft-pr-message/header.toml
@@ -1,0 +1,16 @@
+[common]
+description = "Draft PR Message 🐙"
+
+[routing]
+
+[routing.claude]
+model = "sonnet"
+
+[compose]
+agent = "garfield"
+
+[compose.claude]
+use-task = true
+
+[opencode]
+subtask = true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/finish-pr/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/finish-pr/header.claude.yaml
@@ -1,2 +1,0 @@
-argument-hint: "[branch]"
-use-task: true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/finish-pr/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/finish-pr/header.opencode.yaml
@@ -1,3 +1,0 @@
-agent: garfield
-argument-hint: "[branch]"
-subtask: true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/finish-pr/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/finish-pr/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[branch]"

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/commands/finish-pr/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/commands/finish-pr/header.toml
@@ -1,0 +1,12 @@
+[common]
+description = "Wrap up a finished PR 🧹"
+argument-hint = "[branch]"
+
+[compose]
+agent = "garfield"
+
+[compose.claude]
+use-task = true
+
+[opencode]
+subtask = true

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/header.claude.yaml
@@ -1,2 +1,0 @@
-name: garfield
-model: sonnet

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/header.codex.toml
@@ -1,2 +1,0 @@
-model = "gpt-5.6-terra"
-model_reasoning_effort = "medium"

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/header.pi.yaml
@@ -1,4 +1,0 @@
-model-anthropic: claude-sonnet-5
-model-openai-codex: gpt-5.6-terra
-model-google: 'gemini-3-flash'
-thinking-openai-codex: medium

--- a/home-manager/_mixins/agentic/assistants/agents/garfield/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/garfield/header.toml
@@ -1,0 +1,29 @@
+[common]
+description = "A specialised git workflow assistant that enforces best practices for commit messages, pull requests, and code explanations while strictly adhering to Conventional Commits standards."
+
+[routing]
+
+[routing.claude]
+model = "sonnet"
+
+[routing.codex]
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+
+[routing.pi]
+
+[routing.pi.anthropic]
+model = "claude-sonnet-5"
+
+[routing.pi.openai-codex]
+model = "gpt-5.6-terra"
+thinking = "medium"
+
+[routing.pi.google]
+model = "gemini-3-flash"
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/gonzales/commands/project-performance-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/gonzales/commands/project-performance-review/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: gonzales

--- a/home-manager/_mixins/agentic/assistants/agents/gonzales/commands/project-performance-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/gonzales/commands/project-performance-review/header.toml
@@ -1,0 +1,5 @@
+[common]
+description = "Project Performance Review ⚡"
+
+[compose]
+agent = "gonzales"

--- a/home-manager/_mixins/agentic/assistants/agents/gonzales/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/gonzales/header.claude.yaml
@@ -1,1 +1,0 @@
-name: gonzales

--- a/home-manager/_mixins/agentic/assistants/agents/gonzales/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/gonzales/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/gonzales/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/gonzales/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "A pragmatic performance specialist who identifies high-impact optimisations in bottlenecks and hotspots while preserving code simplicity and focusing on user-perceivable improvements."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-project/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-project/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<name> [team]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-project/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-project/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "<name> [team]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-project/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-project/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<name> [team]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-project/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-project/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Create Project 🗂️"
+argument-hint = "<name> [team]"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-task/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-task/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<project|path>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-task/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-task/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: penfold

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-task/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-task/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<project|path>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-task/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/create-task/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Create Task 📝"
+
+[claude]
+argument-hint = "<project|path>"
+
+[compose]
+agent = "penfold"
+
+[pi]
+argument-hint = "<project|path>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/draft-self-review/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/draft-self-review/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<cycle> [activity-file]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/draft-self-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/draft-self-review/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "<cycle> [activity-file]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/draft-self-review/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/draft-self-review/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<cycle> [activity-file]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/draft-self-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/draft-self-review/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Draft Self-Review 🪞"
+argument-hint = "<cycle> [activity-file]"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/gather-review-data/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/gather-review-data/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<start-date> <end-date>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/gather-review-data/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/gather-review-data/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "<start-date> <end-date>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/gather-review-data/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/gather-review-data/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<start-date> <end-date>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/gather-review-data/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/gather-review-data/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Gather Review Data 📊"
+argument-hint = "<start-date> <end-date>"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[target]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "[target]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[target]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-comment/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Post Comment 📤"
+argument-hint = "[target]"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-issue/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-issue/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<repo>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-issue/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-issue/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "<repo>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-issue/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-issue/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<repo>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-issue/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/post-issue/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Post Issue 📮"
+argument-hint = "<repo>"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-open-source-attestation/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-open-source-attestation/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-open-source-attestation/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-open-source-attestation/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "[pr|branch|worktree]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-open-source-attestation/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-open-source-attestation/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-open-source-attestation/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-open-source-attestation/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Open Source Attestation Review 🧾"
+argument-hint = "[pr|branch|worktree]"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<issue-or-file>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: penfold

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<issue-or-file>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Review Task 🔬"
+
+[claude]
+argument-hint = "<issue-or-file>"
+
+[compose]
+agent = "penfold"
+
+[pi]
+argument-hint = "<issue-or-file>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/review-task/header.toml
@@ -2,10 +2,10 @@
 description = "Review Task 🔬"
 
 [claude]
-argument-hint = "<issue-or-file>"
+argument-hint = "[issue-or-file]"
 
 [compose]
 agent = "penfold"
 
 [pi]
-argument-hint = "<issue-or-file>"
+argument-hint = "[issue-or-file]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/triage-tasks/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/triage-tasks/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[issue-id ...]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/triage-tasks/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/triage-tasks/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "[issue-id ...]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/triage-tasks/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/triage-tasks/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[issue-id ...]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/triage-tasks/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/triage-tasks/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Triage Tasks 🗂️"
+argument-hint = "[issue-id ...]"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/update-task/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/update-task/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<issue|path>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/update-task/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/update-task/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: penfold

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/update-task/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/update-task/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<issue|path>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/update-task/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/update-task/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Update Task ✏️"
+
+[claude]
+argument-hint = "<issue|path>"
+
+[compose]
+agent = "penfold"
+
+[pi]
+argument-hint = "<issue|path>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/weekly-update/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/weekly-update/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<slack-channel>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/weekly-update/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/weekly-update/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "<slack-channel>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/weekly-update/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/weekly-update/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<slack-channel>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/weekly-update/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/weekly-update/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Weekly Update 📣"
+argument-hint = "<slack-channel>"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-create/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-create/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<cycle> [team]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-create/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-create/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "<cycle> [team]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-create/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-create/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<cycle> [team]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-create/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-create/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Create Work Order 📋"
+argument-hint = "<cycle> [team]"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-next/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-next/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: penfold

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-next/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-next/header.toml
@@ -1,0 +1,5 @@
+[common]
+description = "Find Next Work 👉"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-plan/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-plan/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<projects...> [theme]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-plan/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-plan/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "<projects...> [theme]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-plan/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-plan/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<projects...> [theme]"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-plan/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-plan/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Plan Work Order 📐"
+argument-hint = "<projects...> [theme]"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-update/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-update/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<instructions>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-update/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-update/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penfold
-argument-hint: "<instructions>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-update/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-update/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<instructions>"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-update/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/commands/work-order-update/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Update Work Order ✏️"
+argument-hint = "<instructions>"
+
+[compose]
+agent = "penfold"

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/header.claude.yaml
@@ -1,1 +1,0 @@
-name: penfold

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/penfold/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penfold/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "A thoughtful research generalist who explores ideas through dialogue, synthesises findings into context-efficient overviews, and frames problems clearly for downstream specialists."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/audit-communication-rules/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/audit-communication-rules/header.claude.yaml
@@ -1,1 +1,0 @@
-use-task: true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/audit-communication-rules/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/audit-communication-rules/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penry
-subtask: true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/audit-communication-rules/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/audit-communication-rules/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Audit Communication Rules 🛡️"
+
+[compose]
+agent = "penry"
+
+[compose.claude]
+use-task = true
+
+[opencode]
+subtask = true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-code-review/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-code-review/header.claude.yaml
@@ -1,1 +1,0 @@
-use-task: true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-code-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-code-review/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penry
-subtask: true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-code-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-code-review/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Project Code Review 🔍"
+
+[compose]
+agent = "penry"
+
+[compose.claude]
+use-task = true
+
+[opencode]
+subtask = true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-smells-review/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-smells-review/header.claude.yaml
@@ -1,1 +1,0 @@
-use-task: true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-smells-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-smells-review/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: penry
-subtask: true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-smells-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/commands/project-smells-review/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Project Smells Review 🦨"
+
+[compose]
+agent = "penry"
+
+[compose.claude]
+use-task = true
+
+[opencode]
+subtask = true

--- a/home-manager/_mixins/agentic/assistants/agents/penry/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/header.claude.yaml
@@ -1,1 +1,0 @@
-name: penry

--- a/home-manager/_mixins/agentic/assistants/agents/penry/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/penry/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/penry/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "A meticulous code reviewer who identifies practical maintainability improvements through simplification, deduplication, and naming clarity while ensuring all changes are small, safe, and preserve exact functionality."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/README.md
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/README.md
@@ -46,14 +46,14 @@ skills/
 
 | Skill             | Owns                                                                                     | Loads when                                                                                        |
 | ----------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `write-skill`     | Agent Skills open spec, SKILL.md frontmatter, progressive disclosure, references layout  | User edits or creates a `SKILL.md`; mentions "skill", "skills", or names a skill path             |
+| `write-skill`     | Agent Skills open spec, repository metadata, generated native frontmatter, progressive disclosure, references layout | User edits or creates a `SKILL.md`; mentions "skill", "skills", or names a skill path             |
 | `write-assistant` | Agent system prompts, persona, capabilities, voice, output contracts, sub-agent triggers | User edits or creates an agent prompt, sub-agent, assistant, or persona artefact                  |
 | `write-agents-md` | `AGENTS.md` open spec, `CLAUDE.md`, `.cursor/rules/*`, consolidation and migration       | User edits or creates project instructions, rules, project memory, or mentions any of those names |
-| `write-command`   | Slash commands and prompt templates, shim structure, headers per provider, `$ARGUMENTS`  | User edits or creates a slash command, prompt template, or command shim                           |
+| `write-command`   | Slash commands and prompt templates, shim structure, repository metadata, generated native frontmatter per provider, `$ARGUMENTS` | User edits or creates a slash command, prompt template, or command shim                           |
 
 Each skill is description-triggered. The trigger phrases live in the
-`description` frontmatter field, not in the body, because the body only loads
-after the description has already matched.
+`[common] description` field in `header.toml`, which the composer emits in
+generated native frontmatter. The body only loads after the description matches.
 
 ### 2.2 Shim, not monolith
 
@@ -177,7 +177,7 @@ The repo targets four runtimes: Claude Code, OpenCode, Pi, and Codex.
 Skill and command artefacts must work across all four; vendor extensions
 are isolated to references and provider tables in `header.toml`.
 
-### 4.1 Portable frontmatter only
+### 4.1 Repository metadata and native frontmatter
 
 Repository skills use `header.toml` for metadata and a frontmatter-free `SKILL.md` for the body. The composer generates native frontmatter.
 

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/README.md
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/README.md
@@ -110,7 +110,7 @@ caps them at 10,000 characters. Rosey's targets sit inside that band:
 | `AGENTS.md` root    | 50-200 lines                           | 32 KiB (Codex truncates) |
 | Command shim body   | 4-6 lines                              | 10 lines                 |
 | Standalone command  | 30-60 lines if it has an output format | 80 lines                 |
-| `description.txt`   | ≤50 chars                              | 60 chars                 |
+| `[common] description`   | ≤50 chars                              | 60 chars                 |
 | `argument-hint`     | ≤25 chars                              | 30 chars                 |
 
 The numbers are guidance, not religion. The "would removing this cause the
@@ -175,26 +175,21 @@ consume context and, on OpenAI, still count against rate limits.
 
 The repo targets four runtimes: Claude Code, OpenCode, Pi, and Codex.
 Skill and command artefacts must work across all four; vendor extensions
-are isolated to references and per-provider header files.
+are isolated to references and provider tables in `header.toml`.
 
 ### 4.1 Portable frontmatter only
 
-A SKILL.md frontmatter in this repo uses only the two fields from the open
-spec at `agentskills.io`:
+Repository skills use `header.toml` for metadata and a frontmatter-free `SKILL.md` for the body. The composer generates native frontmatter.
 
-```yaml
----
-name: <kebab-case, ≤64 chars, matches parent dir>
-description: <≤1024 chars, third person, when-to-use, trigger-rich>
----
+```toml
+[common]
+name = "example-skill"
+description = "Use when the user asks for the example workflow."
 ```
 
-Vendor-specific fields (`when_to_use`, `allowed-tools`, `disable-model-invocation`,
-`user-invocable`, `argument-hint`, `paths`, `model`, `effort`, `context`,
-`agent`, `hooks`, `shell` from Claude Code; `agent` and `subtask` from
-OpenCode; the Codex companion `agents/openai.yaml`) are documented in
-`write-skill/references/portability.md` but kept out of the SKILL.md
-frontmatter so the file loads cleanly on every runtime.
+The explicit skill name must match its directory. Optional portable fields include `license`, `compatibility`, and `metadata`. Native non-model fields belong in client tables. Model and effort pins belong in routing tables. Ordinary Codex companion policy belongs under `[codex.policy]`.
+
+See `write-skill` for the complete source contract. Agent and command names derive from directory names.
 
 `AGENTS.md` uses **no** frontmatter at all; the open `agents.md` spec is
 plain Markdown with any headings, and vendor parsers do not read YAML at the

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-agents-md/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-agents-md/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[file]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-agents-md/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-agents-md/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[file]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-agents-md/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-agents-md/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[file]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-agents-md/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-agents-md/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Create AGENTS.md 🤖"
+argument-hint = "[file]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-assistant/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-assistant/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[agent-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-assistant/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-assistant/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[agent-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-assistant/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-assistant/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[agent-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-assistant/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-assistant/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Create AI Assistant ✨"
+argument-hint = "[agent-name]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-command/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-command/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[command-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-command/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-command/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[command-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-command/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-command/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[command-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-command/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-command/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Create Slash Command 🪄"
+argument-hint = "[command-name]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-skill/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-skill/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[skill-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-skill/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-skill/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[skill-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-skill/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-skill/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[skill-name]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-skill/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/create-skill/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Create Skill 🧩"
+argument-hint = "[skill-name]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fork/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fork/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fork/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fork/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fork/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fork/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fork/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fork/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Compact handover to a subagent 🔀"
+argument-hint = "[focus]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fresh/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fresh/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fresh/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fresh/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fresh/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fresh/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fresh/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/handover-fresh/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Handover to a fresh session 📤"
+argument-hint = "[focus]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-agents-md/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-agents-md/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[file]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-agents-md/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-agents-md/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[file]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-agents-md/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-agents-md/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[file]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-agents-md/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-agents-md/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Update AGENTS.md 🧠"
+argument-hint = "[file]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-assistant/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-assistant/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[agent-prompt]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-assistant/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-assistant/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[agent-prompt]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-assistant/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-assistant/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[agent-prompt]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-assistant/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-assistant/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Update AI Assistant ⚡"
+argument-hint = "[agent-prompt]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[command-path]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[command-path]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[command-path]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Update Slash Command ⚡"
+argument-hint = "[command-path]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/prompt.md
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-command/prompt.md
@@ -4,4 +4,4 @@ Load the `write-command` skill and run its **update** flow on the target.
 
 Command path argument: $ARGUMENTS. If blank, ask for the command directory or `prompt.md` path.
 
-Apply `write-command`: diagnose body form, headers per provider, argument-hint, argument substitution (`$ARGUMENTS` vs `$1`), and side-effect declaration; preserve `description.txt` unless wrong; emit the changed files plus a short changelog. Do not duplicate that guidance here.
+Apply `write-command`: diagnose body form, `header.toml` provider tables, argument-hint, argument substitution (`$ARGUMENTS` vs `$1`), and side-effect declaration; preserve `[common] description` unless wrong; emit the changed files plus a short changelog. Do not duplicate that guidance here.

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-skill/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-skill/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[skill-path]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-skill/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-skill/header.opencode.yaml
@@ -1,2 +1,0 @@
-agent: rosey
-argument-hint: "[skill-path]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-skill/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-skill/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[skill-path]"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-skill/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/commands/update-skill/header.toml
@@ -1,0 +1,6 @@
+[common]
+description = "Update Skill ⚡"
+argument-hint = "[skill-path]"
+
+[compose]
+agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/header.claude.yaml
@@ -1,1 +1,0 @@
-name: rosey

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/rosey/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/rosey/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "A prompt and skill specialist who crafts, refines, and maintains agent prompts, skills, commands, and instruction files with ruthless token efficiency."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/agents/velma/commands/align-documentation/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/commands/align-documentation/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[scope]"

--- a/home-manager/_mixins/agentic/assistants/agents/velma/commands/align-documentation/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/commands/align-documentation/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: velma

--- a/home-manager/_mixins/agentic/assistants/agents/velma/commands/align-documentation/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/commands/align-documentation/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[scope]"

--- a/home-manager/_mixins/agentic/assistants/agents/velma/commands/align-documentation/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/commands/align-documentation/header.toml
@@ -1,0 +1,11 @@
+[common]
+description = "Align Documentation 📚"
+
+[claude]
+argument-hint = "[scope]"
+
+[compose]
+agent = "velma"
+
+[pi]
+argument-hint = "[scope]"

--- a/home-manager/_mixins/agentic/assistants/agents/velma/commands/draft-readme/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/commands/draft-readme/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: velma

--- a/home-manager/_mixins/agentic/assistants/agents/velma/commands/draft-readme/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/commands/draft-readme/header.toml
@@ -1,0 +1,5 @@
+[common]
+description = "Draft README 📄"
+
+[compose]
+agent = "velma"

--- a/home-manager/_mixins/agentic/assistants/agents/velma/commands/project-documentation-review/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/commands/project-documentation-review/header.opencode.yaml
@@ -1,1 +1,0 @@
-agent: velma

--- a/home-manager/_mixins/agentic/assistants/agents/velma/commands/project-documentation-review/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/commands/project-documentation-review/header.toml
@@ -1,0 +1,5 @@
+[common]
+description = "Project Documentation Review 📋"
+
+[compose]
+agent = "velma"

--- a/home-manager/_mixins/agentic/assistants/agents/velma/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/header.claude.yaml
@@ -1,1 +1,0 @@
-name: velma

--- a/home-manager/_mixins/agentic/assistants/agents/velma/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/header.opencode.yaml
@@ -1,3 +1,0 @@
-permission:
-  task: deny
-  question: allow

--- a/home-manager/_mixins/agentic/assistants/agents/velma/header.toml
+++ b/home-manager/_mixins/agentic/assistants/agents/velma/header.toml
@@ -1,0 +1,8 @@
+[common]
+description = "A documentation architect who creates engaging, well-organised technical documentation by translating code into clear explanations, crafting compelling READMEs, and structuring information for optimal reader comprehension."
+
+[opencode]
+
+[opencode.permission]
+task = "deny"
+question = "allow"

--- a/home-manager/_mixins/agentic/assistants/commands/ack/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ack/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[phase]"

--- a/home-manager/_mixins/agentic/assistants/commands/ack/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/ack/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/ack/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ack/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[phase]"

--- a/home-manager/_mixins/agentic/assistants/commands/ack/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ack/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[phase]"

--- a/home-manager/_mixins/agentic/assistants/commands/ack/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/ack/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Acknowledge feedback 👂"
+argument-hint = "[phase]"

--- a/home-manager/_mixins/agentic/assistants/commands/ahem/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/ahem/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/ahem/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/ahem/header.toml
@@ -1,0 +1,2 @@
+[common]
+description = "Politely re-issue the Communication Rules 📜"

--- a/home-manager/_mixins/agentic/assistants/commands/ask/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ask/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<question>"

--- a/home-manager/_mixins/agentic/assistants/commands/ask/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/ask/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/ask/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ask/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<question>"

--- a/home-manager/_mixins/agentic/assistants/commands/ask/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ask/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<question>"

--- a/home-manager/_mixins/agentic/assistants/commands/ask/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/ask/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Answer a question 💬"
+argument-hint = "<question>"

--- a/home-manager/_mixins/agentic/assistants/commands/call/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/call/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/commands/call/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/call/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/call/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/call/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/commands/call/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/call/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/commands/call/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/call/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Make the call 🎯"
+argument-hint = "[topic]"

--- a/home-manager/_mixins/agentic/assistants/commands/collaborate/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/collaborate/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<issue-or-file>"

--- a/home-manager/_mixins/agentic/assistants/commands/collaborate/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/collaborate/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/collaborate/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/collaborate/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<issue-or-file>"

--- a/home-manager/_mixins/agentic/assistants/commands/collaborate/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/collaborate/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "<issue-or-file>"

--- a/home-manager/_mixins/agentic/assistants/commands/collaborate/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/collaborate/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Read a task and collaborate on it 🤝"
+argument-hint = "<issue-or-file>"

--- a/home-manager/_mixins/agentic/assistants/commands/gist/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/gist/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/gist/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/gist/header.toml
@@ -1,0 +1,2 @@
+[common]
+description = "Rewrite the previous response concisely"

--- a/home-manager/_mixins/agentic/assistants/commands/grill-me/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/grill-me/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[plan]"

--- a/home-manager/_mixins/agentic/assistants/commands/grill-me/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/grill-me/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/grill-me/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/grill-me/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[plan]"

--- a/home-manager/_mixins/agentic/assistants/commands/grill-me/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/grill-me/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[plan]"

--- a/home-manager/_mixins/agentic/assistants/commands/grill-me/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/grill-me/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Grill Me 🔥"
+argument-hint = "[plan]"

--- a/home-manager/_mixins/agentic/assistants/commands/implement-task/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/implement-task/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[issue-or-path]"

--- a/home-manager/_mixins/agentic/assistants/commands/implement-task/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/implement-task/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/implement-task/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/implement-task/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[issue-or-path]"

--- a/home-manager/_mixins/agentic/assistants/commands/implement-task/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/implement-task/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[issue-or-path]"

--- a/home-manager/_mixins/agentic/assistants/commands/implement-task/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/implement-task/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Implement a tracked task end to end 🛠️"
+argument-hint = "[issue-or-path]"

--- a/home-manager/_mixins/agentic/assistants/commands/make-commit/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/make-commit/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/make-commit/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/make-commit/header.toml
@@ -1,0 +1,2 @@
+[common]
+description = "Draft and make a commit ✍️"

--- a/home-manager/_mixins/agentic/assistants/commands/make-pr/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/make-pr/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/make-pr/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/make-pr/header.toml
@@ -1,0 +1,2 @@
+[common]
+description = "Draft and open a PR 🐙"

--- a/home-manager/_mixins/agentic/assistants/commands/oi/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/oi/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/oi/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/oi/header.toml
@@ -1,0 +1,2 @@
+[common]
+description = "Bluntly re-issue the Communication Rules 📜"

--- a/home-manager/_mixins/agentic/assistants/commands/orientate/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/orientate/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/commands/orientate/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/orientate/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/orientate/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/orientate/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/commands/orientate/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/orientate/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/commands/orientate/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/orientate/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Orientate 🧭"
+argument-hint = "[focus]"

--- a/home-manager/_mixins/agentic/assistants/commands/ready/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ready/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/commands/ready/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/ready/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/ready/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ready/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/commands/ready/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/ready/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[topic]"

--- a/home-manager/_mixins/agentic/assistants/commands/ready/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/ready/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Get ready 🌱"
+argument-hint = "[topic]"

--- a/home-manager/_mixins/agentic/assistants/commands/reflect/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/reflect/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/commands/reflect/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/reflect/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/reflect/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/reflect/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/commands/reflect/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/reflect/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[focus]"

--- a/home-manager/_mixins/agentic/assistants/commands/reflect/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/reflect/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Reflect on the session and suggest tooling changes 💭"
+argument-hint = "[focus]"

--- a/home-manager/_mixins/agentic/assistants/commands/reflect/prompt.md
+++ b/home-manager/_mixins/agentic/assistants/commands/reflect/prompt.md
@@ -52,7 +52,7 @@ A block the user asked for is not friction. Denials exist so an agent stops: `gh
 
 The tree lives at `~/Zero/nix-config/home-manager/_mixins/agentic/assistants/`. This session may be running anywhere, so check what exists before judging what is missing.
 
-Keep it cheap. List the directory names under `agents/`, `commands/`, `agents/*/commands/`, and `skills/`. The names are descriptive, so shortlist from them, then read `description.txt` or the `SKILL.md` frontmatter for the few candidates that matter. Do not read `README.md`. Do not read every prompt: the tree holds dozens of commands, and this review does not warrant that cost.
+Keep it cheap. List the directory names under `agents/`, `commands/`, `agents/*/commands/`, and `skills/`. The names are descriptive, so shortlist from them, then read `[common] description` in `header.toml` for the few candidates that matter. Do not read `README.md`. Do not read every prompt: the tree holds dozens of commands, and this review does not warrant that cost.
 
 ### Act only on what the user picks
 

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[target|report]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[target|report]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[target|report]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-again/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Review Code Again 🔁"
+argument-hint = "[target|report]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-colleague/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Review Colleague Code 🔍"
+argument-hint = "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-community/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Review Community Code 🛡️"
+argument-hint = "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/review-code-mine/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Review My Code 🪞"
+argument-hint = "[pr|branch|worktree|commit]"

--- a/home-manager/_mixins/agentic/assistants/commands/wtb/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/wtb/header.claude.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr-url] [#channel]"

--- a/home-manager/_mixins/agentic/assistants/commands/wtb/header.codex.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/wtb/header.codex.toml
@@ -1,1 +1,0 @@
-allow-implicit-invocation = false

--- a/home-manager/_mixins/agentic/assistants/commands/wtb/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/wtb/header.opencode.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr-url] [#channel]"

--- a/home-manager/_mixins/agentic/assistants/commands/wtb/header.pi.yaml
+++ b/home-manager/_mixins/agentic/assistants/commands/wtb/header.pi.yaml
@@ -1,1 +1,0 @@
-argument-hint: "[pr-url] [#channel]"

--- a/home-manager/_mixins/agentic/assistants/commands/wtb/header.toml
+++ b/home-manager/_mixins/agentic/assistants/commands/wtb/header.toml
@@ -1,0 +1,3 @@
+[common]
+description = "Want to Buy 🪿"
+argument-hint = "[pr-url] [#channel]"

--- a/home-manager/_mixins/agentic/assistants/compose.nix
+++ b/home-manager/_mixins/agentic/assistants/compose.nix
@@ -1,15 +1,20 @@
 {
   lib,
   pkgs ? null,
+  basePath ? ./.,
 }:
 let
   # Read a file, stripping trailing whitespace
   readFile = path: lib.trim (builtins.readFile path);
 
-  # Read a file if it exists, otherwise return an empty string. Used for
-  # optional per-platform headers such as `header.pi.yaml`, where absence
-  # means "use defaults".
-  readOptionalFile = path: if builtins.pathExists path then readFile path else "";
+  metadata = import ./metadata.nix { inherit lib; };
+  inherit (metadata) readHeader;
+  headerFor =
+    kind: platform: name: path:
+    metadata.project kind platform name (readHeader path);
+  renderHeader =
+    kind: platform: name: path:
+    metadata.renderYaml (headerFor kind platform name path);
 
   # Compose with YAML frontmatter: ---\n{header}\n---\n\n{body}\n
   # Adds blank line after frontmatter and trailing newline
@@ -30,108 +35,6 @@ let
     else
       lib.trim text;
 
-  isQuotedString =
-    value:
-    let
-      length = builtins.stringLength value;
-      first = builtins.substring 0 1 value;
-      last = builtins.substring (length - 1) 1 value;
-    in
-    length >= 2 && ((first == "\"" && last == "\"") || (first == "'" && last == "'"));
-
-  validateYamlHeader =
-    path:
-    if !(builtins.pathExists path) then
-      true
-    else
-      let
-        lines = lib.splitString "\n" (builtins.readFile path);
-        numberedLines = lib.imap0 (index: text: {
-          line = index + 1;
-          inherit text;
-        }) lines;
-        isHeaderLine =
-          entry:
-          let
-            trimmed = lib.trim entry.text;
-          in
-          trimmed == ""
-          || lib.hasPrefix "#" trimmed
-          || builtins.match "^[A-Za-z0-9_-]+:[[:space:]]*.*$" trimmed != null
-          || builtins.match "^[[:space:]]+[A-Za-z0-9_-]+:[[:space:]]*.*$" entry.text != null;
-        argumentHintValue =
-          line:
-          let
-            matched = builtins.match "^argument-hint:[[:space:]]*(.*)$" (lib.trim line);
-          in
-          if matched == null then null else builtins.elemAt matched 0;
-        invalidSyntax = lib.filter (entry: !(isHeaderLine entry)) numberedLines;
-        invalidArgumentHints = lib.filter (
-          entry:
-          let
-            value = argumentHintValue entry.text;
-          in
-          value != null && !(isQuotedString value)
-        ) numberedLines;
-        formatLine = entry: "${toString path}:${toString entry.line}: ${entry.text}";
-      in
-      if invalidSyntax != [ ] then
-        throw "Invalid YAML header syntax in ${toString path}:\n${
-          lib.concatMapStringsSep "\n" formatLine invalidSyntax
-        }"
-      else if invalidArgumentHints != [ ] then
-        throw "Invalid argument-hint in ${toString path}: expected a quoted string, got:\n${
-          lib.concatMapStringsSep "\n" formatLine invalidArgumentHints
-        }"
-      else
-        true;
-
-  stripMatchingQuotes =
-    value:
-    let
-      length = builtins.stringLength value;
-      first = builtins.substring 0 1 value;
-      last = builtins.substring (length - 1) 1 value;
-    in
-    if length >= 2 && ((first == "\"" && last == "\"") || (first == "'" && last == "'")) then
-      builtins.substring 1 (length - 2) value
-    else
-      value;
-
-  normaliseProviderModelValue =
-    value:
-    let
-      trimmed = lib.trim value;
-      length = builtins.stringLength trimmed;
-      first = builtins.substring 0 1 trimmed;
-      last = builtins.substring (length - 1) 1 trimmed;
-      hasMatchingQuotes =
-        length >= 2 && ((first == "\"" && last == "\"") || (first == "'" && last == "'"));
-      startsUnsupportedYaml = lib.any (prefix: lib.hasPrefix prefix trimmed) [
-        "|"
-        ">"
-        "&"
-        "*"
-      ];
-    in
-    if trimmed == "" || startsUnsupportedYaml then
-      null
-    else if hasMatchingQuotes then
-      stripMatchingQuotes trimmed
-    else if first == "\"" || first == "'" || lib.hasInfix ":" trimmed then
-      null
-    else
-      trimmed;
-
-  # Default Pi subagent header lines. Each generated agent inherits these.
-  # Optional `header.pi.yaml` content is appended verbatim so agent-specific
-  # Pi-native fields, including explicit depth limits, are preserved.
-  piAgentDefaultLines = [
-    "systemPromptMode: append"
-    "inheritProjectContext: false"
-    "inheritSkills: true"
-  ];
-
   # Discover directories in a path
   discoverDirs =
     path:
@@ -139,9 +42,6 @@ let
       lib.filterAttrs (_name: type: type == "directory") (builtins.readDir path)
     else
       { };
-
-  # Base path for all assistant files
-  basePath = ./.;
 
   # ============ AGENTS ============
 
@@ -151,113 +51,21 @@ let
   # Compose a single agent for a specific platform using the provided prompt.
   composeAgentFromPrompt =
     platform: agentName: prompt:
-    let
-      agentPath = basePath + "/agents/${agentName}";
-      description = readFile (agentPath + "/description.txt");
-      headerPath = agentPath + "/header.${platform}.yaml";
-      body = prompt;
-    in
-    if platform == "pi" then
-      # Pi: header.pi.yaml is optional. Inject `name` and `description`,
-      # then the generated subagent defaults, then any agent-specific
-      # Pi-native fields from header.pi.yaml verbatim.
-      let
-        rawHeader = builtins.seq (validateYamlHeader headerPath) (readOptionalFile headerPath);
-        baseLines = [
-          "name: ${agentName}"
-          "description: ${builtins.toJSON description}"
-        ]
-        ++ piAgentDefaultLines;
-        lines = baseLines ++ lib.optional (rawHeader != "") rawHeader;
-      in
-      composeWithFrontmatter (lib.concatStringsSep "\n" lines) body
-    else
-      let
-        header = builtins.seq (validateYamlHeader headerPath) (readFile headerPath);
-        # Inject description from description.txt into header
-        headerWithDescription = "description: \"${description}\"\n${header}";
-      in
-      composeWithFrontmatter headerWithDescription body;
+    composeWithFrontmatter (renderHeader "agent" platform agentName (
+      basePath + "/agents/${agentName}"
+    )) prompt;
 
-  parseAgentProviderModelLine =
-    line:
-    let
-      uncommented = lib.head (lib.splitString "#" line);
-      matched = builtins.match "^[[:space:]]*model-([A-Za-z0-9_-]+):[[:space:]]*(.+)[[:space:]]*$" uncommented;
-    in
-    if matched == null then
-      null
-    else
-      let
-        value = normaliseProviderModelValue (builtins.elemAt matched 1);
-      in
-      if value == null then
-        null
-      else
-        {
-          name = builtins.elemAt matched 0;
-          inherit value;
-        };
-
-  # Valid Pi thinking levels. `defaultThinkingLevel` and per-call `thinking`
-  # both use this set. Invalid values fail evaluation rather than silently
-  # entering the generated map.
-  validThinkingLevels = [
-    "off"
-    "minimal"
-    "low"
-    "medium"
-    "high"
-    "xhigh"
-  ];
-
-  parseAgentProviderThinkingLine =
-    agentName: line:
-    let
-      uncommented = lib.head (lib.splitString "#" line);
-      matched = builtins.match "^[[:space:]]*thinking-([A-Za-z0-9_-]+):[[:space:]]*(.+)[[:space:]]*$" uncommented;
-    in
-    if matched == null then
-      null
-    else
-      let
-        provider = builtins.elemAt matched 0;
-        value = normaliseProviderModelValue (builtins.elemAt matched 1);
-      in
-      if value == null then
-        null
-      else if !(lib.elem value validThinkingLevels) then
-        throw "Invalid thinking level ${builtins.toJSON value} for thinking-${provider} in agent ${agentName}/header.pi.yaml. Expected one of: ${lib.concatStringsSep ", " validThinkingLevels}."
-      else
-        {
-          name = provider;
-          inherit value;
-        };
-
-  # Regex-only harvester for flat `model-<provider>: <id>` keys in Pi
-  # headers. This is intentionally narrower than a YAML parser.
+  agentProviderRoutes = agentName: (readHeader (basePath + "/agents/${agentName}")).routing.pi or { };
   extractAgentProviderModels =
     agentName:
-    let
-      header = readOptionalFile (basePath + "/agents/${agentName}/header.pi.yaml");
-      entries = lib.filter (entry: entry != null) (
-        map parseAgentProviderModelLine (lib.splitString "\n" header)
-      );
-    in
-    lib.foldl' (acc: entry: acc // { "${entry.name}" = entry.value; }) { } entries;
-
-  # Sibling harvester for `thinking-<provider>: <level>` keys in Pi headers.
-  # Mirrors extractAgentProviderModels but validates against the closed set of
-  # Pi thinking levels; invalid values fail evaluation with a clear message.
+    lib.mapAttrs (_: route: route.model) (
+      lib.filterAttrs (_: route: route ? model) (agentProviderRoutes agentName)
+    );
   extractAgentProviderThinking =
     agentName:
-    let
-      header = readOptionalFile (basePath + "/agents/${agentName}/header.pi.yaml");
-      entries = lib.filter (entry: entry != null) (
-        map (parseAgentProviderThinkingLine agentName) (lib.splitString "\n" header)
-      );
-    in
-    lib.foldl' (acc: entry: acc // { "${entry.name}" = entry.value; }) { } entries;
+    lib.mapAttrs (_: route: route.thinking) (
+      lib.filterAttrs (_: route: route ? thinking) (agentProviderRoutes agentName)
+    );
 
   # Compose a single agent for a specific platform.
   composeAgent =
@@ -331,6 +139,7 @@ let
   commandSources =
     lib.mapAttrsToList (cmdName: _: {
       name = cmdName;
+      agentName = null;
       source = toString (basePath + "/commands/${cmdName}");
     }) standaloneCommandDirs
     ++ lib.concatLists (
@@ -338,6 +147,7 @@ let
         agentName: _:
         lib.mapAttrsToList (cmdName: _: {
           name = cmdName;
+          inherit agentName;
           source = toString (basePath + "/agents/${agentName}/commands/${cmdName}");
         }) (discoverAgentCommands agentName)
       ) agentDirs
@@ -347,65 +157,54 @@ let
   # `default.nix` for agent-scoped commands that wrap the body with
   # subagent-launch boilerplate before emitting frontmatter, and internally
   # by `composeCommand` for standalone commands.
+  commandPath =
+    agentName: cmdName:
+    if agentName != null then
+      basePath + "/agents/${agentName}/commands/${cmdName}"
+    else
+      basePath + "/commands/${cmdName}";
+
+  commandMetadata =
+    agentName: cmdName:
+    let
+      header = readHeader (commandPath agentName cmdName);
+      selectedAgent = header.compose.agent or agentName;
+    in
+    if selectedAgent != null && !(agentDirs ? ${selectedAgent}) then
+      throw "Unknown compose.agent ${selectedAgent} for command ${cmdName}."
+    else
+      header
+      // {
+        compose =
+          (header.compose or { }) // lib.optionalAttrs (selectedAgent != null) { agent = selectedAgent; };
+      };
+
   composePiCommandFromPrompt =
     agentName: cmdName: body:
-    let
-      cmdPath =
-        if agentName != null then
-          basePath + "/agents/${agentName}/commands/${cmdName}"
-        else
-          basePath + "/commands/${cmdName}";
-      description = readFile (cmdPath + "/description.txt");
-      headerPath = cmdPath + "/header.pi.yaml";
-      rawHeader = builtins.seq (validateYamlHeader headerPath) (readOptionalFile headerPath);
-      lines = [
-        "description: ${builtins.toJSON description}"
-      ]
-      ++ lib.optional (rawHeader != "") rawHeader;
-    in
-    composeWithFrontmatter (lib.concatStringsSep "\n" lines) body;
+    composeWithFrontmatter (metadata.renderYaml (
+      metadata.project "command" "pi" cmdName (commandMetadata agentName cmdName)
+    )) body;
 
-  # Compose a single command for a specific platform using the provided body.
-  # The body is wrapped verbatim with all per-platform boilerplate (Claude
-  # `@agent` prepend or `use-task` Task wrapper, Pi subagent prelude via
-  # composePiCommandFromPrompt). Passing the body as an argument lets callers
-  # substitute a sops placeholder string where the plaintext prompt would
-  # otherwise be read, so secret commands compose identically without the
-  # body ever entering the Nix store. Mirrors composeAgentFromPrompt and
-  # composePiCommandFromPrompt.
   composeCommandFromPrompt =
     platform: agentName: cmdName: body:
     let
-      cmdPath =
-        if agentName != null then
-          basePath + "/agents/${agentName}/commands/${cmdName}"
-        else
-          basePath + "/commands/${cmdName}";
+      source = commandMetadata agentName cmdName;
+      selectedAgent = source.compose.agent or null;
+      useTask = source.compose.claude.use-task or false;
+      native = metadata.project "command" platform cmdName source;
+      header = metadata.renderYaml (
+        native
+        // lib.optionalAttrs (platform == "opencode" && selectedAgent != null) { agent = selectedAgent; }
+      );
     in
-    if platform == "pi" then
-      composePiCommandFromPrompt agentName cmdName body
+    if platform == "claude" && selectedAgent != null && useTask then
+      composeWithFrontmatter header "Use the Task tool to launch the ${selectedAgent} agent for the following task:\n\n${body}"
+    else if platform == "claude" && selectedAgent != null then
+      composeWithFrontmatter header "@${selectedAgent}\n\n${body}"
+    else if platform == "pi" && selectedAgent != null then
+      composeWithFrontmatter header "Use the subagent tool to launch the `${selectedAgent}` agent for the task below.\n\nSet `context` to `\"fresh\"`.\n\n${body}"
     else
-      let
-        description = readFile (cmdPath + "/description.txt");
-        headerPath = cmdPath + "/header.${platform}.yaml";
-        rawHeader = builtins.seq (validateYamlHeader headerPath) (readFile headerPath);
-        # Inject description from description.txt into header
-        header = "description: \"${description}\"\n${rawHeader}";
-        # Check if this command should use Task tool for subagent execution
-        useTask = lib.hasInfix "use-task: true" rawHeader;
-      in
-      if platform == "claude" && agentName != null && useTask then
-        # Claude Code with agent + use-task: instruct to use Task tool for subagent
-        composeWithFrontmatter header ''
-          Use the Task tool to launch the ${agentName} agent for the following task:
-
-          ${body}''
-      else if platform == "claude" && agentName != null then
-        # Claude Code with agent (no use-task): prepend @agent on its own line before body
-        composeWithFrontmatter header "@${agentName}\n\n${body}"
-      else
-        # All other cases: standard frontmatter + body
-        composeWithFrontmatter header body;
+      composeWithFrontmatter header body;
 
   # Compose a single command for a specific platform
   # agentName is null for standalone commands
@@ -599,19 +398,13 @@ let
           agentName:
           let
             agentPath = basePath + "/agents/${agentName}";
-            description = escapeMarkdownTableCell (readFile (agentPath + "/description.txt"));
+            description = escapeMarkdownTableCell (readHeader agentPath).common.description;
           in
           "- **${agentName}**: ${description}"
         ) sortedAgentNames
       );
     in
     ''
-      ---
-      name: delegate-task
-      description: Routes non-trivial work to the right specialist agent and applies when coordinating delegated results, waiting for agent completion, or relaying specialist responses.
-      user-invocable: true
-      ---
-
       ## Agents
 
       ${agentLines}
@@ -713,49 +506,135 @@ let
     else
       throw "The communication-rules skill body (${toString skillPath}) has drifted from the house style (${toString stylePath}). Copy the body of house-style.md (frontmatter stripped) into SKILL.md below its frontmatter.";
 
-  generatedSkills = {
-    delegate-task = {
-      content = lib.trim delegateTaskSkillContent;
-      path =
-        if pkgs != null then
-          pkgs.writeTextDir "SKILL.md" delegateTaskSkillContent
-        else
-          throw "composeSkills requires pkgs to materialise generated skills";
-      extras = { };
+  generatedSkillsFor =
+    platform:
+    let
+      content = composeWithFrontmatter (renderHeader "skill" platform "delegate-task" (
+        basePath + "/skills/delegate-task"
+      )) (stripFrontmatter delegateTaskSkillContent);
+    in
+    {
+      delegate-task = {
+        inherit content;
+        path = buildSkillTree platform "delegate-task" (
+          [
+            {
+              name = "SKILL.md";
+              path = pkgs.writeText "SKILL.md" content;
+            }
+          ]
+          ++ skillCompanionEntries platform (basePath + "/skills/delegate-task")
+        );
+        extras =
+          lib.optionalAttrs (skillCompanionEntries platform (basePath + "/skills/delegate-task") != [ ])
+            {
+              agents = "directory";
+            };
+      };
     };
-  };
 
   skillDirs = physicalSkillDirs // {
     delegate-task = "generated";
   };
 
-  # Compose a single skill into a structured value:
-  #   - content: the SKILL.md body (verbatim, trimmed)
-  #   - path:    the source skill directory in the Nix store (used to copy
-  #              the entire tree wholesale for Claude Code and OpenCode)
-  #   - extras:  attrset of sibling entries beside SKILL.md ({ name = type; ... })
-  #              so callers (e.g. the Codex activation script) can deploy
-  #              supporting files and subdirectories generically
-  composeSkill =
-    skillName:
+  skillCompanionEntries =
+    platform: path:
     let
-      skillPath = basePath + "/skills/${skillName}";
-      entries = builtins.readDir skillPath;
-      extras = lib.filterAttrs (name: _: name != "SKILL.md") entries;
+      companion =
+        if platform == "codex" && builtins.pathExists (path + "/header.toml") then
+          metadata.skillCompanion path
+        else
+          { };
     in
-    {
-      content = readFile (skillPath + "/SKILL.md");
-      path = skillPath;
-      inherit extras;
+    lib.optional (companion != { }) {
+      name = "agents/openai.yaml";
+      path = pkgs.writeText "openai.yaml" (metadata.renderYaml companion + "\n");
     };
 
-  # Generate all skills. Secret skills are excluded, because every consumer of
-  # this attrset either reads the SKILL.md body or symlinks the source
-  # directory, and both would put plaintext in the store.
-  # Returns attrset: { skillName = { content; path; extras; }; ... }
-  composeSkills = builtins.seq communicationRulesSkillInSync (
-    generatedSkills // lib.mapAttrs (name: _: composeSkill name) physicalSkillDirs
-  );
+  skillTree =
+    platform: path:
+    lib.concatLists (
+      lib.mapAttrsToList (
+        name: type:
+        let
+          source = path + "/${name}";
+        in
+        if name == "header.toml" then
+          [ ]
+        else if type == "directory" then
+          map (entry: entry // { name = "${name}/${entry.name}"; }) (skillTree platform source)
+        else if name == "SKILL.md" && builtins.pathExists (path + "/header.toml") then
+          [
+            {
+              inherit name;
+              path = pkgs.writeText "SKILL.md" (
+                composeWithFrontmatter (renderHeader "skill" platform (builtins.baseNameOf path) path) (
+                  builtins.readFile source
+                )
+              );
+            }
+          ]
+        else
+          [
+            {
+              inherit name;
+              path = source;
+            }
+          ]
+      ) (builtins.readDir path)
+    )
+    ++ skillCompanionEntries platform path;
+
+  # Codex follows directory links but skips SKILL.md file links during discovery.
+  buildSkillTree =
+    platform: skillName: entries:
+    let
+      tree = pkgs.linkFarm "${platform}-skill-${skillName}" entries;
+    in
+    if platform != "codex" then
+      tree
+    else
+      tree.overrideAttrs (old: {
+        buildCommand =
+          old.buildCommand
+          + lib.concatMapStringsSep "\n" (entry: ''
+            cp --remove-destination -- ${lib.escapeShellArg "${entry.path}"} "$out"/${lib.escapeShellArg entry.name}
+          '') (lib.filter (entry: builtins.baseNameOf entry.name == "SKILL.md") entries);
+      });
+
+  composeSkill =
+    platform: skillName:
+    let
+      source = basePath + "/skills/${skillName}";
+      companionEntries = skillCompanionEntries platform source;
+      content = builtins.seq companionEntries (
+        composeWithFrontmatter (renderHeader "skill" platform skillName source) (
+          builtins.readFile (source + "/SKILL.md")
+        )
+      );
+      extras =
+        lib.filterAttrs (
+          name: _:
+          !(lib.elem name [
+            "SKILL.md"
+            "header.toml"
+          ])
+        ) (builtins.readDir source)
+        // lib.optionalAttrs (companionEntries != [ ]) {
+          agents = "directory";
+        };
+    in
+    {
+      inherit content extras;
+      path = buildSkillTree platform skillName (skillTree platform source);
+    };
+
+  composeSkillsFor =
+    platform:
+    builtins.seq communicationRulesSkillInSync (
+      generatedSkillsFor platform // lib.mapAttrs (name: _: composeSkill platform name) physicalSkillDirs
+    );
+  composeSkills = composeSkillsFor "claude";
 
   # ============ GLOBAL INSTRUCTIONS ============
 
@@ -763,14 +642,22 @@ let
     platform:
     let
       instructionsPath = basePath + "/instructions";
-      headerPath = instructionsPath + "/header.${platform}.yaml";
-      header = builtins.seq (validateYamlHeader headerPath) (readFile headerPath);
+      header = renderHeader "instructions" platform "instructions" instructionsPath;
       body = readFile (instructionsPath + "/global.md");
     in
     composeWithFrontmatter header body;
 
 in
 {
+  inherit
+    readHeader
+    headerFor
+    commandMetadata
+    commandPath
+    composeSkillsFor
+    ;
+  inherit (metadata) renderToml;
+
   # Agent composition functions
   inherit
     composeAgents

--- a/home-manager/_mixins/agentic/assistants/default.nix
+++ b/home-manager/_mixins/agentic/assistants/default.nix
@@ -1,14 +1,12 @@
 {
   config,
   lib,
+  noughtyLib,
   pkgs,
   ...
 }:
 let
   readFileTrim = path: lib.trim (builtins.readFile path);
-  readFileTrimIfExists = path: if builtins.pathExists path then readFileTrim path else "";
-  readTomlOrEmpty =
-    path: if builtins.pathExists path then builtins.fromTOML (builtins.readFile path) else { };
   codexAgentPrompt =
     prompt:
     lib.replaceStrings
@@ -21,27 +19,6 @@ let
         "Permitted tools: `spawn_agent` for delegation, direct conversation"
       ]
       prompt;
-  tomlMultilineLiteral =
-    value: if lib.hasInfix "'''" value then builtins.toJSON value else "'''\n${value}\n'''";
-  renderCodexAgentToml =
-    {
-      name,
-      description,
-      developerInstructions,
-      header ? "",
-    }:
-    ''
-      ${lib.optionalString (header != "") "${header}\n"}
-      name = ${builtins.toJSON name}
-      description = ${builtins.toJSON description}
-      developer_instructions = ${tomlMultilineLiteral developerInstructions}
-    '';
-  renderCodexOpenAiYaml =
-    { allowImplicitInvocation }:
-    ''
-      policy:
-        allow_implicit_invocation: ${if allowImplicitInvocation then "true" else "false"}
-    '';
   codexDir =
     if config.home.preferXdgDirectories then
       "${config.xdg.configHome}/codex"
@@ -54,6 +31,7 @@ let
   codingAgentDirs = lib.removeAttrs compose.agentDirs [ "traya" ];
 
   globalInstructions = readFileTrim ./instructions/global.md;
+  piEnabled = noughtyLib.userHasTag "developer";
 
   # ============ SECRET COMMANDS ============
 
@@ -108,9 +86,8 @@ let
   secretOpencodePath = cmdName: "${config.xdg.configHome}/opencode/commands/${cmdName}.md";
   secretPiPath = cmdName: "${config.home.homeDirectory}/.pi/agent/prompts/${cmdName}.md";
 
-  # sops templates for Claude, OpenCode, and Pi. Each renders the composed
-  # command (frontmatter + per-platform body wrapper) with the sops placeholder
-  # standing in for the prompt body, written to an explicit path at activation.
+  # sops templates for Claude, OpenCode, and Pi render in private sops paths.
+  # The ownership helper links them to the explicit client destinations.
   # Pi reuses the subagent-launch prelude assembled for non-secret agent
   # commands so the placeholder body carries identical routing.
   secretCommandTemplates = lib.listToAttrs (
@@ -127,7 +104,7 @@ let
           else
             let
               piPrompt = ''
-                Use the subagent tool to launch the `${agentName}` agent for the task below.
+                Use the subagent tool to launch the `${(compose.commandMetadata agentName cmdName).compose.agent}` agent for the task below.
 
                 - Set `context` to `"fresh"`. Do not set `"fork"`; the parent session is large and forking inherits parent prose without bound.
 
@@ -148,7 +125,7 @@ let
           path = secretOpencodePath cmdName;
         })
       ]
-      ++ [
+      ++ lib.optionals piEnabled [
         (lib.nameValuePair "assistant-pi-command-${cmdName}" {
           content = piBody;
           path = secretPiPath cmdName;
@@ -162,10 +139,9 @@ let
   # Collect every secret skill with the metadata each platform needs. A skill
   # is secret when its directory holds a `SKILL.sops` marker instead of a
   # plaintext `SKILL.md`; supporting `.sops` markers render beside it so
-  # progressive disclosure survives encryption. Nothing here enters the store:
-  # Claude, OpenCode, and Pi receive sops templates written to explicit paths
-  # at activation, and Codex copies the decrypted secrets in its activation
-  # script.
+  # progressive disclosure survives encryption. Decrypted bodies stay outside
+  # the store. The ownership helper links rendered templates for Claude,
+  # OpenCode, and Pi, and copies decrypted files for Codex.
   secretSkillList = lib.mapAttrsToList (skillName: _: {
     name = skillName;
     inherit ((compose.skillSecretInfo skillName)) key;
@@ -229,8 +205,7 @@ let
       ) entry.supportFiles
     ) secretSkillList;
 
-  # Claude and OpenCode only receive templates when their programs are enabled;
-  # Pi is ungated, matching how secret commands are deployed.
+  # Secret destinations follow the same client gates as public files.
   secretSkillTemplates = lib.listToAttrs (
     lib.optionals config.programs.claude-code.enable (
       mkSecretSkillTemplates "claude" secretSkillClaudeDir
@@ -238,7 +213,7 @@ let
     ++ lib.optionals config.programs.opencode.enable (
       mkSecretSkillTemplates "opencode" secretSkillOpencodeDir
     )
-    ++ mkSecretSkillTemplates "pi" secretSkillPiDir
+    ++ lib.optionals piEnabled (mkSecretSkillTemplates "pi" secretSkillPiDir)
   );
 
   # ============ CLAUDE CODE ============
@@ -299,7 +274,7 @@ let
   piSkillFiles = lib.mapAttrs' (name: skill: {
     name = ".pi/agent/skills/${name}";
     value.source = skill.path;
-  }) skills;
+  }) piSkills;
   piStandalonePromptFiles = lib.mapAttrs' (cmdName: _: {
     name = ".pi/agent/prompts/${cmdName}.md";
     value.text = compose.composeCommand "pi" null cmdName;
@@ -332,7 +307,7 @@ let
         # variants. The prelude is the sole carrier of agent routing now
         # that the filename no longer encodes the owning agent.
         piPrompt = ''
-          Use the subagent tool to launch the `${agentName}` agent for the task below.
+          Use the subagent tool to launch the `${(compose.commandMetadata agentName cmdName).compose.agent}` agent for the task below.
 
           - Set `context` to `"fresh"`. Do not set `"fork"`; the parent session is large and forking inherits parent prose without bound.
 
@@ -393,13 +368,44 @@ let
     lib.mapAttrs (name: _: compose.extractAgentProviderThinking name) codingAgentDirs
   );
 
+  piInvocationRoutes = {
+    commands = lib.listToAttrs (
+      map (
+        entry:
+        let
+          metadata = compose.commandMetadata entry.agentName entry.name;
+        in
+        {
+          inherit (entry) name;
+          value =
+            lib.optionalAttrs ((metadata.compose or { }) ? agent) { inherit (metadata.compose) agent; }
+            // {
+              providers = metadata.routing.pi or { };
+            };
+        }
+      ) compose.commandSources
+    );
+    skills = lib.mapAttrs (
+      name: _:
+      let
+        metadata = compose.readHeader (./skills + "/${name}");
+      in
+      {
+        providers = metadata.routing.pi or { };
+      }
+    ) (lib.removeAttrs compose.skillDirs [ "delegate-task" ]);
+  };
+
   # ============ SKILLS ============
 
   # composeSkills returns { name = { content; path; extras; }; ... }
   # where `extras` enumerates sibling files and subdirectories alongside
   # SKILL.md (e.g. references/, rules/, metadata.json) that must be deployed
   # for the skill to function.
-  skills = compose.composeSkills;
+  skills = compose.composeSkillsFor "codex";
+  claudeSkills = compose.composeSkillsFor "claude";
+  opencodeSkills = compose.composeSkillsFor "opencode";
+  piSkills = compose.composeSkillsFor "pi";
 
   # Codex's activation script expects { name = "SKILL.md content"; ... } so
   # it can merge in command-derived skill texts. Project skills only.
@@ -412,7 +418,7 @@ let
   mkClaudeSkillFiles = lib.mapAttrs' (name: skill: {
     name = "${config.home.homeDirectory}/.claude/skills/${name}";
     value.source = skill.path;
-  }) skills;
+  }) claudeSkills;
 
   # Generate home.file entries for OpenCode skills.
   # Same approach: symlink the whole skill directory under
@@ -420,48 +426,53 @@ let
   mkOpencodeSkillFiles = lib.mapAttrs' (name: skill: {
     name = "${config.xdg.configHome}/opencode/skills/${name}";
     value.source = skill.path;
-  }) skills;
+  }) opencodeSkills;
 
   # Collect all Codex agent name -> TOML content pairs.
   # codex-rs discovers agent roles by scanning the agents/ directory for .toml
   # files using file_type().is_file(), which returns false for symlinks on Linux.
   # home.file creates symlinks, so agents written via home.file are invisible.
   # Content is written as real files via the activation script below.
-  codexAgents = lib.mapAttrs (
-    name: _:
+  codexRole =
+    name: agentName: route:
     let
-      agentPath = ./agents + "/${name}";
-      description = readFileTrim (agentPath + "/description.txt");
-      prompt = codexAgentPrompt (readFileTrim (agentPath + "/prompt.md"));
-      header = readFileTrimIfExists (agentPath + "/header.codex.toml");
+      agentPath = ./agents + "/${agentName}";
+      metadata = compose.headerFor "agent" "codex" agentName agentPath;
     in
-    renderCodexAgentToml {
-      inherit name description;
-      developerInstructions = prompt;
-      inherit header;
-    }
-  ) codingAgentDirs;
+    compose.renderToml (
+      lib.recursiveUpdate metadata route
+      // {
+        inherit name;
+        developer_instructions = codexAgentPrompt (readFileTrim (agentPath + "/prompt.md"));
+      }
+    );
 
-  # Activation script that writes Codex agent files as real files (not symlinks).
-  codexAgentsActivationScript =
-    let
-      agentCmds = lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (
-          name: content:
-          let
-            escaped = lib.escapeShellArg content;
-          in
-          ''printf '%s' ${escaped} > "${codexDir}/agents/${name}.toml"''
-        ) codexAgents
-      );
-    in
-    ''
-        # Write Codex agent files as real files (not symlinks).
-        # codex-rs skips symlinked .toml files during agent role discovery.
-      rm -rf "${codexDir}/agents"
-      mkdir -p "${codexDir}/agents"
-      ${agentCmds}
-    '';
+  metadataHelpers = import ./metadata.nix { inherit lib; };
+  codexCommandDispatch =
+    cmdName: agentName: cmdPath:
+    metadataHelpers.commandDispatch codingAgentDirs cmdName agentName (compose.readHeader cmdPath);
+
+  codexCommandRoles = lib.listToAttrs (
+    lib.concatMap (
+      entry:
+      let
+        path = /. + entry.source;
+        dispatch = codexCommandDispatch entry.name entry.agentName path;
+      in
+      lib.optional (dispatch.route != { }) {
+        name = dispatch.role;
+        value = codexRole dispatch.role dispatch.selectedAgent dispatch.route;
+      }
+    ) compose.commandSources
+  );
+  codexAgents =
+    if
+      lib.intersectLists (builtins.attrNames codingAgentDirs) (builtins.attrNames codexCommandRoles)
+      != [ ]
+    then
+      throw "A generated Codex command role conflicts with an existing agent."
+    else
+      lib.mapAttrs (name: _: codexRole name name { }) codingAgentDirs // codexCommandRoles;
 
   # Build a Codex skill file (SKILL.md) for a command.
   # Custom prompt support was removed from codex-rs in March 2026. Commands
@@ -473,7 +484,7 @@ let
   # task in a fresh sub-thread. The owning agent's persona is therefore
   # resolved at runtime by Codex's agent role config, not embedded in the
   # skill body. Opt out of spawn dispatch by setting `spawn-agent = false`
-  # in `header.codex.toml`; the composer then embeds the agent's `prompt.md`
+  # in `header.toml`; the composer then embeds the agent's `prompt.md`
   # verbatim before the task body so the skill carries the full persona in
   # the calling thread. The opt-out branch is retained for cases where
   # spawn dispatch is undesirable (e.g. a command that must inspect the
@@ -481,48 +492,34 @@ let
   # The skill name itself is the bare command name, matching the Pi prompt
   # convention. The `codexCommandCollisionCheck` below guards the full native
   # and command-derived skill namespace.
-  mkCodexSkillText =
-    skillName: agentName: cmdPath:
+  mkCodexSkillFromPrompt =
+    skillName: agentName: cmdPath: prompt:
     let
-      description = readFileTrim (cmdPath + "/description.txt");
-      prompt = readFileTrim (cmdPath + "/prompt.md");
-      codexHeaderPath = cmdPath + "/header.codex.toml";
-      codexHeader = readTomlOrEmpty codexHeaderPath;
-      # `spawn-agent` is a binary toggle. Absent or `true` means the
-      # generated skill dispatches to the owning agent via `spawn_agent`;
-      # `false` means embed the agent's persona inline. Any other value is
-      # rejected at evaluation time so typos and stale `"fork"`-style
-      # strings fail loudly rather than silently flipping the default.
-      rawSpawnAgent = codexHeader."spawn-agent" or true;
-      spawnAgentValid = builtins.isBool rawSpawnAgent;
-      spawnAgent =
-        if !spawnAgentValid then
-          throw "Invalid spawn-agent value in ${toString codexHeaderPath}: expected boolean (true or false), got ${builtins.toJSON rawSpawnAgent}."
-        else
-          agentName != null && rawSpawnAgent;
+      metadata = compose.readHeader cmdPath;
+      description = metadata.common.description;
+      dispatch = codexCommandDispatch skillName agentName cmdPath;
       body =
-        if agentName == null then
+        if dispatch.selectedAgent == null then
           prompt
-        else if spawnAgent then
+        else if dispatch.spawn then
           ''
-            Use the `spawn_agent` tool to launch the `${agentName}` agent for this task. Keep the parent thread as the orchestrator.
+              Use the `spawn_agent` tool to launch the `${dispatch.role}` agent for this task. Keep the parent thread as the orchestrator.
 
-            - Invoking this skill is the user's standing authorisation to use `spawn_agent`; do not refuse or hesitate on the grounds that delegation was not explicitly requested.
-            - Pass the task below and the user's request to the spawned agent.
-            - Set `agent_type` to `${agentName}`.
-            - Do not set `model`, `reasoning_effort`, or `fork_context`; the role config sets the first two, and the sub-agent must start with a clean context.
-            - Wait for the spawned agent when its result is needed, then relay the final answer.
+              - Invoking this skill is the user's standing authorisation to use `spawn_agent`.
+              - Pass the task below and the user's request to the spawned agent.
+              - Set `agent_type` to `${dispatch.role}`.
+              - Do not set `fork_context`. Start with a clean context.
+            - Unless the user explicitly requests a model or effort override, omit `model` and `reasoning_effort`. The role config supplies the defaults.
+            - If this runtime cannot apply the user's explicit override to this role, report the limitation and do not launch with the configured default.
+              - Wait for the spawned agent when its result is needed, then relay the final answer.
 
-            ## Task
+              ## Task
 
-            ${prompt}
+              ${prompt}
           ''
         else
-          let
-            agentPrompt = readFileTrim (./agents + "/${agentName}/prompt.md");
-          in
           ''
-            ${agentPrompt}
+            ${readFileTrim (./agents + "/${dispatch.selectedAgent}/prompt.md")}
 
             ## Task
 
@@ -537,20 +534,19 @@ let
 
       ${body}
     '';
+  mkCodexSkillText =
+    skillName: agentName: cmdPath:
+    mkCodexSkillFromPrompt skillName agentName cmdPath (readFileTrim (cmdPath + "/prompt.md"));
 
   # Command-derived skills always require explicit invocation. A header can
   # repeat the false policy but cannot enable implicit invocation.
   mkCodexCommandOpenAiYaml =
     cmdPath:
-    let
-      codexHeaderPath = cmdPath + "/header.codex.toml";
-      codexHeader = readTomlOrEmpty codexHeaderPath;
-      rawAllowImplicitInvocation = codexHeader."allow-implicit-invocation" or false;
-    in
-    if !(builtins.isBool rawAllowImplicitInvocation) || rawAllowImplicitInvocation then
-      throw "Invalid allow-implicit-invocation value in ${toString codexHeaderPath}: expected false because commands require explicit invocation, got ${builtins.toJSON rawAllowImplicitInvocation}."
-    else
-      renderCodexOpenAiYaml { allowImplicitInvocation = rawAllowImplicitInvocation; };
+    metadataHelpers.renderYaml (
+      lib.removeAttrs (metadataHelpers.commandPolicy (compose.readHeader cmdPath)) [
+        "allow-implicit-invocation"
+      ]
+    );
 
   # Collision guard for the Codex skill namespace. Codex loads every skill
   # from `$CODEX_HOME/skills/<name>/SKILL.md`, so the keyspace is the union
@@ -646,177 +642,98 @@ let
     codexStandaloneCommandOpenAiYamls // codexAgentCommandOpenAiYamls
   );
 
-  # Activation script that writes Codex skills as real files.
-  # codex-rs scans for SKILL.md using entry.file_type() which does NOT follow
-  # symlinks on Linux - it returns the type of the symlink itself. The scanner
-  # only follows symlinked directories, not symlinked files; it skips symlinked
-  # SKILL.md files entirely. home.file creates symlinks, so skills written via
-  # home.file are invisible to codex. Writing real files via activation avoids
-  # this limitation.
-  #
-  # Supporting entries beside SKILL.md (e.g. references/, rules/, metadata.json)
-  # are symlinked into place. The scanner only inspects SKILL.md itself for the
-  # is_file() check, and it does follow symlinked directories, so symlinks for
-  # extras are safe and avoid copying large reference trees. Command-derived
-  # skills always write agents/openai.yaml with implicit invocation disabled.
-  codexSkillsActivationScript =
-    let
-      skillCmds = lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (
-          name: content:
-          let
-            escaped = lib.escapeShellArg content;
-            # Project skills carry `extras`; command-derived skills do not
-            # appear in `skills` and so contribute nothing here.
-            inherit ((skills.${name} or { extras = { }; })) extras;
-            extrasCmds = lib.concatStringsSep "\n" (
-              lib.mapAttrsToList (
-                entryName: _:
-                let
-                  src = "${skills.${name}.path}/${entryName}";
-                  dst = "${codexDir}/skills/${name}/${entryName}";
-                in
-                "ln -sfn ${lib.escapeShellArg src} ${lib.escapeShellArg dst}"
-              ) extras
-            );
-            openAiYaml = codexCommandOpenAiYamls.${name} or null;
-            openAiYamlCmd = lib.optionalString (openAiYaml != null) ''
-              mkdir -p "${codexDir}/skills/${name}/agents"
-              printf '%s' ${lib.escapeShellArg openAiYaml} > "${codexDir}/skills/${name}/agents/openai.yaml"
-            '';
-          in
-          ''
-            mkdir -p "${codexDir}/skills/${name}"
-            printf '%s' ${escaped} > "${codexDir}/skills/${name}/SKILL.md"
-            ${extrasCmds}
-            ${openAiYamlCmd}''
-        ) codexSkills
-      );
-    in
-    ''
-      # Write Codex skill files as real files (not symlinks).
-      # codex-rs skips symlinked SKILL.md files during discovery; supporting
-      # entries (subdirectories and sibling files) are symlinked into the
-      # skill directory beside the real SKILL.md.
-      rm -rf "${codexDir}/skills"
-      ${skillCmds}
-    '';
+  ownedFile = path: content: {
+    inherit path;
+    kind = "file";
+    source = toString (pkgs.writeText (builtins.baseNameOf path) content);
+    mode = "0600";
+  };
 
-  codexRootInstructionsActivationScript =
-    let
-      escaped = lib.escapeShellArg globalInstructions;
-    in
-    ''
-      # Write Codex root instructions from the canonical global prompt.
-      mkdir -p "${codexDir}"
-      printf '%s\n' ${escaped} > "${codexDir}/AGENTS.md"
-    '';
+  codexOwnedFiles = [
+    (ownedFile "${codexDir}/AGENTS.md" (globalInstructions + "\n"))
+  ]
+  ++ lib.mapAttrsToList (
+    name: content: ownedFile "${codexDir}/agents/${name}.toml" content
+  ) codexAgents
+  ++ lib.concatLists (
+    lib.mapAttrsToList (
+      name: content:
+      [ (ownedFile "${codexDir}/skills/${name}/SKILL.md" content) ]
+      ++ lib.mapAttrsToList (entryName: _: {
+        path = "${codexDir}/skills/${name}/${entryName}";
+        source = "${skills.${name}.path}/${entryName}";
+        kind = "symlink";
+      }) (skills.${name}.extras or { })
+      ++ lib.optional (codexCommandOpenAiYamls ? ${name}) (
+        ownedFile "${codexDir}/skills/${name}/agents/openai.yaml" codexCommandOpenAiYamls.${name}
+      )
+    ) codexSkills
+  );
 
-  # Activation script that writes Codex SKILL.md files for secret commands.
-  # The Codex skill activation above does `rm -rf skills`, so a sops template
-  # writing into that tree would lose the race. Instead this composes each
-  # secret skill at activation: the public frontmatter plus the spawn_agent
-  # prelude (or the bare standalone form) are written from Nix, then the
-  # decrypted body is appended by reading config.sops.secrets.<key>.path.
-  # Command-derived agents/openai.yaml files use the same header.codex.toml
-  # contract as non-secret commands.
-  # This entry is ordered after codexFiles (which recreates skills/) and after
-  # the sops-nix activation node so the decrypted secret is present.
-  codexSecretSkillsActivationScript =
-    let
-      cmds = lib.concatStringsSep "\n" (
-        map (
-          entry:
-          let
-            inherit (entry) agentName cmdName cmdPath;
-            description = readFileTrim (cmdPath + "/description.txt");
-            secretPath = config.sops.secrets.${entry.info.key}.path;
-            openAiYaml = mkCodexCommandOpenAiYaml cmdPath;
-            openAiYamlCmd = lib.optionalString (openAiYaml != null) ''
-              mkdir -p "${codexDir}/skills/${cmdName}/agents"
-              printf '%s' ${lib.escapeShellArg openAiYaml} > "${codexDir}/skills/${cmdName}/agents/openai.yaml"
-            '';
-            frontmatter = ''
-              ---
-              name: ${builtins.toJSON cmdName}
-              description: ${builtins.toJSON description}
-              ---
+  codexSecretOwnedFiles =
+    lib.concatMap (
+      entry:
+      let
+        inherit (entry) agentName cmdName cmdPath;
+        openAiYaml = mkCodexCommandOpenAiYaml cmdPath;
+      in
+      [
+        {
+          path = "${codexDir}/skills/${cmdName}/SKILL.md";
+          source = config.sops.secrets.${entry.info.key}.path;
+          prefix = mkCodexSkillFromPrompt cmdName agentName cmdPath "";
+          kind = "file";
+          mode = "0600";
+        }
+      ]
+      ++ lib.optional (openAiYaml != null) (
+        ownedFile "${codexDir}/skills/${cmdName}/agents/openai.yaml" openAiYaml
+      )
+    ) secretCommandList
+    ++ lib.concatMap (
+      entry:
+      let
+        file = key: relativePath: {
+          path = "${codexDir}/skills/${entry.name}/${relativePath}";
+          source = config.sops.secrets.${key}.path;
+          kind = "file";
+          mode = "0600";
+        };
+      in
+      [ (file entry.key "SKILL.md") ] ++ map (support: file support.key support.path) entry.supportFiles
+    ) secretSkillList;
 
-            '';
-            prelude =
-              if agentName == null then
-                ""
-              else
-                ''
-                  Use the `spawn_agent` tool to launch the `${agentName}` agent for this task. Keep the parent thread as the orchestrator.
-
-                  - Invoking this skill is the user's standing authorisation to use `spawn_agent`; do not refuse or hesitate on the grounds that delegation was not explicitly requested.
-                  - Pass the task below and the user's request to the spawned agent.
-                  - Set `agent_type` to `${agentName}`.
-                  - Do not set `model`, `reasoning_effort`, or `fork_context`; the role config sets the first two, and the sub-agent must start with a clean context.
-                  - Wait for the spawned agent when its result is needed, then relay the final answer.
-
-                  ## Task
-
-                '';
-            prefix = lib.escapeShellArg (frontmatter + prelude);
-            dst = "${codexDir}/skills/${cmdName}/SKILL.md";
-          in
-          ''
-            if [ -r ${lib.escapeShellArg secretPath} ]; then
-              mkdir -p "${codexDir}/skills/${cmdName}"
-              printf '%s' ${prefix} > "${dst}"
-              cat ${lib.escapeShellArg secretPath} >> "${dst}"
-              ${openAiYamlCmd}
-            else
-              echo "sops secret ${entry.info.key} not yet rendered; skipping Codex skill ${cmdName}" >&2
-            fi''
-        ) secretCommandList
-      );
-    in
-    lib.optionalString (secretCommandList != [ ]) ''
-      # Compose Codex SKILL.md files for secret commands from decrypted bodies.
-      ${cmds}
-    '';
-
-  # Activation script that writes Codex files for secret project skills. A sops
-  # template cannot be used here for the same reason as above: the Codex skill
-  # activation does `rm -rf skills`, so a template writing into that tree would
-  # lose the race. Each decrypted secret is the whole file, so it is copied
-  # verbatim rather than composed. Supporting files keep their relative path
-  # under the skill directory so progressive-disclosure links still resolve.
-  codexSecretProjectSkillsActivationScript =
-    let
-      writeSecretFile =
-        key: dst:
-        let
-          secretPath = config.sops.secrets.${key}.path;
-        in
-        ''
-          if [ -r ${lib.escapeShellArg secretPath} ]; then
-            mkdir -p "$(dirname ${lib.escapeShellArg dst})"
-            cat ${lib.escapeShellArg secretPath} > ${lib.escapeShellArg dst}
-          else
-            echo "sops secret ${key} not yet rendered; skipping Codex skill file ${dst}" >&2
-          fi'';
-      cmds = lib.concatStringsSep "\n" (
-        lib.concatMap (
-          entry:
-          let
-            dir = "${codexDir}/skills/${entry.name}";
-          in
-          [ (writeSecretFile entry.key "${dir}/SKILL.md") ]
-          ++ map (file: writeSecretFile file.key "${dir}/${file.path}") entry.supportFiles
-        ) secretSkillList
-      );
-    in
-    lib.optionalString (secretSkillList != [ ]) ''
-      # Write Codex files for secret project skills from decrypted secrets.
-      ${cmds}
-    '';
-
+  secretTemplates = secretCommandTemplates // secretSkillTemplates;
+  secretOwnedFiles = lib.mapAttrsToList (name: template: {
+    inherit (template) path;
+    source = config.sops.templates.${name}.path;
+    kind = "symlink";
+  }) secretTemplates;
+  ownedFiles =
+    lib.optionals config.programs.codex.enable (codexOwnedFiles ++ codexSecretOwnedFiles)
+    ++ secretOwnedFiles;
+  ownedDeployment = import ./owned-deployment.nix {
+    inherit
+      config
+      lib
+      pkgs
+      ownedFiles
+      ;
+    requiresSecrets =
+      secretOwnedFiles != [ ] || (config.programs.codex.enable && codexSecretOwnedFiles != [ ]);
+  };
 in
 {
+  options.agentic.assistants.ownedSpec = lib.mkOption {
+    type = lib.types.attrs;
+    internal = true;
+    description = "Desired assistant files and permitted ownership roots.";
+  };
+  options.agentic.assistants.requiresSecrets = lib.mkOption {
+    type = lib.types.bool;
+    internal = true;
+    description = "Whether assistant deployment requires a successful secret refresh.";
+  };
   options.agentic.assistants.pi = {
     homeFiles = lib.mkOption {
       type = lib.types.attrs;
@@ -824,21 +741,29 @@ in
       internal = true;
       description = "Home Manager file entries for Pi Agent assistant resources.";
     };
+    invocationRoutes = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      internal = true;
+      description = "Routes applied only at explicit command and skill invocation boundaries.";
+    };
     providerRouterMap = lib.mkOption {
       type = lib.types.attrsOf (lib.types.attrsOf lib.types.str);
       default = { };
       internal = true;
-      description = "Per-agent provider->modelId map harvested from header.pi.yaml. Consumed by the local pi-provider-router extension.";
+      description = "Per-agent provider->modelId map read from header.toml routing.pi. Consumed by the local pi-provider-router extension.";
     };
     providerRouterThinkingMap = lib.mkOption {
       type = lib.types.attrsOf (lib.types.attrsOf lib.types.str);
       default = { };
       internal = true;
-      description = "Per-agent provider->thinking-level map harvested from header.pi.yaml. Consumed by the local pi-provider-router extension as a sidecar to providerRouterMap.";
+      description = "Per-agent provider->thinking-level map read from header.toml routing.pi. Consumed by the local pi-provider-router extension as a sidecar to providerRouterMap.";
     };
   };
 
   config = {
+    agentic.assistants.ownedSpec = ownedDeployment.spec;
+    agentic.assistants.requiresSecrets = ownedDeployment.requiresSecrets;
     # Report whether OpenCode and Pi carry the house style in their system
     # prompt. Neither has an output-style mechanism, so the carriage is the
     # append to their global instructions below. The flag is read back from the
@@ -846,24 +771,20 @@ in
     # Rules tripwire falls back to injecting the full rules on a fresh context.
     agentic.houseStyle.inSystemPrompt = {
       opencode = config.programs.opencode.enable && carriesHouseStyle opencodeInstructions;
-      pi = carriesHouseStyle piHomeFiles.".pi/agent/AGENTS.md".text;
+      pi = piEnabled && carriesHouseStyle piHomeFiles.".pi/agent/AGENTS.md".text;
     };
 
     agentic.assistants.pi = {
       homeFiles = piHomeFiles;
+      invocationRoutes = piInvocationRoutes;
       providerRouterMap = piProviderRouterMap;
       providerRouterThinkingMap = piProviderRouterThinkingMap;
     };
 
-    # sops-nix declarations for secret command prompts and secret skills.
-    # Secrets decrypt the bodies; templates substitute the placeholder into the
-    # composed Claude, OpenCode, and Pi files at activation, writing each to its
-    # explicit path so plaintext never enters the store. Codex is handled by
-    # activation scripts instead (see codexSecretSkillsActivationScript and
-    # codexSecretProjectSkillsActivationScript).
+    # Render secrets privately before the ownership helper installs client files.
     sops = {
       secrets = secretCommandSecrets // secretSkillSecrets;
-      templates = secretCommandTemplates // secretSkillTemplates;
+      templates = lib.mapAttrs (_: template: builtins.removeAttrs template [ "path" ]) secretTemplates;
     };
 
     home = {
@@ -883,27 +804,7 @@ in
         (lib.mkIf config.programs.opencode.enable mkOpencodeSkillFiles)
       ];
 
-      # Codex skills and agents: written as real files via activation script (not symlinks).
-      # codex-rs uses file_type().is_file() for discovery, which returns false for symlinks
-      # on Linux. home.file creates symlinks, so both are invisible without this workaround.
-      activation.codexFiles = lib.mkIf config.programs.codex.enable (
-        lib.hm.dag.entryAfter [ "writeBoundary" ] (
-          codexRootInstructionsActivationScript + codexSkillsActivationScript + codexAgentsActivationScript
-        )
-      );
-
-      # Write Codex files for secret commands and secret skills after
-      # codexFiles has recreated skills/ and after sops-nix has rendered the
-      # decrypted secrets. A sops template cannot be used here because
-      # codexFiles does `rm -rf skills`; these entries write the decrypted
-      # bodies from the secret paths instead.
-      activation.codexSecretFiles =
-        lib.mkIf (config.programs.codex.enable && (secretCommandList != [ ] || secretSkillList != [ ]))
-          (
-            lib.hm.dag.entryAfter [ "codexFiles" "sops-nix" ] (
-              codexSecretSkillsActivationScript + codexSecretProjectSkillsActivationScript
-            )
-          );
+      inherit (ownedDeployment) activation;
     };
 
     programs = {

--- a/home-manager/_mixins/agentic/assistants/default.nix
+++ b/home-manager/_mixins/agentic/assistants/default.nix
@@ -385,15 +385,25 @@ let
         }
       ) compose.commandSources
     );
-    skills = lib.mapAttrs (
-      name: _:
-      let
-        metadata = compose.readHeader (./skills + "/${name}");
-      in
-      {
-        providers = metadata.routing.pi or { };
-      }
-    ) (lib.removeAttrs compose.skillDirs [ "delegate-task" ]);
+    skills =
+      lib.mapAttrs
+        (
+          name: _:
+          let
+            metadata = compose.readHeader (./skills + "/${name}");
+          in
+          {
+            providers = metadata.routing.pi or { };
+          }
+        )
+        (
+          lib.removeAttrs (
+            compose.skillDirs
+            // lib.filterAttrs (
+              name: _: builtins.pathExists (./skills + "/${name}/header.toml")
+            ) compose.secretSkillDirs
+          ) [ "delegate-task" ]
+        );
   };
 
   # ============ SKILLS ============

--- a/home-manager/_mixins/agentic/assistants/instructions/README.md
+++ b/home-manager/_mixins/agentic/assistants/instructions/README.md
@@ -110,7 +110,7 @@ itself the parent's job.
 
 `delegate-task` is generated from the agent registry by `compose.nix`. The
 generator iterates over `sortedAgentNames`, reads each agent's
-`description.txt`, and emits a SKILL.md with the routing table, fresh-context
+`header.toml` descriptions, and emits a SKILL.md with the routing table, fresh-context
 rule, packet template, response contract, and relay policy already filled in.
 
 ### 3.1 What the skill owns
@@ -402,8 +402,7 @@ Authoritative sources behind the global rules and the generated
 
 - `home-manager/_mixins/agentic/assistants/instructions/global.md`
 - `home-manager/_mixins/agentic/assistants/styles/house-style/house-style.md`
-- `home-manager/_mixins/agentic/assistants/instructions/header.claude.yaml`
-- `home-manager/_mixins/agentic/assistants/instructions/header.opencode.yaml`
+- `home-manager/_mixins/agentic/assistants/instructions/header.toml`
 - `home-manager/_mixins/agentic/assistants/compose.nix` (the `delegate-task`
   generator at lines 579-676 and the `communication-rules` generator at
   lines 681-689)

--- a/home-manager/_mixins/agentic/assistants/instructions/header.claude.yaml
+++ b/home-manager/_mixins/agentic/assistants/instructions/header.claude.yaml
@@ -1,1 +1,0 @@
-description: "Environment constraints and tool preferences for NixOS workstation"

--- a/home-manager/_mixins/agentic/assistants/instructions/header.opencode.yaml
+++ b/home-manager/_mixins/agentic/assistants/instructions/header.opencode.yaml
@@ -1,1 +1,0 @@
-description: "Environment constraints and tool preferences for NixOS workstation"

--- a/home-manager/_mixins/agentic/assistants/instructions/header.toml
+++ b/home-manager/_mixins/agentic/assistants/instructions/header.toml
@@ -1,0 +1,5 @@
+[claude]
+description = "Environment constraints and tool preferences for NixOS workstation"
+
+[opencode]
+description = "Environment constraints and tool preferences for NixOS workstation"

--- a/home-manager/_mixins/agentic/assistants/metadata.nix
+++ b/home-manager/_mixins/agentic/assistants/metadata.nix
@@ -1,0 +1,317 @@
+{ lib }:
+let
+  providers = [
+    "claude"
+    "opencode"
+    "codex"
+    "pi"
+  ];
+  companionKeys = [
+    "interface"
+    "policy"
+    "dependencies"
+  ];
+  modelKeys = [
+    "model"
+    "effort"
+    "model_reasoning_effort"
+    "reasoningEffort"
+    "thinking"
+  ];
+  fail = path: message: throw "${toString path}/header.toml: ${message}";
+  nonEmptyString = value: builtins.isString value && lib.trim value != "";
+  noNull =
+    value:
+    if builtins.isAttrs value then
+      lib.all noNull (builtins.attrValues value)
+    else if builtins.isList value then
+      lib.all noNull value
+    else
+      value != null;
+  readHeader =
+    path:
+    let
+      header = builtins.fromTOML (builtins.readFile (path + "/header.toml"));
+      unknown = lib.subtractLists (
+        [
+          "common"
+          "compose"
+          "routing"
+        ]
+        ++ providers
+      ) (builtins.attrNames header);
+      nativeModels =
+        lib.concatMap
+          (
+            native:
+            lib.filter (
+              key: lib.elem key modelKeys || lib.hasPrefix "model-" key || lib.hasPrefix "thinking-" key
+            ) (builtins.attrNames native)
+          )
+          (
+            map (provider: header.${provider} or { }) ([ "common" ] ++ providers)
+            ++ [ (header.opencode.options or { }) ]
+          );
+      routing = header.routing or { };
+      unsupportedSkill =
+        builtins.pathExists (path + "/SKILL.md")
+        && lib.any (provider: (routing.${provider} or { }) != { }) [
+          "codex"
+          "opencode"
+        ];
+      routeValid =
+        provider: route:
+        let
+          allowed =
+            if provider == "claude" then
+              [
+                "model"
+                "effort"
+              ]
+            else if provider == "codex" then
+              [
+                "model"
+                "model_reasoning_effort"
+              ]
+            else if provider == "opencode" then
+              [
+                "model"
+                "reasoningEffort"
+              ]
+            else
+              [
+                "model"
+                "thinking"
+              ];
+        in
+        builtins.isAttrs route
+        && lib.all (key: lib.elem key allowed) (builtins.attrNames route)
+        && lib.all nonEmptyString (builtins.attrValues route)
+        && (
+          !(route ? thinking)
+          || lib.elem route.thinking [
+            "off"
+            "minimal"
+            "low"
+            "medium"
+            "high"
+            "xhigh"
+            "max"
+          ]
+        );
+      routesValid = lib.all (
+        provider:
+        lib.elem provider providers
+        && (
+          if provider == "pi" then
+            builtins.isAttrs routing.pi && lib.all (routeValid "pi") (builtins.attrValues routing.pi)
+          else
+            routeValid provider routing.${provider}
+        )
+      ) (builtins.attrNames routing);
+      controls = header.compose or { };
+      controlValid =
+        lib.all (
+          key:
+          lib.elem key [
+            "agent"
+            "claude"
+            "codex"
+          ]
+        ) (builtins.attrNames controls)
+        &&
+          lib.all
+            (
+              provider:
+              builtins.isAttrs (controls.${provider} or { })
+              && lib.all (
+                key:
+                lib.elem key (if provider == "claude" then [ "use-task" ] else [ "spawn-agent" ])
+                && builtins.isBool controls.${provider}.${key}
+              ) (builtins.attrNames (controls.${provider} or { }))
+            )
+            [
+              "claude"
+              "codex"
+            ];
+    in
+    if unknown != [ ] then
+      fail path "Unknown tables: ${lib.concatStringsSep ", " unknown}."
+    else if !noNull header then
+      fail path "Null metadata is not supported."
+    else if nativeModels != [ ] then
+      fail path "Model settings belong exclusively in routing tables."
+    else if unsupportedSkill then
+      fail path "Codex and OpenCode skill routing has no supported native execution boundary."
+    else if !routesValid then
+      fail path "Invalid routing provider, field, or value."
+    else if !controlValid then
+      fail path "Composition switches must be booleans."
+    else if controls ? agent && !nonEmptyString controls.agent then
+      fail path "compose.agent must be a non-empty string."
+    else
+      header;
+
+  project =
+    kind: platform: name: header:
+    let
+      common = header.common or { };
+      allowed =
+        if kind == "skill" then
+          [
+            "name"
+            "description"
+            "license"
+            "compatibility"
+            "metadata"
+            "allowed-tools"
+          ]
+        else if kind == "command" then
+          [ "description" ] ++ lib.optional (platform != "codex") "argument-hint"
+        else if kind == "agent" then
+          [ "description" ]
+        else
+          [ ];
+      defaults = lib.optionalAttrs (kind == "agent" && platform == "pi") {
+        systemPromptMode = "append";
+        inheritProjectContext = false;
+        inheritSkills = true;
+      };
+      native =
+        if kind == "skill" && platform == "codex" then
+          lib.removeAttrs (header.codex or { }) companionKeys
+        else
+          header.${platform} or { };
+      route = (header.routing or { }).${platform} or { };
+      unsupported =
+        (
+          kind == "skill"
+          && lib.elem platform [
+            "codex"
+            "opencode"
+          ]
+          && route != { }
+        )
+        || (kind == "instructions" && route != { })
+        || (platform == "opencode" && kind == "command" && route ? reasoningEffort);
+      projectedRoute = if platform == "pi" then { } else route;
+      identity = lib.optionalAttrs (
+        kind == "agent"
+        && lib.elem platform [
+          "claude"
+          "pi"
+          "codex"
+        ]
+      ) { inherit name; };
+      result = lib.foldl' lib.recursiveUpdate { } [
+        defaults
+        (lib.getAttrs (lib.intersectLists allowed (builtins.attrNames common)) common)
+        native
+        projectedRoute
+        identity
+      ];
+      validSkill =
+        kind != "skill"
+        || (
+          (common.name or "") == name
+          && builtins.stringLength name <= 64
+          && builtins.match "[a-z0-9]+(-[a-z0-9]+)*" name != null
+          && nonEmptyString (common.description or "")
+        );
+    in
+    if unsupported then
+      throw "Unsupported ${platform} routing for ${kind} ${name}."
+    else if !validSkill then
+      throw "Invalid skill identity or description for ${name}."
+    else if native ? name && native.name != name then
+      throw "Provider name must match ${name}."
+    else
+      result;
+
+  renderYaml =
+    value:
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (
+        key: item:
+        "${
+          if builtins.match "[A-Za-z0-9_-]+" key != null then key else builtins.toJSON key
+        }: ${builtins.toJSON item}"
+      ) value
+    );
+  renderToml =
+    value:
+    let
+      scalar =
+        item:
+        if builtins.isAttrs item then
+          "{ ${
+            lib.concatStringsSep ", " (lib.mapAttrsToList (key: v: "${builtins.toJSON key} = ${scalar v}") item)
+          } }"
+        else if builtins.isList item then
+          "[${lib.concatMapStringsSep ", " scalar item}]"
+        else
+          builtins.toJSON item;
+    in
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (key: item: "${builtins.toJSON key} = ${scalar item}") value
+    );
+
+  commandDispatch =
+    knownAgents: cmdName: agentName: header:
+    let
+      selectedAgent = header.compose.agent or agentName;
+      spawn = header.compose.codex.spawn-agent or true;
+      route = header.routing.codex or { };
+    in
+    if selectedAgent != null && !(knownAgents ? ${selectedAgent}) then
+      throw "Unknown Codex agent ${selectedAgent} for ${cmdName}."
+    else if route != { } && (selectedAgent == null || !spawn) then
+      throw "Codex command ${cmdName} routes inline work. Select an agent with spawn-agent = true, or remove routing.codex."
+    else
+      {
+        inherit selectedAgent spawn route;
+        role = if route == { } then selectedAgent else "command-${cmdName}";
+      };
+
+  commandPolicy =
+    header:
+    let
+      value =
+        header.codex.policy.allow_implicit_invocation or (header.codex.allow-implicit-invocation or false);
+    in
+    if value != false then
+      throw "Codex commands require policy.allow_implicit_invocation = false."
+    else
+      lib.recursiveUpdate (header.codex or { }) { policy.allow_implicit_invocation = false; };
+
+  skillCompanion =
+    path:
+    let
+      native = (readHeader path).codex or { };
+      companion = lib.getAttrs (lib.intersectLists companionKeys (builtins.attrNames native)) native;
+      policy = companion.policy or { };
+    in
+    if companion != { } && builtins.pathExists (path + "/agents/openai.yaml") then
+      fail path "Codex companion metadata conflicts with agents/openai.yaml. Keep one metadata source."
+    else if
+      companion != { }
+      && builtins.pathExists (path + "/agents")
+      && (builtins.readDir path).agents != "directory"
+    then
+      fail path "Codex companion metadata requires agents to be a directory."
+    else if policy ? allow_implicit_invocation && !builtins.isBool policy.allow_implicit_invocation then
+      fail path "codex.policy.allow_implicit_invocation must be a boolean."
+    else
+      companion;
+in
+{
+  inherit
+    readHeader
+    project
+    renderYaml
+    renderToml
+    commandDispatch
+    commandPolicy
+    skillCompanion
+    ;
+}

--- a/home-manager/_mixins/agentic/assistants/owned-deployment.nix
+++ b/home-manager/_mixins/agentic/assistants/owned-deployment.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  ownedFiles,
+  requiresSecrets,
+}:
+let
+  home = config.home.homeDirectory;
+  stateDir = "${config.xdg.stateHome}/agentic/assistants";
+  package = import ./owned-files { inherit pkgs; };
+  spec = {
+    version = 1;
+    inherit home stateDir;
+    configHome = config.xdg.configHome;
+    roots = lib.unique [
+      "${home}/.codex"
+      "${config.xdg.configHome}/codex"
+      "${home}/.claude"
+      "${config.xdg.configHome}/opencode"
+      "${home}/.pi/agent"
+    ];
+    files = ownedFiles;
+    retire = lib.optional (
+      home == "/home/martin" && config.noughty.host.name == "zannah"
+    ) "${home}/.pi/agent/agents/traya.md";
+  };
+  specFile = pkgs.writeText "assistant-owned-files.json" (builtins.toJSON spec);
+in
+{
+  inherit spec requiresSecrets;
+  activation = {
+    captureAssistantOwnership =
+      lib.hm.dag.entryBetween [ "sops-nix" "linkGeneration" ] [ "writeBoundary" ]
+        ''
+          run ${pkgs.python3}/bin/python ${./owned-files/bootstrap.py} ${specFile} \
+            --old-generation "''${oldGenPath:-}" \
+            --output ${lib.escapeShellArg "${stateDir}/bootstrap.json"}
+        '';
+    assistantOwnedFiles =
+      lib.hm.dag.entryAfter
+        [
+          "writeBoundary"
+          "linkGeneration"
+          "captureAssistantOwnership"
+          "sops-nix"
+          "refreshSopsNix"
+        ]
+        ''
+          run ${lib.getExe package} ${specFile} \
+            --bootstrap-manifest ${lib.escapeShellArg "${stateDir}/bootstrap.json"}
+        '';
+  };
+}

--- a/home-manager/_mixins/agentic/assistants/owned-files/README.md
+++ b/home-manager/_mixins/agentic/assistants/owned-files/README.md
@@ -1,0 +1,19 @@
+# Owned assistant files
+
+`deploy.py` updates explicit generated destinations without clearing client directories. Home Manager packages it as `deploy-owned-agent-files` and supplies the deployment specification during activation.
+
+See [activation ownership and cleanup](../README.md#activation-ownership-and-cleanup) for ownership rules, migration, conflict handling, and transaction limits.
+
+## Tests
+
+From the repository root, run:
+
+```console
+python3 home-manager/_mixins/agentic/assistants/owned-files/test_deploy.py
+```
+
+The tests create temporary homes and synthetic sources. They do not activate Home Manager, read real secrets, or change the active client configuration.
+
+The tests check removals, renames, client disablement, manual-file preservation, conflicts, symlink boundaries, missing sources, dry runs, one-off retirement, and rollback after an injected failure.
+
+Use the test harness for experiments. Do not invoke the deployer manually against your real home directory.

--- a/home-manager/_mixins/agentic/assistants/owned-files/bootstrap.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/bootstrap.py
@@ -295,7 +295,7 @@ def main():
         if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) != 0o600:
             raise ValueError("Existing bootstrap must be a private regular file owned by the current user")
         previous = json.loads(destination.read_text())
-        if previous.get("version") != 1 or not isinstance(previous.get("files"), dict):
+        if not isinstance(previous, dict) or previous.get("version") != 1 or not isinstance(previous.get("files"), dict):
             raise ValueError("Invalid existing bootstrap manifest")
         records.update(verified_records(previous["files"], spec["roots"]))
     records.update(capture(spec, args.old_generation))

--- a/home-manager/_mixins/agentic/assistants/owned-files/bootstrap.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/bootstrap.py
@@ -36,17 +36,14 @@ def printf_content(fmt, body):
     raise Unsupported("Unsupported printf format")
 
 
-def parse_public(section, directories=None):
+def parse_public(section):
     words = tokens(section)
     records = {}
-    created = set()
     i = 0
     while i < len(words):
         if words[i:i + 2] in (["mkdir", "-p"], ["rm", "-rf"]):
             if i + 3 > len(words):
                 raise Unsupported("Incomplete directory command")
-            if words[i] == "mkdir":
-                created.add(words[i + 2])
             i += 3
         elif words[i:i + 2] == ["ln", "-sfn"] and i + 4 <= len(words):
             records[words[i + 3]] = {"kind": "symlink", "target": words[i + 2]}
@@ -56,8 +53,6 @@ def parse_public(section, directories=None):
             i += 5
         else:
             raise Unsupported("Unsupported public writer command")
-    if directories is not None:
-        directories.update(created)
     return records
 
 
@@ -67,10 +62,9 @@ def safe_secret_source(source, home, config_home=None, secret_root=None):
     return path.is_absolute() and ".." not in path.parts and path.is_relative_to(root) and path != root
 
 
-def parse_secrets(section, home, config_home=None, directories=None, secret_root=None):
+def parse_secrets(section, home, config_home=None, secret_root=None):
     words = tokens(section)
     records = {}
-    created = set()
     unavailable = False
     i = 0
     while i < len(words):
@@ -88,8 +82,6 @@ def parse_secrets(section, home, config_home=None, directories=None, secret_root
                     arguments = shlex.split(directory[2:-1])
                     if len(arguments) != 2 or arguments[0] != "dirname":
                         raise Unsupported("Unsupported directory expression")
-                    directory = str(Path(arguments[1]).parent)
-                created.add(directory)
                 i += 3
             elif words[i] == "printf" and i + 5 <= len(words) and words[i + 3] == ">":
                 contents[words[i + 4]] = printf_content(words[i + 1], words[i + 2])
@@ -112,8 +104,6 @@ def parse_secrets(section, home, config_home=None, directories=None, secret_root
             raise Unsupported("Unsupported secret fallback")
         i += 6
         records.update({path: fingerprint(body) for path, body in contents.items() if body is not None})
-    if directories is not None:
-        directories.update(created)
     if unavailable:
         print("Owned-file bootstrap: previous secret bodies are unavailable, leaving unverified copies unchanged.", file=sys.stderr)
     return records
@@ -261,12 +251,7 @@ def old_secret_links(generation, roots, config_relative=Path(".config"), manifes
     return records
 
 
-def verified_directories(directories, roots):
-    return sorted(path for path in directories if allowed(path, roots) and Path(path).is_dir()
-                  and not any(parent.is_symlink() for parent in (Path(path), *Path(path).parents)))
-
-
-def capture(spec, old_generation, directories=None):
+def capture(spec, old_generation):
     if (Path(spec["stateDir"]) / "manifest.json").exists() or not old_generation:
         return {}
     generation = Path(old_generation).resolve()
@@ -275,7 +260,6 @@ def capture(spec, old_generation, directories=None):
         return {}
     script_sections = sections(immutable_text(generation / "activate"))
     expected = {}
-    created = set()
     manifest = {}
     try:
         config_relative = Path(spec.get("configHome", str(Path(spec["home"]) / ".config"))).relative_to(spec["home"])
@@ -283,15 +267,13 @@ def capture(spec, old_generation, directories=None):
         expected.update(old_secret_links(generation, spec["roots"], config_relative, manifest))
     except (OSError, Unsupported, ValueError, KeyError, TypeError):
         print("Owned-file bootstrap: cannot verify previous secret links, leaving them unchanged.", file=sys.stderr)
-    for name, parser in (("codexFiles", lambda text: parse_public(text, created)),
-                         ("codexSecretFiles", lambda text: parse_secrets(text, spec["home"], spec.get("configHome"), created, manifest.get("symlinkPath")))):
+    for name, parser in (("codexFiles", parse_public),
+                         ("codexSecretFiles", lambda text: parse_secrets(text, spec["home"], spec.get("configHome"), manifest.get("symlinkPath")))):
         try:
             expected.update({path: record for path, record in parser(script_sections.get(name, "")).items()
                              if assistant_path(path, spec["roots"], codex_only=True)})
         except (Unsupported, ValueError, IndexError):
             print(f"Owned-file bootstrap: unsupported previous {name} writer, leaving its files unchanged.", file=sys.stderr)
-    if directories is not None:
-        directories.update(verified_directories(created, spec["roots"]))
     return verified_records(expected, spec["roots"])
 
 
@@ -308,7 +290,6 @@ def main():
     if any(parent.is_symlink() for parent in (destination.parent, *destination.parent.parents)):
         raise ValueError("Bootstrap state directory must not contain symlinks")
     records = {}
-    directories = set()
     if destination.exists() and not (Path(spec["stateDir"]) / "manifest.json").exists():
         info = destination.lstat()
         if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) != 0o600:
@@ -317,9 +298,8 @@ def main():
         if previous.get("version") != 1 or not isinstance(previous.get("files"), dict):
             raise ValueError("Invalid existing bootstrap manifest")
         records.update(verified_records(previous["files"], spec["roots"]))
-        directories.update(verified_directories(previous.get("directories", []), spec["roots"]))
-    records.update(capture(spec, args.old_generation, directories))
-    result = {"version": 1, "files": records, "directories": sorted(directories)}
+    records.update(capture(spec, args.old_generation))
+    result = {"version": 1, "files": records, "directories": []}
     destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(destination.parent, 0o700)
     fd, temporary = tempfile.mkstemp(prefix=".bootstrap-", dir=destination.parent)

--- a/home-manager/_mixins/agentic/assistants/owned-files/bootstrap.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/bootstrap.py
@@ -1,0 +1,337 @@
+"""Recover verified ownership from the previous Home Manager generation."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import plistlib
+import re
+import shlex
+import stat
+import sys
+import tempfile
+from xml.parsers.expat import ExpatError
+
+
+class Unsupported(ValueError):
+    pass
+
+
+def fingerprint(content):
+    return {"kind": "file", "sha256": hashlib.sha256(content).hexdigest()}
+
+
+def tokens(section):
+    lexer = shlex.shlex(section, posix=True, punctuation_chars=";>")
+    lexer.whitespace_split = True
+    return list(lexer)
+
+
+def printf_content(fmt, body):
+    if fmt == "%s":
+        return body.encode()
+    if fmt in ("%s\\n", "%s\n"):
+        return (body + "\n").encode()
+    raise Unsupported("Unsupported printf format")
+
+
+def parse_public(section, directories=None):
+    words = tokens(section)
+    records = {}
+    created = set()
+    i = 0
+    while i < len(words):
+        if words[i:i + 2] in (["mkdir", "-p"], ["rm", "-rf"]):
+            if i + 3 > len(words):
+                raise Unsupported("Incomplete directory command")
+            if words[i] == "mkdir":
+                created.add(words[i + 2])
+            i += 3
+        elif words[i:i + 2] == ["ln", "-sfn"] and i + 4 <= len(words):
+            records[words[i + 3]] = {"kind": "symlink", "target": words[i + 2]}
+            i += 4
+        elif words[i] == "printf" and i + 5 <= len(words) and words[i + 3] == ">":
+            records[words[i + 4]] = fingerprint(printf_content(words[i + 1], words[i + 2]))
+            i += 5
+        else:
+            raise Unsupported("Unsupported public writer command")
+    if directories is not None:
+        directories.update(created)
+    return records
+
+
+def safe_secret_source(source, home, config_home=None, secret_root=None):
+    path = Path(source)
+    root = Path(secret_root) if secret_root else Path(config_home or Path(home) / ".config") / "sops-nix/secrets"
+    return path.is_absolute() and ".." not in path.parts and path.is_relative_to(root) and path != root
+
+
+def parse_secrets(section, home, config_home=None, directories=None, secret_root=None):
+    words = tokens(section)
+    records = {}
+    created = set()
+    unavailable = False
+    i = 0
+    while i < len(words):
+        if words[i:i + 3] != ["if", "[", "-r"] or words[i + 4:i + 7] != ["]", ";", "then"]:
+            raise Unsupported("Unsupported secret condition")
+        source = words[i + 3]
+        if not safe_secret_source(source, home, config_home, secret_root):
+            raise Unsupported("Secret source is outside the runtime secret directory")
+        i += 7
+        contents = {}
+        while i < len(words) and words[i] != "else":
+            if words[i:i + 2] == ["mkdir", "-p"] and i + 3 <= len(words):
+                directory = words[i + 2]
+                if directory.startswith("$(dirname ") and directory.endswith(")"):
+                    arguments = shlex.split(directory[2:-1])
+                    if len(arguments) != 2 or arguments[0] != "dirname":
+                        raise Unsupported("Unsupported directory expression")
+                    directory = str(Path(arguments[1]).parent)
+                created.add(directory)
+                i += 3
+            elif words[i] == "printf" and i + 5 <= len(words) and words[i + 3] == ">":
+                contents[words[i + 4]] = printf_content(words[i + 1], words[i + 2])
+                i += 5
+            elif words[i:i + 2] == ["cat", source] and i + 4 <= len(words) and words[i + 2] in (">", ">>"):
+                target = words[i + 3]
+                if words[i + 2] == ">>" and target not in contents:
+                    raise Unsupported("Secret append has no literal prefix")
+                try:
+                    body = Path(source).read_bytes()
+                except OSError:
+                    body = None
+                    unavailable = True
+                prefix = contents.get(target, b"") if words[i + 2] == ">>" else b""
+                contents[target] = prefix + body if body is not None else None
+                i += 4
+            else:
+                raise Unsupported("Unsupported secret writer command")
+        if words[i:i + 2] != ["else", "echo"] or words[i + 3:i + 6] != [">", "&2", "fi"]:
+            raise Unsupported("Unsupported secret fallback")
+        i += 6
+        records.update({path: fingerprint(body) for path, body in contents.items() if body is not None})
+    if directories is not None:
+        directories.update(created)
+    if unavailable:
+        print("Owned-file bootstrap: previous secret bodies are unavailable, leaving unverified copies unchanged.", file=sys.stderr)
+    return records
+
+
+def sections(script):
+    marker = re.compile(r'^_iNote "Activating %s" "([^"\n]+)"\n', re.MULTILINE)
+    matches = list(marker.finditer(script))
+    return {
+        match.group(1): script[match.end():matches[index + 1].start() if index + 1 < len(matches) else len(script)]
+        for index, match in enumerate(matches)
+    }
+
+
+def allowed(path, roots):
+    candidate = Path(path)
+    return candidate.is_absolute() and ".." not in candidate.parts and any(
+        candidate != root and candidate.is_relative_to(root) for root in map(Path, roots)
+    )
+
+
+def assistant_path(path, roots, codex_only=False):
+    if not allowed(path, roots):
+        return False
+    for root in map(Path, roots):
+        candidate = Path(path)
+        if not candidate.is_relative_to(root):
+            continue
+        parts = candidate.relative_to(root).parts
+        codex = root.name in ("codex", ".codex")
+        if codex_only and not codex:
+            continue
+        if codex and parts == ("AGENTS.md",):
+            return True
+        if len(parts) >= 2 and parts[0] in ("agents", "commands", "prompts", "skills"):
+            return True
+    return False
+
+
+def verified_records(expected, roots):
+    verified = {}
+    for name, record in expected.items():
+        if not allowed(name, roots) or not isinstance(record, dict):
+            continue
+        path = Path(name)
+        if any(parent.is_symlink() for parent in path.parents):
+            continue
+        try:
+            info = path.lstat()
+            if record.get("kind") == "symlink" and isinstance(record.get("target"), str):
+                matches = stat.S_ISLNK(info.st_mode) and os.readlink(path) == record["target"]
+            elif record.get("kind") == "file" and re.fullmatch(r"[0-9a-f]{64}", str(record.get("sha256", ""))):
+                matches = stat.S_ISREG(info.st_mode) and fingerprint(path.read_bytes()) == record
+            else:
+                continue
+            if matches:
+                verified[name] = record
+        except OSError:
+            continue
+    return verified
+
+
+def store_path(value):
+    path = Path(value)
+    return path.is_absolute() and ".." not in path.parts and path.is_relative_to("/nix/store")
+
+
+def immutable_text(path):
+    path = Path(path).resolve()
+    if not store_path(str(path)):
+        raise Unsupported("Previous generation reference is outside the Nix store")
+    return path.read_text()
+
+
+def darwin_sops_script(generation):
+    plist = generation / "LaunchAgents/org.nix-community.home.sops-nix.plist"
+    if not plist.exists():
+        return None
+    try:
+        definition = plistlib.loads(immutable_text(plist).encode())
+    except (ValueError, ExpatError, plistlib.InvalidFileException) as error:
+        raise Unsupported("Unsupported previous sops launchd plist") from error
+    if not isinstance(definition, dict):
+        raise Unsupported("Unsupported previous sops launchd plist")
+    arguments = definition.get("ProgramArguments")
+    if not isinstance(arguments, list) or not all(isinstance(argument, str) for argument in arguments):
+        raise Unsupported("Unsupported previous sops launchd arguments")
+    if len(arguments) == 3 and arguments[:2] == ["/bin/sh", "-c"]:
+        command = shlex.split(arguments[2])
+        if len(command) != 5 or command[:4] != ["/bin/wait4path", "/nix/store", "&&", "exec"]:
+            raise Unsupported("Unsupported previous sops launchd wait command")
+        script = command[4]
+    elif len(arguments) == 1 and store_path(arguments[0]) and arguments[0].endswith("/bin/sops-nix"):
+        command = tokens(immutable_text(arguments[0]))
+        if len(command) != 2 or command[0] != "exec":
+            raise Unsupported("Unsupported previous sops launchd wrapper")
+        script = command[1]
+    else:
+        raise Unsupported("Unsupported previous sops launchd command")
+    if not store_path(script):
+        raise Unsupported("Previous sops launchd script is outside the Nix store")
+    return script
+
+
+def old_sops_manifest(generation, config_relative=Path(".config")):
+    service = generation / "home-files" / config_relative / "systemd/user/sops-nix.service"
+    if service.exists():
+        starts = re.findall(r"^ExecStart=(.+)$", immutable_text(service), re.MULTILINE)
+        if len(starts) != 1:
+            raise Unsupported("Unsupported previous sops service")
+        command = shlex.split(starts[0])
+        if len(command) != 1 or not store_path(command[0]):
+            raise Unsupported("Unsupported previous sops service command")
+        script = command[0]
+    else:
+        script = darwin_sops_script(generation)
+        if script is None:
+            return {}
+    words = tokens(immutable_text(script))
+    if len(words) != 3 or not words[0].endswith("/bin/sops-install-secrets") or words[1] != "-ignore-passwd" or not store_path(words[2]):
+        raise Unsupported("Unsupported previous sops installation command")
+    manifest = json.loads(immutable_text(words[2]))
+    if not isinstance(manifest, dict):
+        raise Unsupported("Unsupported previous sops manifest")
+    return manifest
+
+
+def old_secret_links(generation, roots, config_relative=Path(".config"), manifest=None):
+    if manifest is None:
+        manifest = old_sops_manifest(generation, config_relative)
+    if not manifest:
+        return {}
+    link_root = manifest.get("symlinkPath", "")
+    if not Path(link_root).is_absolute():
+        raise Unsupported("Unsupported previous runtime secret directory")
+    records = {}
+    for secret in manifest.get("secrets", []):
+        path, name = secret.get("path", ""), secret.get("name", "")
+        if assistant_path(path, roots) and name and not Path(name).is_absolute() and ".." not in Path(name).parts:
+            records[path] = {"kind": "symlink", "target": str(Path(link_root) / name)}
+    for template in manifest.get("templates", []):
+        path, name = template.get("path", ""), template.get("name", "")
+        if assistant_path(path, roots) and name and not Path(name).is_absolute() and ".." not in Path(name).parts:
+            records[path] = {"kind": "symlink", "target": str(Path(link_root) / "rendered" / name)}
+    return records
+
+
+def verified_directories(directories, roots):
+    return sorted(path for path in directories if allowed(path, roots) and Path(path).is_dir()
+                  and not any(parent.is_symlink() for parent in (Path(path), *Path(path).parents)))
+
+
+def capture(spec, old_generation, directories=None):
+    if (Path(spec["stateDir"]) / "manifest.json").exists() or not old_generation:
+        return {}
+    generation = Path(old_generation).resolve()
+    if not store_path(str(generation)) or not (generation / "activate").is_file():
+        print("Owned-file bootstrap: no immutable previous generation, leaving existing files unchanged.", file=sys.stderr)
+        return {}
+    script_sections = sections(immutable_text(generation / "activate"))
+    expected = {}
+    created = set()
+    manifest = {}
+    try:
+        config_relative = Path(spec.get("configHome", str(Path(spec["home"]) / ".config"))).relative_to(spec["home"])
+        manifest = old_sops_manifest(generation, config_relative)
+        expected.update(old_secret_links(generation, spec["roots"], config_relative, manifest))
+    except (OSError, Unsupported, ValueError, KeyError, TypeError):
+        print("Owned-file bootstrap: cannot verify previous secret links, leaving them unchanged.", file=sys.stderr)
+    for name, parser in (("codexFiles", lambda text: parse_public(text, created)),
+                         ("codexSecretFiles", lambda text: parse_secrets(text, spec["home"], spec.get("configHome"), created, manifest.get("symlinkPath")))):
+        try:
+            expected.update({path: record for path, record in parser(script_sections.get(name, "")).items()
+                             if assistant_path(path, spec["roots"], codex_only=True)})
+        except (Unsupported, ValueError, IndexError):
+            print(f"Owned-file bootstrap: unsupported previous {name} writer, leaving its files unchanged.", file=sys.stderr)
+    if directories is not None:
+        directories.update(verified_directories(created, spec["roots"]))
+    return verified_records(expected, spec["roots"])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("spec")
+    parser.add_argument("--old-generation", default="")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    spec = json.loads(Path(args.spec).read_text())
+    destination = Path(args.output)
+    if destination != Path(spec["stateDir"]) / "bootstrap.json":
+        raise ValueError("Bootstrap output must be bootstrap.json in stateDir")
+    if any(parent.is_symlink() for parent in (destination.parent, *destination.parent.parents)):
+        raise ValueError("Bootstrap state directory must not contain symlinks")
+    records = {}
+    directories = set()
+    if destination.exists() and not (Path(spec["stateDir"]) / "manifest.json").exists():
+        info = destination.lstat()
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) != 0o600:
+            raise ValueError("Existing bootstrap must be a private regular file owned by the current user")
+        previous = json.loads(destination.read_text())
+        if previous.get("version") != 1 or not isinstance(previous.get("files"), dict):
+            raise ValueError("Invalid existing bootstrap manifest")
+        records.update(verified_records(previous["files"], spec["roots"]))
+        directories.update(verified_directories(previous.get("directories", []), spec["roots"]))
+    records.update(capture(spec, args.old_generation, directories))
+    result = {"version": 1, "files": records, "directories": sorted(directories)}
+    destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(destination.parent, 0o700)
+    fd, temporary = tempfile.mkstemp(prefix=".bootstrap-", dir=destination.parent)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(result, handle, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, destination)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+if __name__ == "__main__":
+    main()

--- a/home-manager/_mixins/agentic/assistants/owned-files/default.nix
+++ b/home-manager/_mixins/agentic/assistants/owned-files/default.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+pkgs.writeShellApplication {
+  name = "deploy-owned-agent-files";
+  runtimeInputs = [ pkgs.python3 ];
+  text = ''
+    exec python3 ${./deploy.py} "$@"
+  '';
+}

--- a/home-manager/_mixins/agentic/assistants/owned-files/deploy.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/deploy.py
@@ -57,7 +57,7 @@ def load_manifest(path):
     if not stat.S_ISREG(path.lstat().st_mode):
         raise Conflict(f"Manifest is not a regular file: {path}")
     data = json.loads(path.read_text())
-    if data.get("version") != 1 or not isinstance(data.get("files"), dict):
+    if not isinstance(data, dict) or data.get("version") != 1 or not isinstance(data.get("files"), dict):
         raise Conflict("Unsupported ownership manifest")
     directories = data.get("directories", [])
     if not isinstance(directories, list) or any(not isinstance(path, str) for path in directories):

--- a/home-manager/_mixins/agentic/assistants/owned-files/deploy.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/deploy.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Deploy explicit generated files without replacing unowned content."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+
+
+class Conflict(Exception):
+    pass
+
+
+def absolute(value):
+    path = Path(value)
+    if not path.is_absolute() or ".." in path.parts:
+        raise Conflict(f"Expected an absolute path without '..': {path}")
+    return path
+
+
+def parents_safe(path):
+    for parent in reversed(path.parents):
+        try:
+            info = parent.lstat()
+        except FileNotFoundError:
+            continue
+        if not stat.S_ISDIR(info.st_mode):
+            raise Conflict(f"Destination parent is not a real directory: {parent}")
+
+
+def allowed(path, roots):
+    if not any(path != root and path.is_relative_to(root) for root in roots):
+        raise Conflict(f"Destination is outside the allowed roots: {path}")
+    parents_safe(path)
+    return path
+
+
+def fingerprint(path):
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(info.st_mode):
+        return {"kind": "symlink", "target": os.readlink(path)}
+    if stat.S_ISREG(info.st_mode):
+        return {"kind": "file", "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+    return {"kind": "other"}
+
+
+def load_manifest(path):
+    if not path.exists() and not path.is_symlink():
+        return {"version": 1, "files": {}, "directories": []}
+    if not stat.S_ISREG(path.lstat().st_mode):
+        raise Conflict(f"Manifest is not a regular file: {path}")
+    data = json.loads(path.read_text())
+    if data.get("version") != 1 or not isinstance(data.get("files"), dict):
+        raise Conflict("Unsupported ownership manifest")
+    directories = data.get("directories", [])
+    if not isinstance(directories, list) or any(not isinstance(path, str) for path in directories):
+        raise Conflict("Invalid owned directory list")
+    for value in data["files"].values():
+        if not isinstance(value, dict) or value.get("kind") not in ("file", "symlink"):
+            raise Conflict("Invalid ownership fingerprint")
+        if value["kind"] == "file" and (
+            not isinstance(value.get("sha256"), str)
+            or len(value["sha256"]) != 64
+            or any(c not in "0123456789abcdef" for c in value["sha256"])
+        ):
+            raise Conflict("Invalid file fingerprint")
+        if value["kind"] == "symlink" and not isinstance(value.get("target"), str):
+            raise Conflict("Invalid symlink fingerprint")
+    return data
+
+
+def snapshot(path):
+    current = fingerprint(path)
+    if current is None:
+        return None
+    if current["kind"] == "symlink":
+        return ("symlink", current["target"], None)
+    if current["kind"] != "file":
+        raise Conflict(f"Cannot replace a non-file destination: {path}")
+    return ("file", path.read_bytes(), stat.S_IMODE(path.stat().st_mode))
+
+
+def replace(path, value):
+    parents_safe(path)
+    if value is None:
+        path.unlink(missing_ok=True)
+        return
+    kind, content, mode = value
+    descriptor, temporary = tempfile.mkstemp(prefix=".agent-owned-", dir=path.parent)
+    temporary = Path(temporary)
+    try:
+        if kind == "file":
+            with os.fdopen(descriptor, "wb") as output:
+                descriptor = None
+                output.write(content)
+                output.flush()
+                os.fchmod(output.fileno(), mode)
+                os.fsync(output.fileno())
+        else:
+            os.close(descriptor)
+            descriptor = None
+            temporary.unlink()
+            temporary.symlink_to(content)
+        os.replace(temporary, path)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+def make_parents(path, created):
+    parents_safe(path)
+    missing = []
+    parent = path.parent
+    while not parent.exists():
+        missing.append(parent)
+        parent = parent.parent
+    for parent in reversed(missing):
+        parent.mkdir(mode=0o700)
+        created.append(parent)
+
+
+def deploy(spec, dry_run=False, bootstrap_manifest=None):
+    if spec.get("version") != 1:
+        raise Conflict("Unsupported deployment specification")
+    roots = [absolute(root) for root in spec["roots"]]
+    state = absolute(spec["stateDir"])
+    parents_safe(state / "manifest.json")
+    if any(state == root or state.is_relative_to(root) for root in roots):
+        raise Conflict("Ownership state must be outside client roots")
+    if state.exists() and (
+        state.stat().st_uid != os.getuid() or stat.S_IMODE(state.stat().st_mode) & 0o077
+    ):
+        raise Conflict(f"Ownership state is not private: {state}")
+    manifest_path = state / "manifest.json"
+    manifest = load_manifest(manifest_path)
+    old = {allowed(absolute(path), roots): value for path, value in manifest["files"].items()}
+    owned_directories = {
+        allowed(absolute(path), roots) for path in manifest.get("directories", [])
+    }
+    if bootstrap_manifest:
+        bootstrap = load_manifest(absolute(bootstrap_manifest))
+        for path, value in bootstrap["files"].items():
+            path = allowed(absolute(path), roots)
+            if path not in old:
+                old[path] = value
+        owned_directories.update(
+            allowed(absolute(path), roots)
+            for path in bootstrap.get("directories", [])
+            if absolute(path) not in roots
+        )
+    desired = {}
+    expected = {}
+    for entry in spec["files"]:
+        path = allowed(absolute(entry["path"]), roots)
+        if path in desired:
+            raise Conflict(f"Duplicate destination: {path}")
+        source = absolute(entry["source"])
+        kind = entry["kind"]
+        if kind == "file":
+            if not source.is_file():
+                raise Conflict(f"Required source is not a readable file: {source}")
+            content = entry.get("prefix", "").encode() + source.read_bytes()
+            mode = int(entry.get("mode", "0600"), 8)
+            if mode not in (0o600, 0o644, 0o700, 0o755):
+                raise Conflict(f"Unsupported file mode for {path}")
+            desired[path] = (kind, content, mode)
+            expected[path] = {"kind": kind, "sha256": hashlib.sha256(content).hexdigest()}
+        elif kind == "symlink":
+            if source.is_file():
+                source.read_bytes()
+            elif source.is_dir():
+                with os.scandir(source) as entries:
+                    list(entries)
+            else:
+                raise Conflict(f"Required symlink source is unavailable: {source}")
+            desired[path] = (kind, str(source), None)
+            expected[path] = {"kind": kind, "target": str(source)}
+        else:
+            raise Conflict(f"Unsupported destination kind: {kind}")
+        current = fingerprint(path)
+        if current is not None and current != old.get(path):
+            proven = False
+            for candidate in entry.get("bootstrapSources", []):
+                candidate = absolute(candidate)
+                if kind == "symlink":
+                    proven |= current == {"kind": "symlink", "target": str(candidate)}
+                elif candidate.is_file():
+                    proven |= current == fingerprint(candidate)
+            if not proven:
+                raise Conflict(f"Preserving an unowned or modified destination: {path}")
+    for path in desired:
+        if any(parent in desired for parent in path.parents):
+            raise Conflict(f"Destination overlaps another generated file: {path}")
+    changes = dict(desired)
+    for path, recorded in old.items():
+        if path not in desired:
+            current = fingerprint(path)
+            if current == recorded:
+                changes[path] = None
+            elif current is not None:
+                print(f"Preserving modified former output: {path}", file=sys.stderr)
+    retired = set(manifest.get("retired", []))
+    for name in spec.get("retire", []):
+        path = allowed(absolute(name), roots)
+        if path.name != "traya.md" or path.parts[-4:] != (".pi", "agent", "agents", "traya.md"):
+            raise Conflict(f"Unapproved legacy retirement: {path}")
+        if str(path) in retired:
+            continue
+        if path in desired:
+            raise Conflict(f"Retirement overlaps a desired destination: {path}")
+        current = fingerprint(path)
+        if current is not None and current["kind"] != "file":
+            print(f"Preserving non-regular legacy path: {path}", file=sys.stderr)
+        elif current is not None:
+            changes[path] = None
+        retired.add(str(path))
+    before = {path: snapshot(path) for path in changes}
+    original_fingerprints = {path: fingerprint(path) for path in changes}
+    if dry_run:
+        print(f"Would deploy {len(desired)} files and retire {sum(v is None for v in changes.values())} files")
+        return
+    created = []
+    applied = []
+    removed_directories = []
+    try:
+        make_parents(manifest_path, created)
+        for path, value in changes.items():
+            if value is not None:
+                make_parents(path, created)
+            parents_safe(path)
+            if fingerprint(path) != original_fingerprints[path]:
+                raise Conflict(f"Destination changed during deployment: {path}")
+            replace(path, value)
+            applied.append(path)
+        owned_directories.update(
+            path for path in created if any(path != root and path.is_relative_to(root) for root in roots)
+        )
+        for directory in sorted(owned_directories, key=lambda path: len(path.parts), reverse=True):
+            parents_safe(directory)
+            if directory.is_symlink():
+                continue
+            try:
+                mode = stat.S_IMODE(directory.stat().st_mode)
+                directory.rmdir()
+                removed_directories.append((directory, mode))
+            except (FileNotFoundError, OSError):
+                pass
+        remaining_directories = [str(path) for path in owned_directories if path.is_dir() and not path.is_symlink()]
+        result = {
+            "version": 1,
+            "files": {str(path): value for path, value in expected.items()},
+            "directories": sorted(remaining_directories),
+            "retired": sorted(retired),
+        }
+        replace(manifest_path, ("file", (json.dumps(result, indent=2) + "\n").encode(), 0o600))
+    except BaseException:
+        failures = []
+        for directory, mode in reversed(removed_directories):
+            try:
+                parents_safe(directory)
+                directory.mkdir(mode=mode)
+                directory.chmod(mode)
+            except (OSError, Conflict):
+                failures.append(str(directory))
+        for path in reversed(applied):
+            try:
+                make_parents(path, created)
+                replace(path, before[path])
+            except (OSError, Conflict):
+                failures.append(str(path))
+        for directory in reversed(created):
+            try:
+                directory.rmdir()
+            except OSError:
+                pass
+        if failures:
+            raise Conflict("Rollback failed for: " + ", ".join(failures)) from None
+        raise
+    if bootstrap_manifest:
+        bootstrap_path = absolute(bootstrap_manifest)
+        if bootstrap_path == state / "bootstrap.json" and not bootstrap_path.is_symlink():
+            bootstrap_path.unlink(missing_ok=True)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("spec")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--bootstrap-manifest")
+    args = parser.parse_args(argv)
+    try:
+        spec = json.loads(Path(args.spec).read_text())
+        deploy(spec, args.dry_run or bool(os.environ.get("DRY_RUN_CMD")), args.bootstrap_manifest)
+    except (OSError, ValueError, KeyError, TypeError, Conflict) as error:
+        print(f"Agent file deployment failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/home-manager/_mixins/agentic/assistants/owned-files/test_bootstrap.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/test_bootstrap.py
@@ -37,17 +37,56 @@ class BootstrapTests(unittest.TestCase):
         self.target.write_text("User modification.\n")
         self.assertEqual(set(bootstrap.verified_records(expected, [str(self.root)])), {str(link)})
 
-    def test_only_declared_real_directories_are_captured(self):
-        declared = self.target.parent
-        manual = self.root / "manual"
-        manual.mkdir()
-        alias = self.root / "alias"
-        alias.symlink_to(manual, target_is_directory=True)
-        directories = set()
-        bootstrap.parse_public(f"mkdir -p {declared}\nmkdir -p {alias}\n", directories)
-        verified = bootstrap.verified_directories(directories, [str(self.root)])
-        self.assertEqual(set(verified), {str(declared)})
-        self.assertNotIn(str(manual), verified)
+    def test_legacy_mkdir_does_not_claim_manual_directories_on_disable_or_migration(self):
+        module_spec = importlib.util.spec_from_file_location("deploy_bootstrap", Path(__file__).with_name("deploy.py"))
+        deploy = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(deploy)
+        source = self.home / ".config/sops-nix/secrets/fake"
+        source.parent.mkdir(parents=True)
+        source.write_text("Generated content.\n")
+        for writer in ("codexFiles", "codexSecretFiles"):
+            for migrate in (False, True):
+                with self.subTest(writer=writer, migrate=migrate):
+                    fixture = f"{writer}-{migrate}"
+                    manual = self.root / "skills" / fixture
+                    manual.mkdir()
+                    target = manual / "SKILL.md"
+                    target.write_bytes(source.read_bytes())
+                    empty = manual / "empty"
+                    empty.mkdir()
+                    commands = f"mkdir -p {manual}\nmkdir -p {empty}\n"
+                    if writer == "codexFiles":
+                        commands += f"printf '%s' {shlex.quote(source.read_text())} > {target}\n"
+                    else:
+                        commands = f"if [ -r {source} ]; then\n{commands}cat {source} > {target}\nelse\necho 'Missing fake secret.' >&2\nfi\n"
+                    generation = self.home / f"generation-{fixture}"
+                    generation.mkdir()
+                    (generation / "activate").write_text(f'_iNote "Activating %s" "{writer}"\n{commands}')
+                    state = self.home / f"state-{fixture}"
+                    spec = {"version": 1, "stateDir": str(state), "roots": [str(self.root)], "home": str(self.home), "files": []}
+                    desired = self.home / f"spec-{fixture}.json"
+                    desired.write_text(json.dumps(spec))
+                    captured = state / "bootstrap.json"
+                    with mock.patch.object(bootstrap, "store_path", return_value=True):
+                        with mock.patch("sys.argv", ["bootstrap.py", str(desired), "--old-generation", str(generation), "--output", str(captured)]):
+                            bootstrap.main()
+                    records = json.loads(captured.read_text())
+                    self.assertEqual(records["directories"], [])
+                    self.assertEqual(records["files"], {str(target): bootstrap.fingerprint(source.read_bytes())})
+                    replacement = self.root / "skills" / f"new-{fixture}" / "SKILL.md"
+                    if migrate:
+                        spec["files"] = [{"kind": "file", "path": str(replacement), "source": str(source)}]
+                    deploy.deploy(spec, bootstrap_manifest=str(captured))
+                    self.assertFalse(target.exists())
+                    self.assertTrue(manual.is_dir())
+                    self.assertTrue(empty.is_dir())
+                    if migrate:
+                        self.assertEqual(replacement.read_bytes(), source.read_bytes())
+                        spec["files"] = []
+                        deploy.deploy(spec)
+                        self.assertFalse(replacement.parent.exists())
+                        self.assertTrue(manual.is_dir())
+                        self.assertTrue(empty.is_dir())
 
     def secret_script(self, source):
         return f"if [ -r {shlex.quote(str(source))} ]; then\nmkdir -p {shlex.quote(str(self.target.parent))}\nprintf '%s' 'Prefix\n' > {shlex.quote(str(self.target))}\ncat {shlex.quote(str(source))} >> {shlex.quote(str(self.target))}\nelse\necho 'Missing fake secret.' >&2\nfi\n"
@@ -133,13 +172,15 @@ class BootstrapTests(unittest.TestCase):
         deploy.deploy(spec, bootstrap_manifest=str(captured))
         self.assertEqual(destination.readlink(), new_source)
 
-    def test_retry_keeps_prior_proof_when_secret_content_changes(self):
+    def test_retry_keeps_file_proof_but_drops_unproven_directories(self):
         state = self.home / "state"
         state.mkdir(mode=0o700)
         self.target.write_text("Fake old copied secret.\n")
         record = bootstrap.fingerprint(self.target.read_bytes())
         captured = state / "bootstrap.json"
-        captured.write_text(json.dumps({"version": 1, "files": {str(self.target): record}}))
+        manual = self.root / "skills/manual"
+        manual.mkdir()
+        captured.write_text(json.dumps({"version": 1, "files": {str(self.target): record}, "directories": [str(manual), str(self.target.parent)]}))
         captured.chmod(0o600)
         spec = self.home / "spec.json"
         spec.write_text(json.dumps({"stateDir": str(state), "roots": [str(self.root)], "home": str(self.home)}))
@@ -147,6 +188,14 @@ class BootstrapTests(unittest.TestCase):
             with mock.patch("sys.argv", ["bootstrap.py", str(spec), "--output", str(captured)]):
                 bootstrap.main()
         self.assertEqual(json.loads(captured.read_text())["files"], {str(self.target): record})
+        self.assertEqual(json.loads(captured.read_text())["directories"], [])
+        module_spec = importlib.util.spec_from_file_location("deploy_retry", Path(__file__).with_name("deploy.py"))
+        deploy = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(deploy)
+        deploy.deploy({"version": 1, "stateDir": str(state), "roots": [str(self.root)], "files": []}, bootstrap_manifest=str(captured))
+        self.assertFalse(self.target.exists())
+        self.assertTrue(self.target.parent.is_dir())
+        self.assertTrue(manual.is_dir())
 
     def darwin_fixture(self, direct_launcher=False):
         generation = self.home / "darwin-generation"

--- a/home-manager/_mixins/agentic/assistants/owned-files/test_bootstrap.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/test_bootstrap.py
@@ -1,0 +1,201 @@
+"""Check old-generation ownership proofs with synthetic scripts and fake secrets."""
+
+import importlib.util
+import json
+from pathlib import Path
+import plistlib
+import shlex
+import tempfile
+import unittest
+from unittest import mock
+
+
+module_spec = importlib.util.spec_from_file_location("owned_bootstrap", Path(__file__).with_name("bootstrap.py"))
+bootstrap = importlib.util.module_from_spec(module_spec)
+module_spec.loader.exec_module(bootstrap)
+
+
+class BootstrapTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="bootstrap-tests-")
+        self.addCleanup(temporary.cleanup)
+        self.home = Path(temporary.name)
+        self.root = self.home / ".codex"
+        self.root.mkdir()
+        self.target = self.root / "skills/fixture/SKILL.md"
+        self.target.parent.mkdir(parents=True)
+
+    def test_literal_public_writer_proves_exact_bytes_and_symlink_target(self):
+        content = "---\nname: fixture\n---\nA user's $literal `text`.\n"
+        self.target.write_text(content)
+        link = self.target.parent / "references"
+        link.symlink_to("/nix/store/fixture/references")
+        script = f"mkdir -p {shlex.quote(str(self.target.parent))}\nprintf '%s' {shlex.quote(content)} > {shlex.quote(str(self.target))}\nln -sfn /nix/store/fixture/references {shlex.quote(str(link))}\n"
+        expected = bootstrap.parse_public(script)
+        verified = bootstrap.verified_records(expected, [str(self.root)])
+        self.assertEqual(set(verified), {str(self.target), str(link)})
+        self.target.write_text("User modification.\n")
+        self.assertEqual(set(bootstrap.verified_records(expected, [str(self.root)])), {str(link)})
+
+    def test_only_declared_real_directories_are_captured(self):
+        declared = self.target.parent
+        manual = self.root / "manual"
+        manual.mkdir()
+        alias = self.root / "alias"
+        alias.symlink_to(manual, target_is_directory=True)
+        directories = set()
+        bootstrap.parse_public(f"mkdir -p {declared}\nmkdir -p {alias}\n", directories)
+        verified = bootstrap.verified_directories(directories, [str(self.root)])
+        self.assertEqual(set(verified), {str(declared)})
+        self.assertNotIn(str(manual), verified)
+
+    def secret_script(self, source):
+        return f"if [ -r {shlex.quote(str(source))} ]; then\nmkdir -p {shlex.quote(str(self.target.parent))}\nprintf '%s' 'Prefix\n' > {shlex.quote(str(self.target))}\ncat {shlex.quote(str(source))} >> {shlex.quote(str(self.target))}\nelse\necho 'Missing fake secret.' >&2\nfi\n"
+
+    def test_secret_writer_requires_matching_prefix_and_fake_secret(self):
+        source = self.home / ".config/sops-nix/secrets/fake"
+        source.parent.mkdir(parents=True)
+        source.write_text("Fake body.\n")
+        self.target.write_text("Prefix\nFake body.\n")
+        expected = bootstrap.parse_secrets(self.secret_script(source), str(self.home))
+        self.assertEqual(set(bootstrap.verified_records(expected, [str(self.root)])), {str(self.target)})
+        self.target.write_text("Prefix\nUser modification.\n")
+        self.assertEqual(bootstrap.verified_records(expected, [str(self.root)]), {})
+
+    def test_missing_secret_does_not_prove_the_existing_copy(self):
+        source = self.home / ".config/sops-nix/secrets/missing"
+        self.target.write_text("Prefix\nExisting content.\n")
+        self.assertEqual(bootstrap.parse_secrets(self.secret_script(source), str(self.home)), {})
+
+    def test_secret_source_outside_runtime_root_is_rejected_before_reading(self):
+        with self.assertRaises(bootstrap.Unsupported):
+            bootstrap.parse_secrets(self.secret_script(self.home / "outside"), str(self.home))
+
+    def test_unknown_shell_command_is_not_executed_or_partially_adopted(self):
+        marker = self.home / "must-not-exist"
+        with self.assertRaises(bootstrap.Unsupported):
+            bootstrap.parse_public(f"printf '%s' generated > {self.target}\ntouch {marker}\n")
+        self.assertFalse(marker.exists())
+
+    def test_symlink_parent_and_outside_destination_are_not_proof(self):
+        outside = self.home / "outside"
+        outside.mkdir()
+        target = outside / "SKILL.md"
+        target.write_text("Generated content.\n")
+        alias = self.root / "alias"
+        alias.symlink_to(outside, target_is_directory=True)
+        record = bootstrap.fingerprint(target.read_bytes())
+        self.assertEqual(bootstrap.verified_records({str(alias / "SKILL.md"): record, str(target): record}, [str(self.root)]), {})
+
+    def test_existing_manifest_prevents_repeated_bootstrap(self):
+        state = self.home / "state"
+        state.mkdir()
+        (state / "manifest.json").write_text("{}")
+        self.assertEqual(bootstrap.capture({"stateDir": str(state)}, "/not/read"), {})
+
+    def test_old_sops_template_link_is_proved_and_replaced_after_refresh(self):
+        generation = self.home / "old-generation"
+        service = generation / "home-files/.config/systemd/user/sops-nix.service"
+        service.parent.mkdir(parents=True)
+        runner = self.home / "sops-runner"
+        manifest = self.home / "sops-manifest.json"
+        old_runtime = self.home / ".config/sops-nix/secrets"
+        source = old_runtime / "rendered/assistant-codex-skill-fixture"
+        source.parent.mkdir(parents=True)
+        source.write_text("Fake old template.\n")
+        destination = self.root / "skills/fixture/template.md"
+        destination.symlink_to(source)
+        manifest.write_text(json.dumps({
+            "symlinkPath": str(old_runtime), "secrets": [],
+            "templates": [{"name": "assistant-codex-skill-fixture", "path": str(destination)}],
+        }))
+        runner.write_text(f"/nix/store/fake/bin/sops-install-secrets -ignore-passwd {manifest}\n")
+        service.write_text(f"[Service]\nExecStart={runner}\n")
+        with mock.patch.object(bootstrap, "store_path", return_value=True):
+            records = bootstrap.old_secret_links(generation, [str(self.root)])
+        verified = bootstrap.verified_records(records, [str(self.root)])
+        self.assertEqual(verified, {str(destination): {"kind": "symlink", "target": str(source)}})
+        state = self.home / "state"
+        state.mkdir(mode=0o700)
+        captured = state / "bootstrap.json"
+        captured.write_text(json.dumps({"version": 1, "files": verified}))
+        captured.chmod(0o600)
+        new_source = self.home / "new-rendered-template"
+        new_source.write_text("Fake new template.\n")
+        module_spec = importlib.util.spec_from_file_location("deploy_template", Path(__file__).with_name("deploy.py"))
+        deploy = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(deploy)
+        spec = {"version": 1, "stateDir": str(state), "roots": [str(self.root)], "files": [
+            {"kind": "symlink", "path": str(destination), "source": str(new_source)},
+        ]}
+        with self.assertRaises(deploy.Conflict):
+            deploy.deploy(spec)
+        deploy.deploy(spec, bootstrap_manifest=str(captured))
+        self.assertEqual(destination.readlink(), new_source)
+
+    def test_retry_keeps_prior_proof_when_secret_content_changes(self):
+        state = self.home / "state"
+        state.mkdir(mode=0o700)
+        self.target.write_text("Fake old copied secret.\n")
+        record = bootstrap.fingerprint(self.target.read_bytes())
+        captured = state / "bootstrap.json"
+        captured.write_text(json.dumps({"version": 1, "files": {str(self.target): record}}))
+        captured.chmod(0o600)
+        spec = self.home / "spec.json"
+        spec.write_text(json.dumps({"stateDir": str(state), "roots": [str(self.root)], "home": str(self.home)}))
+        with mock.patch.object(bootstrap, "capture", return_value={}):
+            with mock.patch("sys.argv", ["bootstrap.py", str(spec), "--output", str(captured)]):
+                bootstrap.main()
+        self.assertEqual(json.loads(captured.read_text())["files"], {str(self.target): record})
+
+    def darwin_fixture(self, direct_launcher=False):
+        generation = self.home / "darwin-generation"
+        plist = generation / "LaunchAgents/org.nix-community.home.sops-nix.plist"
+        plist.parent.mkdir(parents=True)
+        manifest = self.home / "darwin-sops-manifest.json"
+        runtime = self.home / ".config/sops-nix/secrets"
+        target = self.root / "skills/fixture/template.md"
+        manifest.write_text(json.dumps({
+            "symlinkPath": str(runtime), "secrets": [],
+            "templates": [{"name": "assistant-codex-skill-fixture", "path": str(target)}],
+        }))
+        script = self.home / "sops install script"
+        script.write_text(f"/nix/store/fake/bin/sops-install-secrets -ignore-passwd {shlex.quote(str(manifest))}\n")
+        if direct_launcher:
+            launcher = self.home / "launcher/bin/sops-nix"
+            launcher.parent.mkdir(parents=True)
+            launcher.write_text(f"#!/bin/sh\nexec {shlex.quote(str(script))}\n")
+            arguments = [str(launcher)]
+        else:
+            arguments = ["/bin/sh", "-c", f"/bin/wait4path /nix/store && exec {shlex.quote(str(script))}"]
+        plist.write_bytes(plistlib.dumps({"ProgramArguments": arguments}))
+        return generation, plist, target, runtime / "rendered/assistant-codex-skill-fixture"
+
+    def test_darwin_wait4path_plist_recovers_template_link_without_execution(self):
+        generation, _, target, source = self.darwin_fixture()
+        with mock.patch.object(bootstrap, "store_path", return_value=True):
+            records = bootstrap.old_secret_links(generation, [str(self.root)])
+        self.assertEqual(records, {str(target): {"kind": "symlink", "target": str(source)}})
+        self.assertFalse(target.exists())
+
+    def test_darwin_direct_launcher_recovers_template_link_without_execution(self):
+        generation, _, target, source = self.darwin_fixture(direct_launcher=True)
+        with mock.patch.object(bootstrap, "store_path", return_value=True):
+            records = bootstrap.old_secret_links(generation, [str(self.root)])
+        self.assertEqual(records, {str(target): {"kind": "symlink", "target": str(source)}})
+        self.assertFalse(target.exists())
+
+    def test_darwin_plist_rejects_extra_shell_commands(self):
+        generation, plist, _, _ = self.darwin_fixture()
+        data = plistlib.loads(plist.read_bytes())
+        marker = self.home / "must-not-exist"
+        data["ProgramArguments"][2] += f"; touch {marker}"
+        plist.write_bytes(plistlib.dumps(data))
+        with mock.patch.object(bootstrap, "store_path", return_value=True):
+            with self.assertRaises(bootstrap.Unsupported):
+                bootstrap.old_secret_links(generation, [str(self.root)])
+        self.assertFalse(marker.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/home-manager/_mixins/agentic/assistants/owned-files/test_bootstrap.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/test_bootstrap.py
@@ -197,6 +197,25 @@ class BootstrapTests(unittest.TestCase):
         self.assertTrue(self.target.parent.is_dir())
         self.assertTrue(manual.is_dir())
 
+    def test_retry_rejects_non_object_manifest_before_writes(self):
+        state = self.home / "state"
+        state.mkdir(mode=0o700)
+        captured = state / "bootstrap.json"
+        spec = self.home / "spec.json"
+        spec.write_text(json.dumps({"stateDir": str(state), "roots": [str(self.root)], "home": str(self.home)}))
+        for data in ([], None, "invalid", 1, True):
+            with self.subTest(data=data):
+                captured.write_text(json.dumps(data))
+                captured.chmod(0o600)
+                before = captured.read_bytes()
+                with mock.patch.object(bootstrap, "capture") as capture:
+                    with mock.patch("sys.argv", ["bootstrap.py", str(spec), "--output", str(captured)]):
+                        with self.assertRaisesRegex(ValueError, "Invalid existing bootstrap manifest"):
+                            bootstrap.main()
+                    capture.assert_not_called()
+                self.assertEqual(captured.read_bytes(), before)
+                self.assertEqual(list(state.iterdir()), [captured])
+
     def darwin_fixture(self, direct_launcher=False):
         generation = self.home / "darwin-generation"
         plist = generation / "LaunchAgents/org.nix-community.home.sops-nix.plist"

--- a/home-manager/_mixins/agentic/assistants/owned-files/test_deploy.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/test_deploy.py
@@ -208,6 +208,20 @@ class DeploymentTests(unittest.TestCase):
         self.activate(success=False)
         self.assertEqual(self.snapshot(), before)
 
+    def test_non_object_manifest_fails_cleanly_before_writes(self):
+        self.spec["files"] = [self.entry("existing/SKILL.md")]
+        self.activate()
+        self.spec["files"] = [self.entry("new/SKILL.md")]
+        manifest = self.state / "manifest.json"
+        for data in ([], None, "invalid", 1, True):
+            with self.subTest(data=data):
+                manifest.write_text(json.dumps(data))
+                before = self.snapshot()
+                result = self.activate(success=False)
+                self.assertEqual(result.returncode, 1)
+                self.assertEqual(result.stderr, "Agent file deployment failed: Unsupported ownership manifest\n")
+                self.assertEqual(self.snapshot(), before)
+
     def test_stale_symlink_changed_by_user_is_preserved(self):
         self.spec["files"] = [self.entry("guide.md", kind="symlink")]
         self.activate()

--- a/home-manager/_mixins/agentic/assistants/owned-files/test_deploy.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/test_deploy.py
@@ -1,0 +1,330 @@
+"""Check owned-file deployment in temporary homes, without reading real secrets."""
+
+import importlib.util
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+HELPER = Path(__file__).with_name("deploy.py")
+
+
+class DeploymentTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="owned-file-tests-")
+        self.addCleanup(self.temporary.cleanup)
+        self.base = Path(self.temporary.name)
+        self.home = self.base / "home"
+        self.home.mkdir()
+        self.sources = self.base / "sources"
+        self.sources.mkdir()
+        self.state = self.home / ".local/state/agentic-owned-files"
+        self.root = self.home / ".codex/skills"
+        self.pi = self.home / ".pi/agent/agents"
+        self.spec = {
+            "version": 1,
+            "stateDir": str(self.state),
+            "roots": [str(self.root), str(self.pi)],
+            "files": [],
+            "retire": [],
+        }
+
+    def source(self, name, content):
+        path = self.sources / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def entry(self, name, content="Generated content.\n", kind="file", **extra):
+        source = self.source(name, content)
+        return {
+            "path": str(self.root / name),
+            "source": str(source),
+            "kind": kind,
+            "mode": "0600",
+            **extra,
+        }
+
+    def activate(self, success=True, dry_run=False):
+        spec = self.base / "desired.json"
+        spec.write_text(json.dumps(self.spec))
+        command = [sys.executable, str(HELPER), str(spec)]
+        if dry_run:
+            command.append("--dry-run")
+        result = subprocess.run(command, capture_output=True, text=True)
+        if success:
+            self.assertEqual(result.returncode, 0, result.stderr)
+        else:
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+        return result
+
+    def snapshot(self):
+        result = {}
+        for path in self.home.rglob("*"):
+            info = path.lstat()
+            name = str(path.relative_to(self.home))
+            if stat.S_ISLNK(info.st_mode):
+                result[name] = ("symlink", os.readlink(path))
+            elif stat.S_ISREG(info.st_mode):
+                result[name] = ("file", stat.S_IMODE(info.st_mode), path.read_bytes())
+            else:
+                result[name] = ("directory", stat.S_IMODE(info.st_mode))
+        return result
+
+    def test_rename_remove_and_disable_preserve_manual_siblings(self):
+        self.spec["files"] = [self.entry("old/SKILL.md"), self.entry("old/references/guide.md")]
+        self.activate()
+        manual = self.root / "old/references/manual.md"
+        manual.write_text("User content.\n")
+        plugin = self.root / "plugin/SKILL.md"
+        plugin.parent.mkdir()
+        plugin.write_text("Plugin content.\n")
+        self.spec["files"] = [self.entry("renamed/SKILL.md", "New content.\n")]
+        self.activate()
+        self.assertFalse((self.root / "old/SKILL.md").exists())
+        self.assertFalse((self.root / "old/references/guide.md").exists())
+        self.assertEqual(manual.read_text(), "User content.\n")
+        self.assertEqual(plugin.read_text(), "Plugin content.\n")
+        self.assertEqual((self.root / "renamed/SKILL.md").read_text(), "New content.\n")
+        self.spec["files"] = []
+        self.activate()
+        self.assertFalse((self.root / "renamed").exists())
+        self.assertTrue(manual.exists())
+        self.assertTrue(plugin.exists())
+
+    def test_repeated_activation_has_no_history_and_keeps_regular_skill_files(self):
+        self.spec["files"] = [self.entry("fixture/SKILL.md"), self.entry("fixture/references/nested/SKILL.md")]
+        self.activate()
+        before = self.snapshot()
+        for _ in range(3):
+            self.activate()
+            self.assertEqual(self.snapshot(), before)
+        self.assertEqual({p.name for p in self.state.iterdir()}, {"manifest.json"})
+        for entry in self.spec["files"]:
+            path = Path(entry["path"])
+            self.assertTrue(stat.S_ISREG(path.lstat().st_mode))
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+        self.assertEqual(stat.S_IMODE(self.state.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE((self.state / "manifest.json").stat().st_mode), 0o600)
+
+    def test_unknown_destination_conflict_leaves_everything_unchanged(self):
+        self.spec["files"] = [self.entry("existing/SKILL.md")]
+        self.activate()
+        unknown = self.root / "unknown.md"
+        unknown.write_text("Not owned.\n")
+        self.spec["files"] = [self.entry("new.md"), self.entry("unknown.md")]
+        before = self.snapshot()
+        self.activate(success=False)
+        self.assertEqual(self.snapshot(), before)
+
+    def test_modified_desired_file_conflicts_but_modified_stale_file_survives(self):
+        self.spec["files"] = [self.entry("fixture/SKILL.md")]
+        self.activate()
+        path = self.root / "fixture/SKILL.md"
+        path.write_text("User modification.\n")
+        before = self.snapshot()
+        self.activate(success=False)
+        self.assertEqual(self.snapshot(), before)
+        self.spec["files"] = []
+        self.activate()
+        self.assertEqual(path.read_text(), "User modification.\n")
+        manifest = json.loads((self.state / "manifest.json").read_text())
+        self.assertNotIn(str(path), manifest["files"])
+
+    def test_changed_owned_symlink_conflicts_without_touching_its_target(self):
+        self.spec["files"] = [self.entry("guide.md", kind="symlink")]
+        self.activate()
+        path = self.root / "guide.md"
+        outside = self.source("manual.md", "Do not touch.\n")
+        path.unlink()
+        path.symlink_to(outside)
+        before = self.snapshot()
+        self.activate(success=False)
+        self.assertEqual(self.snapshot(), before)
+        self.assertEqual(outside.read_text(), "Do not touch.\n")
+
+    def test_symlink_parent_cannot_escape_the_owned_root(self):
+        self.root.mkdir(parents=True)
+        outside = self.base / "outside"
+        outside.mkdir()
+        (self.root / "escape").symlink_to(outside, target_is_directory=True)
+        self.spec["files"] = [self.entry("safe.md"), self.entry("escape/SKILL.md")]
+        before = self.snapshot()
+        self.activate(success=False)
+        self.assertEqual(self.snapshot(), before)
+        self.assertEqual(list(outside.iterdir()), [])
+
+    def test_missing_or_invalid_sources_prevent_all_mutations(self):
+        self.spec["files"] = [self.entry("existing/SKILL.md")]
+        self.activate()
+        before = self.snapshot()
+        for source in (self.sources / "missing", self.sources):
+            with self.subTest(source=source):
+                self.spec["files"] = [self.entry("new.md"), {
+                    "path": str(self.root / "secret.md"), "source": str(source), "kind": "file",
+                }]
+                self.activate(success=False)
+                self.assertEqual(self.snapshot(), before)
+
+    @unittest.skipIf(os.geteuid() == 0, "Root bypasses source read permissions.")
+    def test_unreadable_secret_leaves_files_and_manifest_unchanged(self):
+        self.spec["files"] = [self.entry("existing/SKILL.md")]
+        self.activate()
+        before = self.snapshot()
+        secret = self.entry("secret.md", "Fake secret.\n")
+        source = Path(secret["source"])
+        source.chmod(0)
+        try:
+            self.spec["files"] = [self.entry("new.md"), secret]
+            self.activate(success=False)
+            self.assertEqual(self.snapshot(), before)
+        finally:
+            source.chmod(0o600)
+
+    def test_dry_run_leaves_the_home_and_manifest_unchanged(self):
+        self.spec["files"] = [self.entry("existing/SKILL.md")]
+        self.activate(dry_run=True)
+        self.assertEqual(self.snapshot(), {})
+        self.activate()
+        before = self.snapshot()
+        self.spec["files"] = [self.entry("new/SKILL.md")]
+        self.activate(dry_run=True)
+        self.assertEqual(self.snapshot(), before)
+
+    def test_invalid_manifest_cannot_authorise_removal(self):
+        self.spec["files"] = [self.entry("existing/SKILL.md")]
+        self.activate()
+        manifest = self.state / "manifest.json"
+        manifest.write_text("{invalid json\n")
+        self.spec["files"] = []
+        before = self.snapshot()
+        self.activate(success=False)
+        self.assertEqual(self.snapshot(), before)
+
+    def test_stale_symlink_changed_by_user_is_preserved(self):
+        self.spec["files"] = [self.entry("guide.md", kind="symlink")]
+        self.activate()
+        path = self.root / "guide.md"
+        target = self.source("user.md", "User content.\n")
+        path.unlink()
+        path.symlink_to(target)
+        self.spec["files"] = []
+        self.activate()
+        self.assertEqual(os.readlink(path), str(target))
+        self.assertEqual(target.read_text(), "User content.\n")
+
+    def test_existing_symlink_to_legacy_name_is_not_retired(self):
+        self.pi.mkdir(parents=True)
+        target = self.source("user-agent.md", "User agent.\n")
+        legacy = self.pi / "traya.md"
+        legacy.symlink_to(target)
+        self.spec["retire"] = [str(legacy)]
+        self.activate()
+        self.assertEqual(os.readlink(legacy), str(target))
+        self.assertEqual(target.read_text(), "User agent.\n")
+
+    def test_secret_prefix_is_combined_before_deployment(self):
+        self.spec["files"] = [self.entry("secret/SKILL.md", "Fake secret body.\n", prefix="---\nname: secret\n---\n")]
+        self.activate()
+        self.assertEqual((self.root / "secret/SKILL.md").read_text(), "---\nname: secret\n---\nFake secret body.\n")
+
+    def test_commit_failure_restores_files_manifest_and_directories(self):
+        self.spec["files"] = [self.entry("old/SKILL.md"), self.entry("kept.md")]
+        self.activate()
+        empty = self.root / "old-empty"
+        empty.mkdir(mode=0o755)
+        captured = self.state / "bootstrap.json"
+        captured.write_text(json.dumps({"version": 1, "files": {}, "directories": [str(empty)]}))
+        captured.chmod(0o600)
+        before = self.snapshot()
+        self.spec["files"] = [self.entry("new/SKILL.md"), self.entry("kept.md", "Updated content.\n")]
+        module_spec = importlib.util.spec_from_file_location("owned_deploy", HELPER)
+        helper = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(helper)
+        real_replace = os.replace
+
+        def fail_manifest(source, destination):
+            if Path(destination) == self.state / "manifest.json":
+                raise OSError("Injected manifest write failure.")
+            return real_replace(source, destination)
+
+        with mock.patch.object(helper.os, "replace", side_effect=fail_manifest):
+            with self.assertRaises(OSError):
+                helper.deploy(self.spec, bootstrap_manifest=str(captured))
+        self.assertEqual(self.snapshot(), before)
+
+    def test_bootstrap_requires_matching_old_source_content(self):
+        self.root.mkdir(parents=True)
+        old = self.source("old-generation.md", "Old generated content.\n")
+        destination = self.root / "SKILL.md"
+        destination.write_text(old.read_text())
+        self.spec["files"] = [self.entry("SKILL.md", "New generated content.\n", bootstrapSources=[str(old)])]
+        self.activate()
+        self.assertEqual(destination.read_text(), "New generated content.\n")
+
+    def test_bootstrap_owned_directories_are_pruned_but_manual_siblings_survive(self):
+        obsolete = self.root / "obsolete"
+        obsolete.mkdir(parents=True)
+        former = obsolete / "SKILL.md"
+        former.write_text("Old generated skill.\n")
+        mixed = self.root / "mixed"
+        mixed.mkdir()
+        manual = mixed / "manual.md"
+        manual.write_text("Manual content.\n")
+        unknown = self.root / "unknown-empty"
+        unknown.mkdir()
+        self.state.mkdir(parents=True, mode=0o700)
+        captured = self.state / "bootstrap.json"
+        captured.write_text(json.dumps({
+            "version": 1,
+            "files": {str(former): {"kind": "file", "sha256": hashlib.sha256(former.read_bytes()).hexdigest()}},
+            "directories": [str(obsolete), str(mixed)],
+        }))
+        captured.chmod(0o600)
+        module_spec = importlib.util.spec_from_file_location("deploy_directories", HELPER)
+        helper = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(helper)
+        helper.deploy(self.spec, bootstrap_manifest=str(captured))
+        self.assertFalse(obsolete.exists())
+        self.assertEqual(manual.read_text(), "Manual content.\n")
+        self.assertTrue(unknown.is_dir())
+
+    def test_bootstrap_does_not_adopt_a_filename_match_or_unverified_backup(self):
+        self.root.mkdir(parents=True)
+        old = self.source("old-generation.md", "Old generated content.\n")
+        destination = self.root / "SKILL.md"
+        destination.write_text("User content.\n")
+        backup = self.root / "SKILL.md.backup-20260101"
+        backup.write_text(old.read_text())
+        self.spec["files"] = [self.entry("SKILL.md", bootstrapSources=[str(old)])]
+        before = self.snapshot()
+        self.activate(success=False)
+        self.assertEqual(self.snapshot(), before)
+
+    def test_legacy_retirement_is_exact_and_not_repeated(self):
+        self.pi.mkdir(parents=True)
+        legacy = self.pi / "traya.md"
+        sibling = self.pi / "traya.md.backup"
+        other = self.root / "traya.md"
+        self.root.mkdir(parents=True)
+        for path in (legacy, sibling, other):
+            path.write_text("Legacy or user content.\n")
+        self.spec["retire"] = [str(legacy)]
+        self.activate()
+        self.assertFalse(legacy.exists())
+        self.assertTrue(sibling.exists())
+        self.assertTrue(other.exists())
+        legacy.write_text("Recreated by the user.\n")
+        self.activate()
+        self.assertEqual(legacy.read_text(), "Recreated by the user.\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/home-manager/_mixins/agentic/assistants/owned-files/test_generated.py
+++ b/home-manager/_mixins/agentic/assistants/owned-files/test_generated.py
@@ -1,0 +1,77 @@
+"""Deploy a built Home Manager specification into a temporary home."""
+
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+@unittest.skipUnless(os.environ.get("ASSISTANT_OWNED_SPEC"), "Set ASSISTANT_OWNED_SPEC to a built specification.")
+class GeneratedDeploymentTests(unittest.TestCase):
+    def test_generated_spec_install_repeat_and_disable(self):
+        spec = json.loads(Path(os.environ["ASSISTANT_OWNED_SPEC"]).read_text())
+        with tempfile.TemporaryDirectory(prefix="generated-owned-files-") as directory:
+            base = Path(directory)
+            home = base / "home"
+            home.mkdir()
+            old_home = Path(spec["home"])
+
+            def relocate(path):
+                return str(home / Path(path).relative_to(old_home))
+
+            spec["home"] = str(home)
+            spec["stateDir"] = relocate(spec["stateDir"])
+            spec["roots"] = [relocate(path) for path in spec["roots"]]
+            spec["retire"] = [relocate(path) for path in spec.get("retire", [])]
+            for number, entry in enumerate(spec["files"]):
+                entry["path"] = relocate(entry["path"])
+                source = Path(entry["source"])
+                if not source.is_relative_to("/nix/store"):
+                    fake = base / "fake-secrets" / str(number)
+                    fake.parent.mkdir(exist_ok=True)
+                    fake.write_text("Fake secret for activation tests.\n")
+                    entry["source"] = str(fake)
+                self.assertNotIn("bootstrapSources", entry)
+
+            desired = base / "desired.json"
+            helper = Path(__file__).with_name("deploy.py")
+
+            def activate():
+                desired.write_text(json.dumps(spec))
+                result = subprocess.run([sys.executable, str(helper), str(desired)], capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            activate()
+            for entry in spec["files"]:
+                path = Path(entry["path"])
+                with self.subTest(path=path):
+                    if entry["kind"] == "file":
+                        self.assertTrue(stat.S_ISREG(path.lstat().st_mode))
+                        self.assertEqual(path.read_bytes(), entry.get("prefix", "").encode() + Path(entry["source"]).read_bytes())
+                    else:
+                        self.assertEqual(os.readlink(path), entry["source"])
+            manifest = Path(spec["stateDir"]) / "manifest.json"
+            before = manifest.read_bytes()
+            activate()
+            self.assertEqual(manifest.read_bytes(), before)
+            self.assertEqual({p.name for p in manifest.parent.iterdir()}, {"manifest.json"})
+            codex = home / ".codex/skills"
+            self.assertTrue(stat.S_ISREG((codex / "love/SKILL.md").lstat().st_mode))
+            nested = codex / "love/references/api/love-window/SKILL.md"
+            self.assertTrue(stat.S_ISREG(nested.lstat().st_mode))
+            manual = codex / "love/manual.md"
+            manual.write_text("Manual content.\n")
+            former = [Path(entry["path"]) for entry in spec["files"]]
+            spec["files"] = []
+            activate()
+            for path in former:
+                self.assertFalse(path.exists() or path.is_symlink(), str(path))
+            self.assertEqual(manual.read_text(), "Manual content.\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/home-manager/_mixins/agentic/assistants/skills/agentic-repo-capability/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/agentic-repo-capability/SKILL.md
@@ -1,7 +1,3 @@
----
-name: agentic-repo-capability
-description: Use when adding or updating repository-local agent capabilities, including MCP servers, agent skills, or slash commands, or when a user asks to equip a repository with agent tooling across Claude Code, Codex, OpenCode, or Pi.
----
 
 # Agentic Repository Capability
 

--- a/home-manager/_mixins/agentic/assistants/skills/agentic-repo-capability/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/agentic-repo-capability/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "agentic-repo-capability"
+description = "Use when adding or updating repository-local agent capabilities, including MCP servers, agent skills, or slash commands, or when a user asks to equip a repository with agent tooling across Claude Code, Codex, OpenCode, or Pi."

--- a/home-manager/_mixins/agentic/assistants/skills/agentic-repo-capability/references/command.md
+++ b/home-manager/_mixins/agentic/assistants/skills/agentic-repo-capability/references/command.md
@@ -6,9 +6,9 @@ Create or update a user-invoked command through the repository's command composi
 
 1. Load `write-command` and read it in full before editing.
 2. Follow its decision rules for a shim, standalone command, or standalone command with an output format. Do not reproduce its doctrine here.
-3. Inspect nearby commands, the owning agent, composition code, required provider headers, and discovery rules.
+3. Inspect nearby commands, the owning agent, composition code, the shared `header.toml`, and discovery rules.
 4. Put reusable workflow guidance in a skill. Keep a command shim limited to invocation, `$ARGUMENTS` handling, and delegation to that skill.
-5. Use `$ARGUMENTS` for a portable free-form argument. Keep argument hints identical across every provider header that supports them.
+5. Use `$ARGUMENTS` for a portable free-form argument. Use `[common] argument-hint` for a shared hint. Preserve provider-specific omissions when migrating existing commands.
 6. Bind the command to its owning agent through the repository's native header or composer. Do not embed the agent persona in the shared body.
 
 When no composer exists, verify each supported client's current project path and format before writing:
@@ -24,7 +24,7 @@ Do not assume that provider frontmatter fields or agent routing work on another 
 
 ## Validate
 
-1. Check that every required source file and provider header exists and parses.
+1. Check that every required source file exists and `header.toml` parses.
 2. Run the repository composer or evaluation for Claude Code, OpenCode, Pi, and any generated Codex skill form.
 3. Inspect each emitted artefact. Confirm its description, argument hint where supported, argument handling, agent binding or launch wrapper, and body. For Codex, check the companion policy and explicit argument mapping without assuming template substitution.
 4. Confirm the command appears in each installed client's discovery output when such diagnostics exist.

--- a/home-manager/_mixins/agentic/assistants/skills/agentic-repo-capability/references/skill.md
+++ b/home-manager/_mixins/agentic/assistants/skills/agentic-repo-capability/references/skill.md
@@ -22,7 +22,7 @@ Client versions differ in shared-path discovery. Prefer a shared path only after
 
 ## Validate
 
-1. Parse the frontmatter and confirm the directory name matches `name`.
+1. Parse `header.toml` when the repository composes skills. Confirm `[common] name` matches the directory and inspect generated frontmatter.
 2. Run at least three trigger scenarios as required by `write-skill`: one load, one ignore, and one defer or boundary case.
 3. Confirm every referenced file exists one level below `SKILL.md`; check required tables of contents and size limits.
 4. Evaluate or run the repository composer and inspect the emitted tree for each supported client.

--- a/home-manager/_mixins/agentic/assistants/skills/audio-metrics/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/audio-metrics/SKILL.md
@@ -1,8 +1,3 @@
----
-name: audio-metrics
-description: "Load for objective audio analysis from ffmpeg metrics - spectral statistics, spectrograms, loudness, EBU R128, LUFS, LU, RMS, dBFS, dBTP, true peak, crest factor, dynamic range, and noise floor. Covers the aspectralstats, astats, ebur128, and loudnorm filters: what each metric measures, how ffmpeg computes it, its units and range, and the external loudness standards and platform targets. Use when reading or producing ffmpeg audio measurements, even when the user names only a metric, filter, or standard."
-user-invocable: true
----
 
 # Audio Metrics Reference
 

--- a/home-manager/_mixins/agentic/assistants/skills/audio-metrics/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/audio-metrics/header.toml
@@ -1,0 +1,6 @@
+[common]
+name = "audio-metrics"
+description = "Load for objective audio analysis from ffmpeg metrics - spectral statistics, spectrograms, loudness, EBU R128, LUFS, LU, RMS, dBFS, dBTP, true peak, crest factor, dynamic range, and noise floor. Covers the aspectralstats, astats, ebur128, and loudnorm filters: what each metric measures, how ffmpeg computes it, its units and range, and the external loudness standards and platform targets. Use when reading or producing ffmpeg audio measurements, even when the user names only a metric, filter, or standard."
+
+[claude]
+user-invocable = true

--- a/home-manager/_mixins/agentic/assistants/skills/communication-rules/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/communication-rules/SKILL.md
@@ -1,7 +1,3 @@
----
-name: communication-rules
-description: Applies whenever an agent produces or writes prose, including replies, files, comments, messages, reports, and other user-visible text. Loads the canonical house-style rules (the Communication Rules) for concise, plain British English before drafting or revising.
----
 
 You are an interactive agent that helps users with software engineering tasks. In addition to completing those tasks, you must write every response in ASD-STE100 Simplified Technical English. Write so a non-native English speaker understands on first read, and so can a manager who never wrote code.
 

--- a/home-manager/_mixins/agentic/assistants/skills/communication-rules/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/communication-rules/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "communication-rules"
+description = "Applies whenever an agent produces or writes prose, including replies, files, comments, messages, reports, and other user-visible text. Loads the canonical house-style rules (the Communication Rules) for concise, plain British English before drafting or revising."

--- a/home-manager/_mixins/agentic/assistants/skills/contribution-voice/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/contribution-voice/SKILL.md
@@ -1,8 +1,3 @@
----
-name: contribution-voice
-description: "Use when drafting text that is published under the user's name in public: a GitHub, Linear, or Slack comment, an issue, a bug report, a pull request description, a review reply, or a commit message. Governs the structure of the text (length, layout, sign-offs, the cut pass) rather than its vocabulary. Use even if the user only says 'reply to this issue', 'write the PR description', or 'draft a comment'."
-user-invocable: true
----
 
 # Contribution Voice
 

--- a/home-manager/_mixins/agentic/assistants/skills/contribution-voice/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/contribution-voice/header.toml
@@ -1,0 +1,6 @@
+[common]
+name = "contribution-voice"
+description = "Use when drafting text that is published under the user's name in public: a GitHub, Linear, or Slack comment, an issue, a bug report, a pull request description, a review reply, or a commit message. Governs the structure of the text (length, layout, sign-offs, the cut pass) rather than its vocabulary. Use even if the user only says 'reply to this issue', 'write the PR description', or 'draft a comment'."
+
+[claude]
+user-invocable = true

--- a/home-manager/_mixins/agentic/assistants/skills/deep-research/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/deep-research/SKILL.md
@@ -1,7 +1,3 @@
----
-name: deep-research
-description: "Use when the user asks to research a topic in depth, compare options, or investigate an open question, and says things like 'deep research', 'research this', 'look into X', or 'what are the options for X'. Runs multi-round web research and synthesises a cited report; use it for an open question with no tracked task yet, and `research-task` when an existing task anchors the work."
----
 
 # Deep Research
 

--- a/home-manager/_mixins/agentic/assistants/skills/deep-research/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/deep-research/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "deep-research"
+description = "Use when the user asks to research a topic in depth, compare options, or investigate an open question, and says things like 'deep research', 'research this', 'look into X', or 'what are the options for X'. Runs multi-round web research and synthesises a cited report; use it for an open question with no tracked task yet, and `research-task` when an existing task anchors the work."

--- a/home-manager/_mixins/agentic/assistants/skills/delegate-task/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/delegate-task/header.toml
@@ -1,0 +1,6 @@
+[common]
+name = "delegate-task"
+description = "Routes non-trivial work to the right specialist agent and applies when coordinating delegated results, waiting for agent completion, or relaying specialist responses."
+
+[claude]
+user-invocable = true

--- a/home-manager/_mixins/agentic/assistants/skills/draft-comment/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/draft-comment/SKILL.md
@@ -1,7 +1,3 @@
----
-name: draft-comment
-description: "Use when drafting one comment, reply, or message for a GitHub issue, pull request, or review thread; a Linear issue or comment; or a Slack message or thread. Use for requests such as 'draft a comment', 'write a reply', or 'help me respond'. Keeps drafting read-only. When the user asks to post, use this as the drafting phase before the relevant write command."
----
 
 # Draft Comment
 

--- a/home-manager/_mixins/agentic/assistants/skills/draft-comment/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/draft-comment/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "draft-comment"
+description = "Use when drafting one comment, reply, or message for a GitHub issue, pull request, or review thread; a Linear issue or comment; or a Slack message or thread. Use for requests such as 'draft a comment', 'write a reply', or 'help me respond'. Keeps drafting read-only. When the user asks to post, use this as the drafting phase before the relevant write command."

--- a/home-manager/_mixins/agentic/assistants/skills/draft-issue/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/draft-issue/SKILL.md
@@ -1,7 +1,3 @@
----
-name: draft-issue
-description: "Use when drafting a GitHub issue, bug report, or feature request for a repository, including requests such as 'draft an issue', 'write a bug report', or 'help me report this'. Checks contribution policy, duplicate issues, and issue templates before writing. Keeps drafting read-only. When the user asks to file or create the issue, use this as the drafting phase before `post-issue`."
----
 
 # Draft Issue
 

--- a/home-manager/_mixins/agentic/assistants/skills/draft-issue/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/draft-issue/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "draft-issue"
+description = "Use when drafting a GitHub issue, bug report, or feature request for a repository, including requests such as 'draft an issue', 'write a bug report', or 'help me report this'. Checks contribution policy, duplicate issues, and issue templates before writing. Keeps drafting read-only. When the user asks to file or create the issue, use this as the drafting phase before `post-issue`."

--- a/home-manager/_mixins/agentic/assistants/skills/draft-project-description/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/draft-project-description/SKILL.md
@@ -1,7 +1,3 @@
----
-name: draft-project-description
-description: "Use when the user asks to write or rewrite a Linear project description, improve a project's LensAgent quality score, or turn project issues into measurable purpose, motivation, outcomes, boundaries, risks, and dates. Resolves the named project, reads every issue and any coaching issue, confirms the match once, then updates only the authorised project fields."
----
 
 # Draft Project Description
 

--- a/home-manager/_mixins/agentic/assistants/skills/draft-project-description/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/draft-project-description/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "draft-project-description"
+description = "Use when the user asks to write or rewrite a Linear project description, improve a project's LensAgent quality score, or turn project issues into measurable purpose, motivation, outcomes, boundaries, risks, and dates. Resolves the named project, reads every issue and any coaching issue, confirms the match once, then updates only the authorised project fields."

--- a/home-manager/_mixins/agentic/assistants/skills/gh/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/gh/SKILL.md
@@ -1,8 +1,3 @@
----
-name: gh
-description: "Use when the user mentions `gh`, `gh api`, the GitHub CLI, the GitHub API, or wants to view, query, search, or change GitHub. Covers querying the GitHub API, raw API calls, PRs/pull requests, review comment replies, issues, workflows/Actions/CI, releases, repos, notifications, status, and any task that views or queries GitHub data."
-user-invocable: true
----
 
 # GitHub CLI (gh) Reference
 

--- a/home-manager/_mixins/agentic/assistants/skills/gh/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/gh/header.toml
@@ -1,0 +1,6 @@
+[common]
+name = "gh"
+description = "Use when the user mentions `gh`, `gh api`, the GitHub CLI, the GitHub API, or wants to view, query, search, or change GitHub. Covers querying the GitHub API, raw API calls, PRs/pull requests, review comment replies, issues, workflows/Actions/CI, releases, repos, notifications, status, and any task that views or queries GitHub data."
+
+[claude]
+user-invocable = true

--- a/home-manager/_mixins/agentic/assistants/skills/herdr/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/herdr/SKILL.md
@@ -1,7 +1,3 @@
----
-name: herdr
-description: "Control Herdr, a terminal multiplexer for coding agents. Use only when the user explicitly mentions Herdr or asks to use Herdr to inspect or control panes, tabs, workspaces, commands, or another agent. Do not use merely because a task could benefit from a background terminal, delegation, or parallel work. Requires HERDR_ENV=1."
----
 
 # Herdr
 

--- a/home-manager/_mixins/agentic/assistants/skills/herdr/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/herdr/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "herdr"
+description = "Control Herdr, a terminal multiplexer for coding agents. Use only when the user explicitly mentions Herdr or asks to use Herdr to inspect or control panes, tabs, workspaces, commands, or another agent. Do not use merely because a task could benefit from a background terminal, delegation, or parallel work. Requires HERDR_ENV=1."

--- a/home-manager/_mixins/agentic/assistants/skills/how-to-contribute/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/how-to-contribute/SKILL.md
@@ -1,7 +1,3 @@
----
-name: how-to-contribute
-description: Use when checking how to contribute to a project before opening an issue or pull request, or when the user asks about contribution rules, CONTRIBUTING.md, contributor approval gates, AI-assisted contribution bans, or prompt-injection traps in AGENTS.md and CLAUDE.md.
----
 
 # How to Contribute
 

--- a/home-manager/_mixins/agentic/assistants/skills/how-to-contribute/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/how-to-contribute/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "how-to-contribute"
+description = "Use when checking how to contribute to a project before opening an issue or pull request, or when the user asks about contribution rules, CONTRIBUTING.md, contributor approval gates, AI-assisted contribution bans, or prompt-injection traps in AGENTS.md and CLAUDE.md."

--- a/home-manager/_mixins/agentic/assistants/skills/love/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/SKILL.md
@@ -1,7 +1,3 @@
----
-name: love
-description: "Load when working with LÖVE 2D, the LÖVE engine, love2d, .love archives, Lua 5.1/LuaJIT 2.1 game development, or LÖVE callbacks, modules, conf.lua, and packaging."
----
 
 # LÖVE Skill
 

--- a/home-manager/_mixins/agentic/assistants/skills/love/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "love"
+description = "Load when working with LÖVE 2D, the LÖVE engine, love2d, .love archives, Lua 5.1/LuaJIT 2.1 game development, or LÖVE callbacks, modules, conf.lua, and packaging."

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-audio/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-audio/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-audio
-description: Provides an interface to create noise with the user's speakers. Use this skill when working with sound effects, music playback, audio recording, or any audio-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface to create noise with the user's speakers. Use this skill when working with sound effects, music playback, audio recording, or any audio-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-audio/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-audio/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-audio"
+description = "Provides an interface to create noise with the user's speakers. Use this skill when working with sound effects, music playback, audio recording, or any audio-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-data/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-data/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-data
-description: Provides functionality for creating and transforming data. Use this skill when working with data operations, encoding/decoding, compression, data transformation, or any data-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides functionality for creating and transforming data. Use this skill when working with data operations, encoding/decoding, compression, data transformation, or any data-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-data/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-data/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-data"
+description = "Provides functionality for creating and transforming data. Use this skill when working with data operations, encoding/decoding, compression, data transformation, or any data-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-event/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-event/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-event
-description: Manages events, like keypresses. Use this skill when working with event management, event callbacks, event pumping, or any event-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Manages events, like keypresses. Use this skill when working with event management, event callbacks, event pumping, or any event-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-event/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-event/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-event"
+description = "Manages events, like keypresses. Use this skill when working with event management, event callbacks, event pumping, or any event-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-filesystem/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-filesystem/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-filesystem
-description: Provides an interface to the user's filesystem. Use this skill when working with file operations, directory management, file reading/writing, or any filesystem-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface to the user's filesystem. Use this skill when working with file operations, directory management, file reading/writing, or any filesystem-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-filesystem/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-filesystem/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-filesystem"
+description = "Provides an interface to the user's filesystem. Use this skill when working with file operations, directory management, file reading/writing, or any filesystem-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-font/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-font/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-font
-description: Allows you to work with fonts. Use this skill when working with font operations, text display, text formatting, or any font-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Allows you to work with fonts. Use this skill when working with font operations, text display, text formatting, or any font-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-font/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-font/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-font"
+description = "Allows you to work with fonts. Use this skill when working with font operations, text display, text formatting, or any font-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-graphics/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-graphics/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-graphics
-description: "The primary responsibility for the love.graphics module is the drawing of lines, shapes, text, Images and other Drawable objects onto the screen. Its secondary responsibilities include loading external files (including Images and Fonts) into memory, creating specialized objects (such as ParticleSystems or Canvases) and managing screen geometry. LÖVE's coordinate system is rooted in the upper-left corner of the screen, which is at location (0, 0). The x axis is horizontal: larger values are further to the right. The y axis is vertical: larger values are further towards the bottom. In many cases, you draw images or shapes in terms of their upper-left corner. Many of the functions are used to manipulate the graphics coordinate system, which is essentially the way coordinates are mapped to the display. You can change the position, scale, and even rotation in this way. Use this skill when working with drawing operations, sprites, animations, shaders, or any visual rendering in LÖVE games."
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 The primary responsibility for the love.graphics module is the drawing of lines, shapes, text, Images and other Drawable objects onto the screen. Its secondary responsibilities include loading external files (including Images and Fonts) into memory, creating specialized objects (such as ParticleSystems or Canvases) and managing screen geometry. LÖVE's coordinate system is rooted in the upper-left corner of the screen, which is at location (0, 0). The x axis is horizontal: larger values are further to the right. The y axis is vertical: larger values are further towards the bottom. In many cases, you draw images or shapes in terms of their upper-left corner. Many of the functions are used to manipulate the graphics coordinate system, which is essentially the way coordinates are mapped to the display. You can change the position, scale, and even rotation in this way. Use this skill when working with drawing operations, sprites, animations, shaders, or any visual rendering in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-graphics/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-graphics/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-graphics"
+description = "The primary responsibility for the love.graphics module is the drawing of lines, shapes, text, Images and other Drawable objects onto the screen. Its secondary responsibilities include loading external files (including Images and Fonts) into memory, creating specialized objects (such as ParticleSystems or Canvases) and managing screen geometry. LÖVE's coordinate system is rooted in the upper-left corner of the screen, which is at location (0, 0). The x axis is horizontal: larger values are further to the right. The y axis is vertical: larger values are further towards the bottom. In many cases, you draw images or shapes in terms of their upper-left corner. Many of the functions are used to manipulate the graphics coordinate system, which is essentially the way coordinates are mapped to the display. You can change the position, scale, and even rotation in this way. Use this skill when working with drawing operations, sprites, animations, shaders, or any visual rendering in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-image/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-image/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-image
-description: Provides an interface to decode encoded image data. Use this skill when working with image operations, texture management, image data manipulation, or any image-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface to decode encoded image data. Use this skill when working with image operations, texture management, image data manipulation, or any image-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-image/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-image/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-image"
+description = "Provides an interface to decode encoded image data. Use this skill when working with image operations, texture management, image data manipulation, or any image-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-joystick/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-joystick/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-joystick
-description: Provides an interface to the user's joystick. Use this skill when working with game controllers, joystick input, gamepad operations, or any input device-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface to the user's joystick. Use this skill when working with game controllers, joystick input, gamepad operations, or any input device-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-joystick/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-joystick/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-joystick"
+description = "Provides an interface to the user's joystick. Use this skill when working with game controllers, joystick input, gamepad operations, or any input device-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-keyboard/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-keyboard/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-keyboard
-description: Provides an interface to the user's keyboard. Use this skill when working with keyboard operations, key events, text input, or any keyboard-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface to the user's keyboard. Use this skill when working with keyboard operations, key events, text input, or any keyboard-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-keyboard/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-keyboard/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-keyboard"
+description = "Provides an interface to the user's keyboard. Use this skill when working with keyboard operations, key events, text input, or any keyboard-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-math/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-math/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-math
-description: Provides system-independent mathematical functions. Use this skill when working with mathematical operations, random number generation, geometric calculations, or any math-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides system-independent mathematical functions. Use this skill when working with mathematical operations, random number generation, geometric calculations, or any math-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-math/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-math/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-math"
+description = "Provides system-independent mathematical functions. Use this skill when working with mathematical operations, random number generation, geometric calculations, or any math-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-mouse/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-mouse/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-mouse
-description: Provides an interface to the user's mouse. Use this skill when working with mouse operations, cursor management, mouse events, or any mouse-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface to the user's mouse. Use this skill when working with mouse operations, cursor management, mouse events, or any mouse-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-mouse/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-mouse/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-mouse"
+description = "Provides an interface to the user's mouse. Use this skill when working with mouse operations, cursor management, mouse events, or any mouse-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-physics/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-physics/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-physics
-description: Can simulate 2D rigid body physics in a realistic manner. This module is based on Box2D, and this API corresponds to the Box2D API as closely as possible. Use this skill when working with physics operations, collision detection, rigid body dynamics, or any physics-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Can simulate 2D rigid body physics in a realistic manner. This module is based on Box2D, and this API corresponds to the Box2D API as closely as possible. Use this skill when working with physics operations, collision detection, rigid body dynamics, or any physics-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-physics/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-physics/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-physics"
+description = "Can simulate 2D rigid body physics in a realistic manner. This module is based on Box2D, and this API corresponds to the Box2D API as closely as possible. Use this skill when working with physics operations, collision detection, rigid body dynamics, or any physics-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-sound/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-sound/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-sound
-description: This module is responsible for decoding sound files. It can't play the sounds, see love.audio for that. Use this skill when working with sound operations, audio decoding, sound data manipulation, or any sound-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 This module is responsible for decoding sound files. It can't play the sounds, see love.audio for that. Use this skill when working with sound operations, audio decoding, sound data manipulation, or any sound-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-sound/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-sound/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-sound"
+description = "This module is responsible for decoding sound files. It can't play the sounds, see love.audio for that. Use this skill when working with sound operations, audio decoding, sound data manipulation, or any sound-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-system/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-system/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-system
-description: Provides access to information about the user's system. Use this skill when working with system operations, platform detection, system information retrieval, or any system-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides access to information about the user's system. Use this skill when working with system operations, platform detection, system information retrieval, or any system-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-system/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-system/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-system"
+description = "Provides access to information about the user's system. Use this skill when working with system operations, platform detection, system information retrieval, or any system-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-thread/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-thread/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-thread
-description: Allows you to work with threads. Threads are separate Lua environments, running in parallel to the main code. As their code runs separately, they can be used to compute complex operations without adversely affecting the frame rate of the main thread. However, as they are separate environments, they cannot access the variables and functions of the main thread, and communication between threads is limited. All LOVE objects (userdata) are shared among threads so you'll only have to send their references across threads. You may run into concurrency issues if you manipulate an object on multiple threads at the same time. When a Thread is started, it only loads the love.thread module. Every other module has to be loaded with require. Use this skill when working with multi-threading, parallel processing, background tasks, or any thread-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Allows you to work with threads. Threads are separate Lua environments, running in parallel to the main code. As their code runs separately, they can be used to compute complex operations without adversely affecting the frame rate of the main thread. However, as they are separate environments, they cannot access the variables and functions of the main thread, and communication between threads is limited. All LOVE objects (userdata) are shared among threads so you'll only have to send their references across threads. You may run into concurrency issues if you manipulate an object on multiple threads at the same time. When a Thread is started, it only loads the love.thread module. Every other module has to be loaded with require. Use this skill when working with multi-threading, parallel processing, background tasks, or any thread-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-thread/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-thread/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-thread"
+description = "Allows you to work with threads. Threads are separate Lua environments, running in parallel to the main code. As their code runs separately, they can be used to compute complex operations without adversely affecting the frame rate of the main thread. However, as they are separate environments, they cannot access the variables and functions of the main thread, and communication between threads is limited. All LOVE objects (userdata) are shared among threads so you'll only have to send their references across threads. You may run into concurrency issues if you manipulate an object on multiple threads at the same time. When a Thread is started, it only loads the love.thread module. Every other module has to be loaded with require. Use this skill when working with multi-threading, parallel processing, background tasks, or any thread-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-timer/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-timer/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-timer
-description: Provides an interface to the user's clock. Use this skill when working with time measurement, frame rate control, performance monitoring, or any time-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface to the user's clock. Use this skill when working with time measurement, frame rate control, performance monitoring, or any time-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-timer/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-timer/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-timer"
+description = "Provides an interface to the user's clock. Use this skill when working with time measurement, frame rate control, performance monitoring, or any time-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-touch/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-touch/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-touch
-description: Provides an interface to touch-screen presses. Use this skill when working with touch operations, multi-touch gestures, touch events, or any touch-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface to touch-screen presses. Use this skill when working with touch operations, multi-touch gestures, touch events, or any touch-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-touch/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-touch/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-touch"
+description = "Provides an interface to touch-screen presses. Use this skill when working with touch operations, multi-touch gestures, touch events, or any touch-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-video/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-video/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-video
-description: This module is responsible for decoding, controlling, and streaming video files. It can't draw the videos, see love.graphics.newVideo and Video objects for that. Use this skill when working with video operations, video decoding, video streaming, or any video-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 This module is responsible for decoding, controlling, and streaming video files. It can't draw the videos, see love.graphics.newVideo and Video objects for that. Use this skill when working with video operations, video decoding, video streaming, or any video-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-video/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-video/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-video"
+description = "This module is responsible for decoding, controlling, and streaming video files. It can't draw the videos, see love.graphics.newVideo and Video objects for that. Use this skill when working with video operations, video decoding, video streaming, or any video-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-window/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-window/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love-window
-description: Provides an interface for modifying and retrieving information about the program's window. Use this skill when working with window operations, display settings, fullscreen modes, or any window-related operations in LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides an interface for modifying and retrieving information about the program's window. Use this skill when working with window operations, display settings, fullscreen modes, or any window-related operations in LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-window/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love-window/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love-window"
+description = "Provides an interface for modifying and retrieving information about the program's window. Use this skill when working with window operations, display settings, fullscreen modes, or any window-related operations in LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love/SKILL.md
@@ -1,10 +1,3 @@
----
-name: love
-description: Provides functions for love operations. Use this skill when working with core functionality for LÖVE games.
-license: MIT
-metadata:
-  author: Ron Dekker <rondekker.nl>
----
 
 ## When to use this skill
 Provides functions for love operations. Use this skill when working with core functionality for LÖVE games.

--- a/home-manager/_mixins/agentic/assistants/skills/love/references/api/love/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/love/references/api/love/header.toml
@@ -1,0 +1,7 @@
+[common]
+name = "love"
+description = "Provides functions for love operations. Use this skill when working with core functionality for LÖVE games."
+license = "MIT"
+
+[common.metadata]
+author = "Ron Dekker <rondekker.nl>"

--- a/home-manager/_mixins/agentic/assistants/skills/nix/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/nix/SKILL.md
@@ -1,7 +1,3 @@
----
-name: nix
-description: "Load when working with Nix, NixOS, Home Manager, nix-darwin, nixpkgs, flakes, derivations, overlays, modules, options, or registries; with .nix files such as configuration.nix, home.nix, default.nix, shell.nix, or flake.nix; or with the Nix CLI (nix build, nix develop, nix flake, nix repl, nix fmt, nix-shell). Use even when the user only mentions a Nix package, option, overlay, flake input, or hash-mismatch error without naming Nix explicitly."
----
 
 # Nix Skill
 

--- a/home-manager/_mixins/agentic/assistants/skills/nix/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/nix/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "nix"
+description = "Load when working with Nix, NixOS, Home Manager, nix-darwin, nixpkgs, flakes, derivations, overlays, modules, options, or registries; with .nix files such as configuration.nix, home.nix, default.nix, shell.nix, or flake.nix; or with the Nix CLI (nix build, nix develop, nix flake, nix repl, nix fmt, nix-shell). Use even when the user only mentions a Nix package, option, overlay, flake input, or hash-mismatch error without naming Nix explicitly."

--- a/home-manager/_mixins/agentic/assistants/skills/research-task/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/research-task/SKILL.md
@@ -1,7 +1,3 @@
----
-name: research-task
-description: "Use when deeply researching an existing tracked task, including a Linear issue key or URL, a GitHub issue or pull request URL or owner/repo#123, or a local Markdown task file. Use for requests such as 'research this task', 'investigate this issue', or 'understand the work around this PR'. Follows linked and related work across Linear, GitHub, Slack, the web, and reachable data warehouses, then recommends cited solutions. Use `deep-research` for an open question with no tracked task."
----
 
 # Research Task
 

--- a/home-manager/_mixins/agentic/assistants/skills/research-task/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/research-task/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "research-task"
+description = "Use when deeply researching an existing tracked task, including a Linear issue key or URL, a GitHub issue or pull request URL or owner/repo#123, or a local Markdown task file. Use for requests such as 'research this task', 'investigate this issue', or 'understand the work around this PR'. Follows linked and related work across Linear, GitHub, Slack, the web, and reachable data warehouses, then recommends cited solutions. Use `deep-research` for an open question with no tracked task."

--- a/home-manager/_mixins/agentic/assistants/skills/review-code-follow-up/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/review-code-follow-up/SKILL.md
@@ -1,8 +1,3 @@
----
-name: review-code-follow-up
-description: "Use for a follow-up code review after an author responds to earlier findings, including requests to re-review, review again, verify fixes, or check addressed feedback. Rechecks the prior feedback and the response delta without restarting the full review."
-user-invocable: true
----
 
 # Review Code Follow-up
 

--- a/home-manager/_mixins/agentic/assistants/skills/review-code-follow-up/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/review-code-follow-up/header.toml
@@ -1,0 +1,6 @@
+[common]
+name = "review-code-follow-up"
+description = "Use for a follow-up code review after an author responds to earlier findings, including requests to re-review, review again, verify fixes, or check addressed feedback. Rechecks the prior feedback and the response delta without restarting the full review."
+
+[claude]
+user-invocable = true

--- a/home-manager/_mixins/agentic/assistants/skills/review-code/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/review-code/SKILL.md
@@ -1,8 +1,3 @@
----
-name: review-code
-description: "Use when reviewing a pull request, branch, worktree, or commit for defects, or when the user says 'review this PR', 'review my code', 'review this branch', 'code review', or asks to get a change reviewed before it ships. Runs a wide sub-agent fan-out, pressure-tests every blocking finding, and writes a review report."
-user-invocable: true
----
 
 # Review Code
 

--- a/home-manager/_mixins/agentic/assistants/skills/review-code/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/review-code/header.toml
@@ -1,0 +1,6 @@
+[common]
+name = "review-code"
+description = "Use when reviewing a pull request, branch, worktree, or commit for defects, or when the user says 'review this PR', 'review my code', 'review this branch', 'code review', or asks to get a change reviewed before it ships. Runs a wide sub-agent fan-out, pressure-tests every blocking finding, and writes a review report."
+
+[claude]
+user-invocable = true

--- a/home-manager/_mixins/agentic/assistants/skills/review-report-path/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/review-report-path/SKILL.md
@@ -1,7 +1,3 @@
----
-name: review-report-path
-description: "Use when a review, audit, or analysis command must decide where to write its report, or must find a report written earlier. Defines durable per-user report storage and the slug and run rules that preserve parallel and past reviews of pull requests, issues, branches, commits, and worktrees. Use even when the caller only says 'write the report', 'read the review report', or names a report file."
----
 
 # Review Report Path
 

--- a/home-manager/_mixins/agentic/assistants/skills/review-report-path/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/review-report-path/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "review-report-path"
+description = "Use when a review, audit, or analysis command must decide where to write its report, or must find a report written earlier. Defines durable per-user report storage and the slug and run rules that preserve parallel and past reviews of pull requests, issues, branches, commits, and worktrees. Use even when the caller only says 'write the report', 'read the review report', or names a report file."

--- a/home-manager/_mixins/agentic/assistants/skills/semgrep/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/semgrep/SKILL.md
@@ -1,7 +1,3 @@
----
-name: semgrep
-description: "Run Semgrep static analysis scans and create custom detection rules. Use when asked to scan code with Semgrep, find security vulnerabilities, write custom YAML rules, or detect specific bug patterns. IMPORTANT: Also use this skill when users ask to 'scan for bugs', 'check code quality', 'find vulnerabilities', 'static analysis', 'lint for security', 'audit this code', or want to enforce coding standards — even if they don't mention Semgrep by name. Semgrep is the right tool for pattern-based code scanning across 30+ languages."
----
 
 # Semgrep Static Analysis
 

--- a/home-manager/_mixins/agentic/assistants/skills/semgrep/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/semgrep/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "semgrep"
+description = "Run Semgrep static analysis scans and create custom detection rules. Use when asked to scan code with Semgrep, find security vulnerabilities, write custom YAML rules, or detect specific bug patterns. IMPORTANT: Also use this skill when users ask to 'scan for bugs', 'check code quality', 'find vulnerabilities', 'static analysis', 'lint for security', 'audit this code', or want to enforce coding standards — even if they don't mention Semgrep by name. Semgrep is the right tool for pattern-based code scanning across 30+ languages."

--- a/home-manager/_mixins/agentic/assistants/skills/sizing/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/sizing/SKILL.md
@@ -1,7 +1,3 @@
----
-name: sizing
-description: "Use when sizing or estimating a task, issue, or ticket, or when checking an estimate someone else set. Defines the T-shirt scale (XS, S, M, L, XL) and what the work at each size looks like, plus the rules for spikes, parent tracking issues, and splitting oversized work. Use even if the user only says 'how big is this', 'what should the estimate be', 'story points', or names a size."
----
 
 # Sizing
 

--- a/home-manager/_mixins/agentic/assistants/skills/sizing/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/sizing/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "sizing"
+description = "Use when sizing or estimating a task, issue, or ticket, or when checking an estimate someone else set. Defines the T-shirt scale (XS, S, M, L, XL) and what the work at each size looks like, plus the rules for spikes, parent tracking issues, and splitting oversized work. Use even if the user only says 'how big is this', 'what should the estimate be', 'story points', or names a size."

--- a/home-manager/_mixins/agentic/assistants/skills/slack/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/slack/SKILL.md
@@ -1,8 +1,3 @@
----
-name: slack
-description: "Use when posting, replying, or sending a DM in Slack, or when the user mentions Slack, a Slack channel, a Slack thread, or a Slack message URL. Covers the `slack-post` helper, its target forms, and channel resolution. Use even if the user only says 'post this in Slack', 'reply in the thread', or 'DM them'."
-user-invocable: true
----
 
 # Slack
 

--- a/home-manager/_mixins/agentic/assistants/skills/slack/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/slack/header.toml
@@ -1,0 +1,6 @@
+[common]
+name = "slack"
+description = "Use when posting, replying, or sending a DM in Slack, or when the user mentions Slack, a Slack channel, a Slack thread, or a Slack message URL. Covers the `slack-post` helper, its target forms, and channel resolution. Use even if the user only says 'post this in Slack', 'reply in the thread', or 'DM them'."
+
+[claude]
+user-invocable = true

--- a/home-manager/_mixins/agentic/assistants/skills/task-tracker/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/task-tracker/SKILL.md
@@ -1,7 +1,3 @@
----
-name: task-tracker
-description: "Use when a command reads or writes a tracked task and must know which tracker holds it: Linear, a GitHub Project, or a local Markdown file. Resolves the tracker from an issue key, an issue URL, `owner/repo#N`, a project URL, or a path, then names the tracker-specific mechanics for status, type, labels, priority, estimate, parent and child order, assignee, comments, long research, and branch links. Use whenever `create-task`, `review-task`, `update-task`, `implement-task`, `make-pr`, or `finish-pr` touches a task, even when the caller names only Linear or only GitHub."
----
 
 # Task tracker
 

--- a/home-manager/_mixins/agentic/assistants/skills/task-tracker/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/task-tracker/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "task-tracker"
+description = "Use when a command reads or writes a tracked task and must know which tracker holds it: Linear, a GitHub Project, or a local Markdown file. Resolves the tracker from an issue key, an issue URL, `owner/repo#N`, a project URL, or a path, then names the tracker-specific mechanics for status, type, labels, priority, estimate, parent and child order, assignee, comments, long research, and branch links. Use whenever `create-task`, `review-task`, `update-task`, `implement-task`, `make-pr`, or `finish-pr` touches a task, even when the caller names only Linear or only GitHub."

--- a/home-manager/_mixins/agentic/assistants/skills/work-order-format/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/work-order-format/SKILL.md
@@ -1,7 +1,3 @@
----
-name: work-order-format
-description: "Use when creating or updating a cycle work order document in Linear. Defines the document title and parent, the wave headings with dependency lines, the strict-parallel rule, the issue bullet and deferred entry forms, and stable wave numbering. Use whenever a command writes or patches a work order."
----
 
 # Work Order Format
 

--- a/home-manager/_mixins/agentic/assistants/skills/work-order-format/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/work-order-format/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "work-order-format"
+description = "Use when creating or updating a cycle work order document in Linear. Defines the document title and parent, the wave headings with dependency lines, the strict-parallel rule, the issue bullet and deferred entry forms, and stable wave numbering. Use whenever a command writes or patches a work order."

--- a/home-manager/_mixins/agentic/assistants/skills/write-agents-md/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-agents-md/SKILL.md
@@ -1,7 +1,3 @@
----
-name: write-agents-md
-description: Use when creating, updating, consolidating, or reviewing an AGENTS.md (or CLAUDE.md, CLAUDE.local.md, .claude/rules/*.md, .cursorrules, .cursor/rules/*.mdc, AGENTS.override.md, or .github/instructions/*.instructions.md) project instruction file. Covers the open agents.md spec, Codex precedence rules, Claude Code memory loading, and migration from legacy formats. Use even if the user only says "instructions", "rules", "project memory", or names a single legacy filename.
----
 
 # Write AGENTS.md
 

--- a/home-manager/_mixins/agentic/assistants/skills/write-agents-md/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/write-agents-md/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "write-agents-md"
+description = "Use when creating, updating, consolidating, or reviewing an AGENTS.md (or CLAUDE.md, CLAUDE.local.md, .claude/rules/*.md, .cursorrules, .cursor/rules/*.mdc, AGENTS.override.md, or .github/instructions/*.instructions.md) project instruction file. Covers the open agents.md spec, Codex precedence rules, Claude Code memory loading, and migration from legacy formats. Use even if the user only says \"instructions\", \"rules\", \"project memory\", or names a single legacy filename."

--- a/home-manager/_mixins/agentic/assistants/skills/write-assistant/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-assistant/SKILL.md
@@ -9,7 +9,9 @@ Author and maintain agent system prompts: the always-loaded persona, capabilitie
 - **Examples** vs **no examples**. Add 1-2 examples for subjective style or judgment work; omit for procedural agents.
 - **Triggers** vs **direct invocation**. Sub-agents selected by routing need a trigger-rich `description`; user-invoked agents only need a name.
 
-## Required structure
+## Required native structure
+
+This template shows native client output. In this repository, keep metadata in `header.toml` and the body in `prompt.md` without frontmatter (see [Repository source](#repository-source)).
 
 ```markdown
 ---

--- a/home-manager/_mixins/agentic/assistants/skills/write-assistant/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-assistant/SKILL.md
@@ -1,7 +1,3 @@
----
-name: write-assistant
-description: Use when creating, updating, refactoring, or reviewing an AI assistant or sub-agent system prompt - persona, role, capabilities, tools, output format, examples, and constraints. Covers Claude Code agents, OpenAI Codex / Responses-API agents, Pi assistants, and OpenCode agents. Use even if the user only says "agent prompt", "assistant", "subagent", "persona", or names the artefact by file path.
----
 
 # Write Assistant
 
@@ -49,6 +45,16 @@ description: <one-sentence trigger summary>
 ```
 
 The seven-element template (role, mission, capabilities, process, constraints, output format, examples) is the consensus across Anthropic, OpenAI, and Google guidance. See `references/structure.md` for filled examples per platform.
+
+## Repository source
+
+In this repository, author metadata in `header.toml`, not in the Markdown body. The composer generates native client frontmatter.
+
+Use `[common] description` for the shared description. Agent names derive from directory names. Keep the agent body in `prompt.md` without frontmatter.
+
+Use `[claude]`, `[opencode]`, `[codex]`, and `[pi]` for native non-model fields. Model and effort overrides belong only under `[routing.<provider>]`. Pi pins use `[routing.pi.<inference-provider>] model` and `thinking`.
+
+Missing provider tables mean no overrides, not disabled output. Omit fields to inherit defaults. TOML has no null.
 
 ## Voice
 
@@ -116,7 +122,7 @@ Keep examples compact. Use `<example_input>` / `<example_output>` tags.
 
 ## Output
 
-When invoked to **create**, produce the complete agent prompt at the requested path.
+When invoked to **create**, produce `header.toml` and `prompt.md` in this repository. Elsewhere, produce the complete native agent prompt.
 
 When invoked to **update**, produce the edited prompt plus this changelog:
 

--- a/home-manager/_mixins/agentic/assistants/skills/write-assistant/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/write-assistant/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "write-assistant"
+description = "Use when creating, updating, refactoring, or reviewing an AI assistant or sub-agent system prompt - persona, role, capabilities, tools, output format, examples, and constraints. Covers Claude Code agents, OpenAI Codex / Responses-API agents, Pi assistants, and OpenCode agents. Use even if the user only says \"agent prompt\", \"assistant\", \"subagent\", \"persona\", or names the artefact by file path."

--- a/home-manager/_mixins/agentic/assistants/skills/write-command/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-command/SKILL.md
@@ -1,7 +1,3 @@
----
-name: write-command
-description: Use when creating, updating, or reviewing a slash command - shims that delegate to a skill or agent, standalone commands with an inline output format, and the `description` / `argument-hint` / `model` headers per provider. Covers Claude Code commands, OpenCode commands, Pi prompt templates, and Codex commands delivered as manual-only skills. Use even if the user only says "slash command", "prompt template", "command shim", "create-command", or names the artefact by path.
----
 
 # Write Command
 
@@ -36,7 +32,7 @@ Rules:
 
 - `description` ≤60 chars where possible. Imperative or noun phrase. No trailing period. Trailing emoji is fine and conventional in this repo.
 - `argument-hint` ≤25 chars. `[arg]` for optional, `<arg>` for required. Anthropic's own examples use `[arg]` for both; if the body falls back to "ask if blank", the argument is optional and the hint must use `[…]`.
-- Vendor-specific fields (`model`, `allowed-tools`, `agent`, `subtask`, `disable-model-invocation`, repo-local `use-task` - Claude Code only; rewrites the body to dispatch through the Task tool) belong in the per-platform header files; see `references/portability.md`.
+- Vendor-specific fields (`allowed-tools`, `subtask`, and `disable-model-invocation`) belong in provider or routing tables in `header.toml`; see `references/portability.md`.
 
 ## Body
 
@@ -66,17 +62,26 @@ Use `$ARGUMENTS` for a shared command that takes one free-form argument. Claude 
 
 ## Repo composition
 
-This repo composes platform headers from per-command files. `compose.nix` reads:
+This repo reads one `header.toml` and one `prompt.md` per command. Keep the body free of frontmatter.
 
-| File                   | Required? | Purpose                                                             |
-| ---------------------- | --------- | ------------------------------------------------------------------- |
-| `prompt.md`            | yes       | Body. Shared across Claude / OpenCode / Pi.                         |
-| `description.txt`      | yes       | One-line label, trailing emoji conventional.                        |
-| `header.claude.yaml`   | yes       | `argument-hint`, `model`, `allowed-tools`, `use-task`.              |
-| `header.opencode.yaml` | yes       | `agent:` binding, optional `model`, optional `subtask` (see below). |
-| `header.pi.yaml`       | no        | `argument-hint` only - Pi has no model/agent at the prompt layer.   |
+```toml
+[common]
+description = "Create Skill 🧩"
+argument-hint = "[skill-name]"
 
-`header.claude.yaml` and `header.opencode.yaml` are read with `readFile` and **must exist for every command, even if no per-provider fields are set** - leave them as empty files; omitting them makes Nix evaluation fail. `header.pi.yaml` is genuinely optional (read with `readOptionalFile`) and can be omitted when the command takes no arguments. On Claude Code, an agent binding via `header.opencode.yaml: agent:` causes `compose.nix` to prepend `@<agent>` to the body automatically; do not write `@agent` into `prompt.md`. The repo-local `use-task: true` field in `header.claude.yaml` rewrites the body into "Use the Task tool to launch the `<agent>` agent for the following task: …". `compose.nix` discovers commands by directory; no codegen edits are required when adding a new command.
+[compose]
+agent = "rosey"
+```
+
+Use `[common]` for the description and a hint shared by Claude Code, OpenCode, and Pi. Preserve existing provider-specific omissions under `[claude]`, `[opencode]`, or `[pi]`.
+
+Keep native non-model fields in provider tables. Put model and effort overrides only under `[routing.<provider>]`. Pi agent routing uses `[routing.pi.<inference-provider>]`.
+
+Use `[compose] agent` for the repository agent binding. Set `[compose.claude] use-task = true` for a Task wrapper. Set `[compose.codex] spawn-agent = false` for same-context execution. Omitted controls preserve the composer defaults.
+
+Names derive from directories. Missing provider tables mean no overrides, not disabled output. TOML has no null. Omit fields to inherit defaults.
+
+The composer discovers commands by directory. Retired provider headers are removed. Retired `description.txt` files are not inputs. Keep them until the user authorises removal.
 
 Codex receives each command as a manual-only command-derived skill, invoked by the user as `$name`. The composer owns `agents/openai.yaml` with `policy.allow_implicit_invocation: false` for every command, including secret bodies. Do not add this policy to shared frontmatter or ordinary reusable skills.
 
@@ -100,7 +105,7 @@ Manual-only controls command selection, not file access or workflow reuse within
 
 ## Per-provider field matrix
 
-When a command accepts arguments, every provider header for a runtime that supports `argument-hint` carries the same hint text. Claude Code, OpenCode, and Pi all display it; do not skip a provider.
+When a command accepts arguments, put a shared `argument-hint` in `[common]`. Claude Code, OpenCode, and Pi all display it; do not skip a provider.
 
 See `references/portability.md` for the full table. Headlines:
 
@@ -121,7 +126,7 @@ In this repo:
 
 - Command-level pins are rare. Only `draft-commit-message` and `draft-pr-message` set `model: sonnet` in Claude Code. Every standalone command, including `make-pr`, omits `model` and inherits the root session model.
 - Pin a model on a new command only when both hold: the work needs a specific tier regardless of the caller's session, and the command can run detached from its agent. Otherwise leave it out.
-- OpenCode headers omit `model` so the user's session model wins. Per-command `model` was ignored on OpenCode 0.6.4 and below; treat it as a hint, not a guarantee.
+- OpenCode routing tables omit `model` so the user's session model wins. Per-command `model` was ignored on OpenCode 0.6.4 and below; treat it as a hint, not a guarantee.
 - Pi has no model field at the prompt-template layer; model and routing live on the agent.
 
 ## Side-effect declaration
@@ -135,22 +140,22 @@ If the body writes files, runs Bash, or hits the network, say so and list paths 
 - Bare `$1` in shims targeting Claude Code (use `$ARGUMENTS`).
 - `allowed-tools` left as `"*"` or bare `Bash`.
 - Long bodies that re-derive routing or response contract owned by `delegate-task`.
-- Time-sensitive text (dates, model IDs) in the body. Pin via `model:` instead.
+- Time-sensitive text (dates, model IDs) in the body. Pin via `[routing.<provider>] model` instead.
 - Embedding generated content (e.g. agent registry snippets) into a command prefix - the volatile data breaks the prompt cache. Put it in a skill that loads on demand.
 - Targeting Codex via legacy `/prompts:` for new work. Use the command composer for commands and `write-skill` for reusable skills.
 
 ## Update flow
 
-1. Read `prompt.md`, `description.txt`, and every `header.*.yaml`.
+1. Read `prompt.md` and `header.toml`.
 2. Identify the form band (shim / standalone / standalone-with-format). Enforce the shim and trivial caps; apply the long command choice before editing a standalone-with-format command.
 3. Diagnose: argument substitution (`$ARGUMENTS` vs `$1`), `argument-hint` bracket convention, persona leakage, missing or stale `description`, model mismatch with sibling commands, missing side-effect declaration, missing or stale README row.
-4. Edit narrowly. Preserve `description.txt` and `argument-hint` unless they are wrong. Do not rewrite a working body.
+4. Edit narrowly. Preserve `[common] description` and `argument-hint` unless they are wrong. Do not rewrite a working body.
 5. If a shim and an existing skill both grew the same doctrine, cut the shim back to the skill body's surface.
 6. Emit changed files plus a short changelog: `Changed`, `Rationale`.
 
 ## Output
 
-When invoked to **create**, produce `prompt.md`, `description.txt`, and the three `header.*.yaml` files in fenced blocks ready to save at the correct path.
+When invoked to **create**, produce `prompt.md` and `header.toml` in fenced blocks ready to save at the correct path.
 
 When invoked to **update**, produce only the changed files plus the changelog. Preserve unchanged sections verbatim.
 

--- a/home-manager/_mixins/agentic/assistants/skills/write-command/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/write-command/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "write-command"
+description = "Use when creating, updating, or reviewing a slash command - shims that delegate to a skill or agent, standalone commands with an inline output format, and the `description` / `argument-hint` / `model` headers per provider. Covers Claude Code commands, OpenCode commands, Pi prompt templates, and Codex commands delivered as manual-only skills. Use even if the user only says \"slash command\", \"prompt template\", \"command shim\", \"create-command\", or names the artefact by path."

--- a/home-manager/_mixins/agentic/assistants/skills/write-command/references/portability.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-command/references/portability.md
@@ -58,7 +58,7 @@ Default behaviour:
 
 `subtask: true` forces subagent invocation even when the bound agent is `mode: primary`. `subtask: false` keeps execution in the caller's session even when the bound agent is a subagent (spec-honoured; sst/opencode#10431 reports it ignored on some builds).
 
-Claude Code and Pi have no equivalent field: every slash invocation runs in the caller's session unless the body explicitly dispatches through the Task tool (Claude) or `/skill:` / sub-agent invocation (Pi). For Claude Code, the repo-local `use-task: true` field in `header.claude.yaml` is the closest analogue.
+Claude Code and Pi have no equivalent field: every slash invocation runs in the caller's session unless the body explicitly dispatches through the Task tool (Claude) or `/skill:` / sub-agent invocation (Pi). For Claude Code, the repo-local `[compose.claude] use-task = true` field in `header.toml` is the closest analogue.
 
 ## OpenCode `model:` honouring
 

--- a/home-manager/_mixins/agentic/assistants/skills/write-command/references/repo-conventions.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-command/references/repo-conventions.md
@@ -7,22 +7,19 @@ This repo's command estate composes through `home-manager/_mixins/agentic/assist
 ```
 commands/<name>/                              (standalone)
 agents/<agent>/commands/<name>/               (agent-scoped)
-├── prompt.md             body, required
-├── description.txt       one-line label, required
-├── header.claude.yaml    required (may be empty)
-├── header.opencode.yaml  required (may be empty)
-└── header.pi.yaml        optional (omit when no positional arg)
+├── prompt.md             body without frontmatter
+└── header.toml           shared, provider, composition, and routing metadata
 ```
 
 `compose.nix` discovers commands by directory listing - no codegen edits when adding a new command.
 
 ## Agent prepend on Claude Code
 
-When `header.opencode.yaml` carries `agent: <name>` and the command lives under `agents/<name>/commands/`, `compose.nix` prepends `@<name>` on its own line before the body for the Claude Code output. Do not write `@agent` into `prompt.md`; the composer adds it.
+When `[compose]` in `header.toml` carries `agent = "<name>"` and the command lives under `agents/<name>/commands/`, `compose.nix` prepends `@<name>` on its own line before the body for the Claude Code output. Do not write `@agent` into `prompt.md`; the composer adds it.
 
 ## `use-task: true` (repo-local)
 
-`header.claude.yaml: use-task: true` rewrites the Claude Code body into:
+`[compose.claude] use-task = true` rewrites the Claude Code body into:
 
 ```
 Use the Task tool to launch the <agent> agent for the following task:
@@ -36,14 +33,18 @@ This dispatches the command through Claude's Task tool instead of the `@agent` p
 
 `home-manager/_mixins/agentic/opencode/default.nix` (around lines 110-120) reads `agents/rosey/commands/create-agents-md/prompt.md` directly and overrides OpenCode's built-in `/init` command with it. If you rename `create-agents-md` or move its `prompt.md`, update that file in the same change. Overriding any other OpenCode built-in (e.g. `/review`) follows the same pattern: one entry in `opencode/default.nix` reading a `prompt.md` from the assistants tree.
 
-## Pi header optionality
+## Provider tables
 
-`header.pi.yaml` is the only optional header. Supply it whenever the command accepts an argument so Pi can display the same `argument-hint` as Claude Code and OpenCode (matches `handover-fork`, `handover-fresh`, `orientate`, `ready`, and every Rosey `create-*` / `update-*` shim). Omit it only when the command takes no positional argument and would otherwise be empty. `compose.nix` uses `readOptionalFile` for it; an empty file is acceptable but adds noise.
+Use `[common] argument-hint` when Claude Code, OpenCode, and Pi share its presence and value. Preserve differing hints in native provider tables.
+
+Missing provider tables mean no overrides, not disabled output. Use `[routing.<provider>]` for model and effort fields. Pi agent pins belong under `[routing.pi.<inference-provider>]`.
+
+Retired provider headers are removed. Retired `description.txt` files remain unconsumed until the user authorises removal.
 
 ## Codex output
 
 Codex receives every command as a manual-only command-derived skill. Users invoke `$name`. The composer emits `agents/openai.yaml` with `policy.allow_implicit_invocation: false` for every command, including secret bodies. The command policy is mandatory and does not change ordinary skill policies.
 
-Agent-scoped commands use `spawn_agent` by default. Set `spawn-agent = false` to embed the owning agent prompt in the caller's context. For nested workflows, follow the source body directly or dispatch it from the top-level orchestrator. Do not execute a generated launch wrapper inside a worker. Resolve installed instructions through the available catalogue or configured skill roots, not a fixed home path.
+Agent-scoped commands use `spawn_agent` by default. Set `[compose.codex] spawn-agent = false` to embed the owning agent prompt in the caller's context. For nested workflows, follow the source body directly or dispatch it from the top-level orchestrator. Do not execute a generated launch wrapper inside a worker. Resolve installed instructions through the available catalogue or configured skill roots, not a fixed home path.
 
 Codex does not substitute `$ARGUMENTS` or positional placeholders in these skills. Map the user's accompanying text to the body's declared arguments. New Codex-only reference guidance belongs in a native skill.

--- a/home-manager/_mixins/agentic/assistants/skills/write-command/references/templates.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-command/references/templates.md
@@ -36,29 +36,15 @@ Skill name argument: $ARGUMENTS. Use it if provided; otherwise ask for the name 
 Apply `write-skill` end-to-end: frontmatter, body, layout, references, anti-patterns, output format. Do not duplicate that guidance here.
 ```
 
-`description.txt`:
+`header.toml`:
 
-```text
-Create Skill 🧩
-```
+```toml
+[common]
+description = "Create Skill 🧩"
+argument-hint = "[skill-name]"
 
-`header.claude.yaml`:
-
-```yaml
-argument-hint: "[skill-name]"
-model: opus
-```
-
-`header.opencode.yaml`:
-
-```yaml
-agent: rosey
-```
-
-`header.pi.yaml`:
-
-```yaml
-argument-hint: "[skill-name]"
+[compose]
+agent = "rosey"
 ```
 
 ## Form B: trivial standalone
@@ -71,28 +57,12 @@ One- or two-line body. No format. Mirrors `ack`, `ready`.
 $ARGUMENTS Assess and acknowledge my message, then yield your turn.
 ```
 
-`description.txt`:
+`header.toml`:
 
-```text
-Acknowledge a phase or message ✅
-```
-
-`header.claude.yaml`:
-
-```yaml
-argument-hint: "[phase]"
-```
-
-`header.opencode.yaml`:
-
-```yaml
-
-```
-
-`header.pi.yaml`:
-
-```yaml
-argument-hint: "[phase]"
+```toml
+[common]
+description = "Acknowledge a phase or message ✅"
+argument-hint = "[phase]"
 ```
 
 ## Form C: standalone with output format
@@ -131,22 +101,14 @@ If the user supplied a focus, tailor the handover to that next-session goal.
 - Exclude easily discoverable information.
 ```
 
-`description.txt`:
+`header.toml`:
 
-```text
-Handover 📤
+```toml
+[common]
+description = "Handover 📤"
+
+[compose]
+agent = "rosey"
 ```
 
-`header.claude.yaml`:
-
-```yaml
-model: sonnet
-```
-
-`header.opencode.yaml`:
-
-```yaml
-agent: rosey
-```
-
-(No `header.pi.yaml`: the command takes no positional arg.)
+Omit `argument-hint` when the command takes no argument. Add model pins only under `[routing.<provider>]` when the command needs one.

--- a/home-manager/_mixins/agentic/assistants/skills/write-command/references/templates.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-command/references/templates.md
@@ -106,6 +106,7 @@ If the user supplied a focus, tailor the handover to that next-session goal.
 ```toml
 [common]
 description = "Handover 📤"
+argument-hint = "[focus]"
 
 [compose]
 agent = "rosey"

--- a/home-manager/_mixins/agentic/assistants/skills/write-skill/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-skill/SKILL.md
@@ -9,7 +9,9 @@ Author and maintain Agent Skills (`SKILL.md`) that load via description-triggere
 - **Skill** vs **command**. Skills are description-triggered and reusable; commands are deterministic and user-invoked. If the workflow needs an argument and a fixed name, build a command that loads the skill.
 - **Add a reference** vs **enlarge the body**. Add a `references/<topic>.md` when material is needed only some of the time, exceeds ~100 lines, or contains variants that differ per task.
 
-## Frontmatter (portable, required)
+## Native output frontmatter (portable, required)
+
+Native skills require the frontmatter below. In this repository, the composer generates it from `header.toml`. Keep source `SKILL.md` files body-only.
 
 ```yaml
 ---

--- a/home-manager/_mixins/agentic/assistants/skills/write-skill/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-skill/SKILL.md
@@ -1,7 +1,3 @@
----
-name: write-skill
-description: Use when creating, updating, or reviewing an Agent Skill - authoring or revising a `SKILL.md`, its frontmatter, layout, references, and progressive disclosure. Use when the user mentions writing, editing, splitting, renaming, or auditing a skill, even if they do not say "skill" explicitly. Covers cross-platform portability across Claude Code, Codex, OpenCode, and Pi.
----
 
 # Write Skill
 
@@ -28,6 +24,20 @@ Rules:
 - `description` ≤1024 chars. Third person. Front-load the use case. Include explicit trigger phrases and synonyms so the model selects the skill without being asked by name.
 - Add platform-specific fields (`user-invocable`, `when_to_use`, `argument-hint`, `disable-model-invocation`, `allowed-tools`, …) **only if required** for behaviour on that platform. See `references/portability.md`.
 
+## Repository source
+
+In this repository, author metadata in `header.toml`, not in the Markdown body. The composer generates native client frontmatter.
+
+Use `[common] description` for the shared description. Skills require an explicit `[common] name` that matches the directory. Portable `license`, `compatibility`, and `metadata` also belong in `[common]`. Keep `SKILL.md` body-only, including nested API skills.
+
+Use `[claude]`, `[opencode]`, `[codex]`, and `[pi]` for native non-model fields. Model and effort overrides belong only under `[routing.<provider>]`. Pi pins use `[routing.pi.<inference-provider>] model` and `thinking`.
+
+The composer rejects model and effort routes for ordinary OpenCode and Codex skills. Use an agent-backed command when a workflow needs those pins.
+
+Missing provider tables mean no overrides, not disabled output. Omit fields to inherit defaults. TOML has no null.
+
+For ordinary Codex skills, put companion policy under `[codex.policy]`. Command-derived skills always use the composer's manual-only policy. Keep encrypted `SKILL.sops` files unchanged as complete native skills.
+
 ## Body
 
 Lean, imperative, action-oriented. Smaller is better. Cap at 500 lines; most skills stay well under that, often under 200. The body loads only after the description triggers, so put all when-to-use phrasing in the description, not in a "When to use" heading.
@@ -44,7 +54,8 @@ Structure:
 
 ```
 <skill-name>/
-├── SKILL.md          required
+├── header.toml       metadata in this repository
+├── SKILL.md          body in this repository, complete skill elsewhere
 ├── references/       loaded on demand from SKILL.md links
 ├── scripts/          executable helpers (no library code)
 └── assets/           templates, static files
@@ -80,7 +91,7 @@ Skill text joins the cached prompt prefix once loaded. Static, short, stable bod
 
 ## Update flow
 
-1. Read `SKILL.md` and every file under `references/`, `scripts/`, `assets/`.
+1. Read `header.toml` when present, `SKILL.md`, and every file under `references/`, `scripts/`, `assets/`.
 2. Identify original intent before changing it.
 3. Diagnose: description triggers, instruction quality, structure, bundled resources, drift.
 4. Preserve the `name` field and the directory name exactly. Never rename a live skill in place.
@@ -107,9 +118,9 @@ Skills are not semver. Treat changes as:
 
 ## Output
 
-When invoked to **create**, produce the new `SKILL.md` (and any references) in fenced blocks ready to save, at the correct path.
+When invoked to **create**, produce `header.toml` and body-only `SKILL.md` in this repository, or a complete native `SKILL.md` elsewhere (and any references) in fenced blocks ready to save, at the correct path.
 
-When invoked to **update**, produce the edited `SKILL.md` (and changed references) in fenced blocks plus a brief changelog: `Changed`, `Rationale`. Preserve unchanged sections verbatim.
+When invoked to **update**, produce the changed metadata, `SKILL.md`, and references in fenced blocks plus a brief changelog: `Changed`, `Rationale`. Preserve unchanged sections verbatim.
 
 If invoked as a sub-agent for routing reasons, follow the response contract from `delegate-task`: start non-artefact work with `Answer:`; return raw artefacts only when the artefact is the deliverable.
 

--- a/home-manager/_mixins/agentic/assistants/skills/write-skill/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/write-skill/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "write-skill"
+description = "Use when creating, updating, or reviewing an Agent Skill - authoring or revising a `SKILL.md`, its frontmatter, layout, references, and progressive disclosure. Use when the user mentions writing, editing, splitting, renaming, or auditing a skill, even if they do not say \"skill\" explicitly. Covers cross-platform portability across Claude Code, Codex, OpenCode, and Pi."

--- a/home-manager/_mixins/agentic/assistants/skills/write-skill/references/portability.md
+++ b/home-manager/_mixins/agentic/assistants/skills/write-skill/references/portability.md
@@ -24,9 +24,13 @@ Use the smallest set that works. Add fields only when a target needs them.
 
 Adding these to a portable skill is harmless on Codex/OpenCode/Pi (ignored), but they confuse human readers. Restrict to skills that target Claude Code only.
 
+## Repository routing limits
+
+The composer rejects `[routing.opencode]` and `[routing.codex]` on ordinary skills. These runtimes lack native per-skill model selection in this composition path. Use an agent-backed command for a workflow that needs model or effort pins.
+
 ## Codex companion
 
-Codex supports `<skill>/agents/openai.yaml` for UI metadata and `policy.allow_implicit_invocation`. Ordinary reusable skills keep their existing policy or Codex's default implicit invocation. This repository's composer sets `policy.allow_implicit_invocation: false` for every command-derived skill, including secret commands. Keep that mandatory command policy separate from ordinary skills and portable `SKILL.md` frontmatter.
+Codex supports `<skill>/agents/openai.yaml` for UI metadata and `policy.allow_implicit_invocation`. In this repository, author companion fields under `[codex]` in `header.toml`, with policy under `[codex.policy]`. Ordinary reusable skills keep their existing policy or Codex's default implicit invocation. This repository's composer sets `policy.allow_implicit_invocation: false` for every command-derived skill, including secret commands. Keep that mandatory command policy separate from ordinary skills and portable `SKILL.md` frontmatter.
 
 The policy controls implicit selection, not explicit file reads within an authorised workflow. A `$child` reference inside a loaded skill does not recursively load the child. Read dependent instructions through the available catalogue or configured skill roots before applying them.
 

--- a/home-manager/_mixins/agentic/assistants/skills/writing-well/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/writing-well/SKILL.md
@@ -1,7 +1,3 @@
----
-name: writing-well
-description: "Use when drafting or revising a prose artefact: documentation, a README, a blog post, a technical guide, a migration guide, release notes, a video script, or long-form explanatory content. Covers composition principles (active voice, concrete language, omitting needless words, emphatic endings, parallel structure, keeping related words together) and the catalogue of AI writing patterns, including puffery, superficial '-ing' analysis, copulative avoidance, chatbot leakage, and overused vocabulary."
----
 
 # Writing Well
 

--- a/home-manager/_mixins/agentic/assistants/skills/writing-well/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/writing-well/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "writing-well"
+description = "Use when drafting or revising a prose artefact: documentation, a README, a blog post, a technical guide, a migration guide, release notes, a video script, or long-form explanatory content. Covers composition principles (active voice, concrete language, omitting needless words, emphatic endings, parallel structure, keeping related words together) and the catalogue of AI writing patterns, including puffery, superficial '-ing' analysis, copulative avoidance, chatbot leakage, and overused vocabulary."

--- a/home-manager/_mixins/agentic/assistants/skills/zk/SKILL.md
+++ b/home-manager/_mixins/agentic/assistants/skills/zk/SKILL.md
@@ -1,7 +1,3 @@
----
-name: zk
-description: Handles requested maintenance of the zk notebook at ~/Notes. Use when the user asks to create, find, search, update, rewrite, rename, split, merge, or reorganise notes there, or names zk for notebook work. Includes title changes, filenames, links, attachments, metadata, and bulk reorganisation. Does not provide automatic agent memory, session capture, or a prescribed Zettelkasten method. Do not load for unrelated Markdown files or general uses of the word notes.
----
 
 # zk
 

--- a/home-manager/_mixins/agentic/assistants/skills/zk/header.toml
+++ b/home-manager/_mixins/agentic/assistants/skills/zk/header.toml
@@ -1,0 +1,3 @@
+[common]
+name = "zk"
+description = "Handles requested maintenance of the zk notebook at ~/Notes. Use when the user asks to create, find, search, update, rewrite, rename, split, merge, or reorganise notes there, or names zk for notebook work. Includes title changes, filenames, links, attachments, metadata, and bulk reorganisation. Does not provide automatic agent memory, session capture, or a prescribed Zettelkasten method. Do not load for unrelated Markdown files or general uses of the word notes."

--- a/home-manager/_mixins/agentic/assistants/tests/test_metadata.py
+++ b/home-manager/_mixins/agentic/assistants/tests/test_metadata.py
@@ -1,0 +1,315 @@
+"""Regression tests for generated provider metadata.
+
+Run with: python -m unittest discover -s home-manager/_mixins/agentic/assistants/tests
+Requires Nix and PyYAML. No configuration is built or activated.
+"""
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import tomllib
+import unittest
+
+import yaml
+
+
+ASSISTANTS = Path(__file__).resolve().parents[1]
+REPO = ASSISTANTS.parents[3]
+
+
+class MetadataTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        result = subprocess.run(
+            ["nix", "eval", "--impure", "--raw", "--expr",
+             f'(builtins.getFlake {json.dumps(str(REPO))}).inputs.nixpkgs.outPath'],
+            capture_output=True, text=True, check=True,
+        )
+        cls.nixpkgs = result.stdout
+
+    def evaluate(self, expression, header=None, success=True, files=None):
+        with tempfile.TemporaryDirectory(prefix="assistant-metadata-test-") as directory:
+            if header is not None:
+                Path(directory, "header.toml").write_text(header)
+            for name, content in (files or {}).items():
+                path = Path(directory, name)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content)
+            expression = (
+                f'let lib = import {self.nixpkgs}/lib; '
+                f'm = import {ASSISTANTS}/metadata.nix {{ inherit lib; }}; '
+                f'c = import {ASSISTANTS}/compose.nix {{ inherit lib; }}; '
+                f'fixture = builtins.toPath {json.dumps(directory)}; '
+                f'h = m.readHeader fixture; '
+                f'in {expression}'
+            )
+            result = subprocess.run(
+                ["nix", "eval", "--impure", "--json", "--expr", expression],
+                capture_output=True, text=True,
+            )
+        if success:
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return json.loads(result.stdout)
+        self.assertNotEqual(result.returncode, 0, "Invalid metadata was accepted")
+        return result.stderr
+
+    def test_nested_values_and_false_survive_both_output_formats(self):
+        header = '''
+[common]
+name = "fixture"
+description = "A description: with # punctuation and \\"quotes\\"."
+[pi]
+inheritSkills = false
+maxDepth = 0
+[pi.extension]
+enabled = false
+labels = ["first", "second"]
+'''
+        result = self.evaluate('let p = m.project "agent" "pi" "fixture" h; in '
+                               '{ yaml = m.renderYaml p; toml = m.renderToml p; }', header)
+        expected = {
+            "name": "fixture", "description": 'A description: with # punctuation and "quotes".',
+            "systemPromptMode": "append", "inheritProjectContext": False,
+            "inheritSkills": False, "maxDepth": 0,
+            "extension": {"enabled": False, "labels": ["first", "second"]},
+        }
+        self.assertEqual(yaml.safe_load(result["yaml"]), expected)
+        self.assertEqual(tomllib.loads(result["toml"]), expected)
+
+    def test_only_selected_provider_fields_reach_frontmatter(self):
+        header = '''
+[common]
+description = "Task description"
+argument-hint = "<path>"
+[claude]
+context = "fork"
+[opencode]
+subtask = false
+[pi]
+extension = "pi-only"
+[compose.claude]
+use-task = true
+[routing.claude]
+model = "sonnet"
+effort = "high"
+[routing.pi.openai-codex]
+model = "gpt-5.6-terra"
+thinking = "medium"
+'''
+        result = self.evaluate('{ claude = m.project "command" "claude" "task" h; '
+                               'pi = m.project "command" "pi" "task" h; '
+                               'codex = m.project "command" "codex" "task" h; }', header)
+        self.assertEqual(result["claude"], {
+            "description": "Task description", "argument-hint": "<path>",
+            "context": "fork", "model": "sonnet", "effort": "high",
+        })
+        self.assertEqual(result["pi"], {
+            "description": "Task description", "argument-hint": "<path>", "extension": "pi-only",
+        })
+        self.assertEqual(result["codex"], {"description": "Task description"})
+
+    def test_pi_defaults_and_explicit_overrides(self):
+        result = self.evaluate('{ defaults = m.project "agent" "pi" "worker" {}; '
+                               'overrides = m.project "agent" "pi" "worker" h; }', '''
+[pi]
+systemPromptMode = "replace"
+inheritProjectContext = true
+inheritSkills = false
+''')
+        self.assertEqual(result["defaults"], {
+            "name": "worker", "systemPromptMode": "append",
+            "inheritProjectContext": False, "inheritSkills": True,
+        })
+        self.assertEqual(result["overrides"], {
+            "name": "worker", "systemPromptMode": "replace",
+            "inheritProjectContext": True, "inheritSkills": False,
+        })
+
+    def test_native_model_settings_cannot_compete_with_routing(self):
+        for provider in ("common", "claude", "opencode", "codex", "pi"):
+            with self.subTest(provider=provider):
+                error = self.evaluate("h", f'[{provider}]\nmodel = "native-model"\n'
+                                      '[routing.codex]\nmodel = "route-model"\n', success=False)
+                self.assertIn("routing", error)
+
+    def test_invalid_routing_and_non_boolean_controls_fail(self):
+        for header in (
+            '[routing.pi.openai-codex]\nthinking = "ultra"\n',
+            '[routing.codex]\nmodel = ""\n',
+            '[routing.codex]\nreasoningEffort = "high"\n',
+            '[compose.codex]\nspawn-agent = "false"\n',
+        ):
+            with self.subTest(header=header):
+                self.evaluate("h", header, success=False)
+
+    def test_opencode_options_cannot_bypass_routing(self):
+        error = self.evaluate("h", '''
+[opencode.options]
+reasoningEffort = "low"
+''', success=False)
+        self.assertIn("Model settings belong exclusively in routing tables.", error)
+        result = self.evaluate('m.project "agent" "opencode" "fixture" h', '''
+[opencode.options]
+textVerbosity = "low"
+store = false
+[opencode.metadata]
+model = "A descriptive label"
+[routing.opencode]
+reasoningEffort = "high"
+''')
+        self.assertEqual(result, {
+            "options": {"textVerbosity": "low", "store": False},
+            "metadata": {"model": "A descriptive label"},
+            "reasoningEffort": "high",
+        })
+
+    def test_pi_skill_routing_is_absent_from_native_frontmatter(self):
+        result = self.evaluate('m.project "skill" "pi" "fixture" h', '''
+[common]
+name = "fixture"
+description = "A directly invoked skill."
+[routing.pi.openai-codex]
+model = "test-model"
+thinking = "high"
+''')
+        self.assertEqual(result, {"name": "fixture", "description": "A directly invoked skill."})
+
+    def test_unsupported_skill_routing_fails_instead_of_disappearing(self):
+        for provider in ("codex", "opencode"):
+            with self.subTest(provider=provider):
+                self.evaluate(f'm.project "skill" "{provider}" "fixture" h',
+                              '[common]\nname = "fixture"\ndescription = "Fixture."\n'
+                              f'[routing.{provider}]\nmodel = "test-model"\n', success=False)
+
+    def test_migrated_garfield_routes_preserve_model_pins(self):
+        result = self.evaluate('{ models = c.extractAgentProviderModels "garfield"; '
+                               'thinking = c.extractAgentProviderThinking "garfield"; }')
+        self.assertEqual(result, {
+            "models": {"anthropic": "claude-sonnet-5", "google": "gemini-3-flash",
+                       "openai-codex": "gpt-5.6-terra"},
+            "thinking": {"openai-codex": "medium"},
+        })
+
+    def test_codex_command_pin_uses_a_separate_role(self):
+        result = self.evaluate('''{
+          pinned = m.commandDispatch { worker = true; } "review" "worker" h;
+          ordinary = m.commandDispatch { worker = true; } "inspect" "worker" {};
+        }''', '''
+[routing.codex]
+model = "command-model"
+model_reasoning_effort = "high"
+''')
+        self.assertEqual(result["pinned"]["role"], "command-review")
+        self.assertEqual(result["pinned"]["selectedAgent"], "worker")
+        self.assertEqual(result["pinned"]["route"], {
+            "model": "command-model", "model_reasoning_effort": "high",
+        })
+        self.assertEqual(result["ordinary"]["role"], "worker")
+        self.assertEqual(result["ordinary"]["route"], {})
+
+    def test_standalone_codex_commands_remain_inline_unless_an_agent_is_selected(self):
+        result = self.evaluate('''{
+          inline = m.commandDispatch { worker = true; } "plain" null {};
+          delegated = m.commandDispatch { worker = true; } "review" null h;
+        }''', '''
+[compose]
+agent = "worker"
+[routing.codex]
+model = "command-model"
+''')
+        self.assertIsNone(result["inline"]["selectedAgent"])
+        self.assertIsNone(result["inline"]["role"])
+        self.assertEqual(result["delegated"]["selectedAgent"], "worker")
+        self.assertEqual(result["delegated"]["role"], "command-review")
+        self.assertTrue(result["delegated"]["spawn"])
+
+    def test_codex_inline_routes_and_unknown_agents_fail(self):
+        for agent, header in (
+            ("null", '[routing.codex]\nmodel = "test-model"\n'),
+            ('"worker"', '[compose.codex]\nspawn-agent = false\n'
+                         '[routing.codex]\nmodel = "test-model"\n'),
+            ('"worker"', '[compose]\nagent = "missing"\n'),
+        ):
+            with self.subTest(agent=agent, header=header):
+                self.evaluate(f'm.commandDispatch {{ worker = true; }} "review" {agent} h',
+                              header, success=False)
+
+    def test_codex_commands_cannot_enable_implicit_invocation(self):
+        result = self.evaluate('m.commandPolicy h', '''
+[codex]
+allow-implicit-invocation = false
+''')
+        self.assertFalse(result["policy"]["allow_implicit_invocation"])
+        self.assertFalse(self.evaluate('m.commandPolicy {}')["policy"]["allow_implicit_invocation"])
+        for value in ("true", '\"false\"'):
+            with self.subTest(value=value):
+                self.evaluate('m.commandPolicy h',
+                              f'[codex]\nallow-implicit-invocation = {value}\n', success=False)
+
+    def test_codex_skill_companion_fields_do_not_leak_into_frontmatter(self):
+        result = self.evaluate('''{
+          frontmatter = m.project "skill" "codex" "fixture" h;
+          companion = m.renderYaml (m.skillCompanion fixture);
+        }''', '''
+[common]
+name = "fixture"
+description = "A directly invoked skill."
+[codex.interface]
+display_name = "Fixture skill"
+[codex.policy]
+allow_implicit_invocation = false
+[codex.dependencies]
+tools = [{ type = "mcp", value = "fixture-service" }]
+''')
+        self.assertEqual(result["frontmatter"], {
+            "name": "fixture", "description": "A directly invoked skill.",
+        })
+        self.assertEqual(yaml.safe_load(result["companion"]), {
+            "interface": {"display_name": "Fixture skill"},
+            "policy": {"allow_implicit_invocation": False},
+            "dependencies": {"tools": [{"type": "mcp", "value": "fixture-service"}]},
+        })
+
+    def test_codex_companion_is_deployable_for_root_and_nested_skills(self):
+        header = '''
+[common]
+name = "NAME"
+description = "A directly invoked skill."
+[codex.policy]
+allow_implicit_invocation = false
+'''
+        files = {
+            "styles/house-style/house-style.md": "Use plain language.\n",
+            "skills/communication-rules/SKILL.md": "Use plain language.\n",
+            "skills/fixture/header.toml": header.replace("NAME", "fixture"),
+            "skills/fixture/SKILL.md": "Run the fixture.\n",
+            "skills/fixture/references/nested/header.toml": header.replace("NAME", "nested"),
+            "skills/fixture/references/nested/SKILL.md": "Run the nested fixture.\n",
+        }
+        result = self.evaluate('''let
+          fixtureComposer = import ''' + str(ASSISTANTS) + '''/compose.nix {
+            inherit lib;
+            basePath = fixture;
+            pkgs = {
+              writeText = name: text: text;
+              linkFarm = name: entries: { overrideAttrs = _: entries; };
+            };
+          };
+          skill = (fixtureComposer.composeSkillsFor "codex").fixture;
+        in { inherit (skill) content extras path; }''', files=files)
+        self.assertEqual(result["extras"]["agents"], "directory")
+        self.assertEqual(result["extras"]["references"], "directory")
+        self.assertNotIn("header.toml", result["extras"])
+        entries = {entry["name"]: entry["path"] for entry in result["path"]}
+        for prefix in ("", "references/nested/"):
+            with self.subTest(prefix=prefix):
+                companion = yaml.safe_load(entries[prefix + "agents/openai.yaml"])
+                self.assertIs(companion["policy"]["allow_implicit_invocation"], False)
+                frontmatter = yaml.safe_load(entries[prefix + "SKILL.md"].split("---", 2)[1])
+                self.assertNotIn("policy", frontmatter)
+                self.assertNotIn(prefix + "header.toml", entries)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/home-manager/_mixins/agentic/assistants/tests/test_skill_files.py
+++ b/home-manager/_mixins/agentic/assistants/tests/test_skill_files.py
@@ -16,6 +16,52 @@ REPO = ASSISTANTS.parents[3]
 
 
 class SkillFileTests(unittest.TestCase):
+    def test_pi_routes_include_secret_skills_with_public_headers(self):
+        files = {
+            "skills/routed/SKILL.sops": "fixture-routed\n",
+            "skills/routed/header.toml": '''[common]
+name = "routed"
+description = "An encrypted fixture skill."
+[routing.pi.openai]
+model = "fixture-model"
+thinking = "high"
+''',
+            "skills/self-review/SKILL.sops": "fixture-headerless\n",
+            "skills/public/SKILL.md": "Run the public fixture.\n",
+            "skills/public/header.toml": '''[common]
+name = "public"
+description = "A public fixture skill."
+''',
+        }
+        with tempfile.TemporaryDirectory(prefix="assistant-skill-routes-") as directory:
+            for name in ("default.nix", "compose.nix", "metadata.nix"):
+                Path(directory, name).write_text((ASSISTANTS / name).read_text())
+            for name, content in files.items():
+                path = Path(directory, name)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content)
+            expression = f'''let
+              flake = builtins.getFlake {json.dumps(str(REPO))};
+              pkgs = import flake.inputs.nixpkgs {{ system = builtins.currentSystem; }};
+              assistants = import {directory}/default.nix {{
+                inherit pkgs;
+                inherit (pkgs) lib;
+                config = {{}};
+                noughtyLib = {{}};
+              }};
+            in assistants.config.agentic.assistants.pi.invocationRoutes.skills'''
+            result = subprocess.run(
+                ["nix", "eval", "--impure", "--json", "--expr", expression],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(result.stdout), {
+                "public": {"providers": {}},
+                "routed": {"providers": {
+                    "openai": {"model": "fixture-model", "thinking": "high"},
+                }},
+            })
+
     def test_codex_discovers_regular_root_and_nested_skill_files(self):
         header = '''[common]
 name = "NAME"

--- a/home-manager/_mixins/agentic/assistants/tests/test_skill_files.py
+++ b/home-manager/_mixins/agentic/assistants/tests/test_skill_files.py
@@ -1,0 +1,93 @@
+"""Build skill trees and check Codex discovery without activating a configuration."""
+
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+ASSISTANTS = Path(__file__).resolve().parents[1]
+REPO = ASSISTANTS.parents[3]
+
+
+class SkillFileTests(unittest.TestCase):
+    def test_codex_discovers_regular_root_and_nested_skill_files(self):
+        header = '''[common]
+name = "NAME"
+description = "A fixture skill."
+[codex.policy]
+allow_implicit_invocation = false
+'''
+        files = {
+            "styles/house-style/house-style.md": "Use plain language.\n",
+            "skills/communication-rules/SKILL.md": "Use plain language.\n",
+            "skills/delegate-task/header.toml": header.replace("NAME", "delegate-task"),
+            "skills/fixture/header.toml": header.replace("NAME", "fixture"),
+            "skills/fixture/SKILL.md": "Run the fixture.\n",
+            "skills/fixture/references/nested/header.toml": header.replace("NAME", "nested"),
+            "skills/fixture/references/nested/SKILL.md": "Run the nested fixture.\n",
+            "skills/fixture/references/nested/guide.md": "Keep this supporting file.\n",
+            "skills/fixture/references/legacy/SKILL.md":
+                "---\nname: legacy\ndescription: Legacy fixture.\n---\n\nKeep this skill.\n",
+        }
+        with tempfile.TemporaryDirectory(prefix="assistant-skill-files-") as directory:
+            for name, content in files.items():
+                path = Path(directory, name)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content)
+            expression = f'''let
+              flake = builtins.getFlake {json.dumps(str(REPO))};
+              pkgs = import flake.inputs.nixpkgs {{ system = builtins.currentSystem; }};
+              composer = import {ASSISTANTS}/compose.nix {{
+                inherit pkgs;
+                inherit (pkgs) lib;
+                basePath = builtins.path {{ path = {json.dumps(directory)}; }};
+              }};
+              skills = composer.composeSkillsFor "codex";
+            in [ skills.fixture.path skills.delegate-task.path ]'''
+            result = subprocess.run(
+                ["nix", "build", "--impure", "--json", "--no-link", "--expr", expression],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            trees = [Path(item["outputs"]["out"]) for item in json.loads(result.stdout)]
+            tree = next(path for path in trees if path.name.endswith("-skill-fixture"))
+            generated = next(path for path in trees if path.name.endswith("-skill-delegate-task"))
+            deployed = Path(directory, "deployed")
+            deployed.mkdir()
+            (deployed / "SKILL.md").write_text((tree / "SKILL.md").read_text())
+            (deployed / "references").symlink_to(tree / "references", target_is_directory=True)
+            discovered = set()
+            pending = [deployed]
+            while pending:
+                with os.scandir(pending.pop()) as entries:
+                    for entry in entries:
+                        if entry.is_dir():
+                            pending.append(Path(entry.path))
+                        elif entry.name == "SKILL.md" and entry.is_file(follow_symlinks=False):
+                            discovered.add(Path(entry.path).relative_to(deployed).as_posix())
+            self.assertEqual(discovered, {
+                "SKILL.md", "references/nested/SKILL.md", "references/legacy/SKILL.md",
+            })
+            self.assertTrue(stat.S_ISREG((generated / "SKILL.md").lstat().st_mode))
+            for name in discovered:
+                self.assertTrue(stat.S_ISREG((tree / name).lstat().st_mode), name)
+            for prefix in ("", "references/nested/"):
+                with self.subTest(prefix=prefix):
+                    skill = (tree / prefix / "SKILL.md").read_text()
+                    self.assertNotIn("policy", yaml.safe_load(skill.split("---", 2)[1]))
+                    companion = yaml.safe_load((tree / prefix / "agents/openai.yaml").read_text())
+                    self.assertIs(companion["policy"]["allow_implicit_invocation"], False)
+                    self.assertFalse((tree / prefix / "header.toml").exists())
+            for name in ("references/nested/guide.md", "references/legacy/SKILL.md"):
+                self.assertEqual((tree / name).read_text(), files["skills/fixture/" + name])
+            self.assertTrue((tree / "references/nested/guide.md").is_symlink())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/home-manager/_mixins/agentic/codex/README.md
+++ b/home-manager/_mixins/agentic/codex/README.md
@@ -85,6 +85,8 @@ Every generated skill is explicitly enabled in `config.toml` with `[[skills.conf
 
 Skills are written as real files via the shared assistants activation. Codex's scanner does not reliably follow symlinked skill files on Linux.
 
+Activation updates exact owned destinations instead of clearing the skills or agents directory. It preserves manual files, plugins, and modified former outputs. A conflicting unknown or modified destination stops helper writes. See [activation ownership and cleanup](../assistants/README.md#activation-ownership-and-cleanup) for migration and recovery limits.
+
 SKILL.md frontmatter requires `name:` and `description:` fields. Quote any `description:` value containing `: `, or Codex fails to parse the skill.
 
 ### Command Skills
@@ -101,7 +103,7 @@ policy:
 
 The policy excludes commands from implicit selection while preserving explicit user invocation. It is not an access restriction. Ordinary reusable skills retain their existing policies. The policy belongs in `agents/openai.yaml`, not in `SKILL.md` frontmatter.
 
-Each agent command uses its bare name, such as `$draft-commit-message`, which matches the Pi prompt convention. Agent commands dispatch to their owning specialist through `spawn_agent` by default. The parent remains the orchestrator. A command with `spawn-agent = false` in `header.codex.toml` embeds the owning persona and task prompt in the caller's context.
+Each agent command uses its bare name, such as `$draft-commit-message`, which matches the Pi prompt convention. Agent commands dispatch to their owning specialist through `spawn_agent` by default. The parent remains the orchestrator. A command with `spawn-agent = false` under `[compose.codex]` in `header.toml` embeds the owning persona and task prompt in the caller's context.
 
 ```text
 $draft-commit-message
@@ -132,7 +134,7 @@ Keep agent launch wrappers unless the calling workflow explicitly requires same-
 
 Agent role files live in `~/.codex/agents/*.toml`. They define roles available to Codex's `spawn_agent` tool, alongside built-in roles such as `explorer` and `worker`.
 
-Agent files are composed from `prompt.md`, `description.txt`, and `header.codex.toml`. The Codex header carries role-local config such as `model = "gpt-5.5"` and `model_reasoning_effort = "high"`.
+Agent files are composed from `prompt.md` and `header.toml`. `[common] description` supplies the description. Native non-model role settings belong under `[codex]`. Model and effort pins belong under `[routing.codex]`, with fields `model` and `model_reasoning_effort`.
 
 The files must be real TOML files, not symlinks. Codex's role discovery skips symlinked role files on Linux.
 
@@ -152,9 +154,8 @@ Fence owns filesystem isolation, network access, and command denials for this
 entry point. The Codex bypass flag prevents a second policy layer from
 interfering with the shared Fence configuration.
 
-Activation removes stale policy keys and generated rule files from both legacy
-and XDG Codex homes so Fence remains the only managed permission and isolation
-provider.
+Activation removes stale managed policy keys from both legacy and XDG Codex
+configurations. It leaves unverified legacy rule files untouched.
 
 Use `codex-fenced` when the shared Fence policy should be the only isolation and command boundary.
 
@@ -186,13 +187,13 @@ codex/
 assistants/
 ├── agents/<name>/
 │   ├── prompt.md
-│   ├── description.txt
+│   ├── header.toml
 │   └── commands/<cmd>/
 │       ├── prompt.md
-│       └── description.txt
+│       └── header.toml
 ├── commands/<name>/
 │   ├── prompt.md
-│   └── description.txt
+│   └── header.toml
 ├── skills/<name>/
 │   └── SKILL.md
 ├── compose.nix

--- a/home-manager/_mixins/agentic/codex/default.nix
+++ b/home-manager/_mixins/agentic/codex/default.nix
@@ -659,8 +659,6 @@ let
       if [ -L "$target_dir/config.toml" ]; then
         rm "$target_dir/config.toml"
       fi
-      rm -f "$target_dir/rules/default.rules"
-      rmdir "$target_dir/rules" 2>/dev/null || true
       ${tomlMergePython}/bin/python ${codexConfigMergeScriptFixed} ${codexConfigToml} "$target_dir/config.toml"
       chmod 644 "$target_dir/config.toml"
     }

--- a/home-manager/_mixins/agentic/pi/README.md
+++ b/home-manager/_mixins/agentic/pi/README.md
@@ -151,7 +151,7 @@ Home Manager deploys local Pi extensions under `~/.pi/agent/extensions/`.
 
 `provider-router` lives at `~/.pi/agent/extensions/provider-router/`. It routes
 Pi `subagent` tool calls to provider-specific models declared in assistant
-`header.pi.yaml` files.
+`header.toml` files under `[routing.pi.<inference-provider>]`.
 
 `quota-status` lives at `~/.pi/agent/extensions/quota-status/`. It listens to
 `sub-core` quota updates and publishes the compact quota segment consumed by
@@ -301,7 +301,7 @@ The extension config is managed at `~/.pi/agent/extensions/subagent/config.json`
 }
 ```
 
-`maxSubagentDepth = 1` allows explicit direct subagent use from top-level Pi sessions. Generated assistant agents do not add a per-agent `maxSubagentDepth` by default; set `maxSubagentDepth` in an individual `header.pi.yaml` only when that agent needs its own depth limit.
+`maxSubagentDepth = 1` allows explicit direct subagent use from top-level Pi sessions. Generated assistant agents do not add a per-agent `maxSubagentDepth` by default; set `[pi] maxSubagentDepth` in an individual `header.toml` only when that agent needs its own depth limit.
 
 The builtin `researcher` agent is disabled by default because it requires `pi-web-access`, which this module does not install.
 
@@ -312,14 +312,18 @@ Source content comes from `home-manager/_mixins/agentic/assistants`. Rendering f
 | Source                                          | Pi destination                     | Mapping                                                                                                                                                                                                                                                                                                            |
 | ----------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `instructions/global.md`                        | `~/.pi/agent/AGENTS.md`            | Global context file loaded by Pi                                                                                                                                                                                                                                                                                   |
-| `agents/<name>/prompt.md` and `description.txt` | `~/.pi/agent/agents/<name>.md`     | Pi subagent Markdown with YAML frontmatter                                                                                                                                                                                                                                                                         |
+| `agents/<name>/prompt.md` and `header.toml` | `~/.pi/agent/agents/<name>.md`     | Pi subagent Markdown with YAML frontmatter                                                                                                                                                                                                                                                                         |
 | `agents/<name>/commands/<command>/prompt.md`    | `~/.pi/agent/prompts/<command>.md` | Prompt template that asks Pi to call the matching subagent. The owning agent is pinned by a `Use the subagent tool to launch the <name> agent` prelude in the body, not by the filename. Evaluation fails if two source directories (across agents or with standalone commands) produce the same `<command>` name. |
 | `commands/<command>/prompt.md`                  | `~/.pi/agent/prompts/<command>.md` | Native Pi prompt template                                                                                                                                                                                                                                                                                          |
 | `skills/<name>/`                                | `~/.pi/agent/skills/<name>/`       | Symlinked Agent Skills directory                                                                                                                                                                                                                                                                                   |
 
 Traya is the unnamed default prompt through `instructions/global.md`. She is not emitted as a named Pi subagent.
 
-Pi agent frontmatter is sourced from `header.pi.yaml`. When the file is absent the agent inherits three defaults: `systemPromptMode: append`, `inheritProjectContext: false`, and `inheritSkills: true`. `name` and `description` are injected automatically from the directory name and `description.txt`. Per-agent values for `model`, `thinking`, `tools`, `defaultContext`, `maxSubagentDepth`, and other Pi-native fields go in `header.pi.yaml` alongside `header.claude.yaml` and `header.codex.toml`. Prompt templates use `header.pi.yaml` for `argument-hint` rather than reading the Claude header.
+The next successful activation retires the approved legacy regular file `~/.pi/agent/agents/traya.md` once. It preserves a symlink or other non-regular path. Public resource links remain Home Manager-owned. Secret resource links use the shared [activation ownership and cleanup](../assistants/README.md#activation-ownership-and-cleanup) helper.
+
+Pi agent frontmatter comes from `header.toml`. Agents retain three generated defaults: `systemPromptMode: append`, `inheritProjectContext: false`, and `inheritSkills: true`. Explicit `[pi]` values override these defaults. Names derive from directories, and descriptions come from `[common] description`.
+
+Native non-model fields, such as `tools`, `defaultContext`, and `maxSubagentDepth`, belong under `[pi]`. Model and thinking overrides belong under `[routing.pi.<inference-provider>]`. Prompt templates receive `argument-hint` from `[common]` or `[pi]`. Missing tables mean no overrides, not disabled output.
 
 Pi subagent Markdown supports explicit `tools` allowlists through Pi-native
 frontmatter when an individual agent needs a narrower tool surface.

--- a/home-manager/_mixins/agentic/pi/default.nix
+++ b/home-manager/_mixins/agentic/pi/default.nix
@@ -292,7 +292,7 @@ let
       # extension, and custom tools, so injecting only the built-in names
       # would hide every extension tool (subtask, lens, footer widgets,
       # MCP/adapter tools, etc.). Per-agent allowlists are expressed in the
-      # agent's Pi-native frontmatter (`tools:` in `header.pi.yaml`).
+      # agent's Pi-native frontmatter (`pi.tools` in `header.toml`).
       exec "${lib.getExe piPackage}" "''${pi_resume[@]}" "$@"
     '';
   };
@@ -797,6 +797,8 @@ lib.mkIf (noughtyLib.userHasTag "developer") {
         builtins.toJSON piAssistant.providerRouterMap;
       ".pi/agent/extensions/provider-router/thinking.json".text =
         builtins.toJSON piAssistant.providerRouterThinkingMap;
+      ".pi/agent/extensions/provider-router/routes.json".text =
+        builtins.toJSON piAssistant.invocationRoutes;
       ".pi/agent/extensions/provider-router/index.ts".source = ./extensions/provider-router/index.ts;
       ".pi/agent/extensions/provider-router/types.d.ts".source = ./extensions/provider-router/types.d.ts;
       ".pi/agent/extensions/provider-router/LICENSE".source = ./extensions/provider-router/LICENSE;

--- a/home-manager/_mixins/agentic/pi/extensions/prompt-template-display/index.test.ts
+++ b/home-manager/_mixins/agentic/pi/extensions/prompt-template-display/index.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
 import register from "./index.ts";
+import registerRouter from "../provider-router/index.ts";
 
 const tempDirs = [];
 afterEach(async () =>
@@ -30,6 +31,7 @@ function harness(commands = []) {
 	let renderer;
 	let beforeAgentStarts = 0;
 	const pi = {
+		events: { on: (name, fn) => { handlers[name] = fn; return () => delete handlers[name]; }, emit: (name, data) => handlers[name]?.(data) },
 		getCommands: () => commands,
 		registerEntryRenderer: (_type, value) => {
 			renderer = value;
@@ -45,6 +47,7 @@ function harness(commands = []) {
 			sentUsers.push({ content, options });
 		},
 	};
+	registerRouter(pi);
 	register(pi);
 	const invoke = (event, mode = "tui") =>
 		handlers.input(event, {

--- a/home-manager/_mixins/agentic/pi/extensions/prompt-template-display/index.ts
+++ b/home-manager/_mixins/agentic/pi/extensions/prompt-template-display/index.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { Box, Text } from "@earendil-works/pi-tui";
+import { routeInvocation } from "../provider-router/index.ts";
 
 const ENTRY_TYPE = "prompt-template-command";
 const MESSAGE_TYPE = "prompt-template-expanded";
@@ -186,6 +187,16 @@ export default function registerPromptTemplateDisplay(pi: ExtensionAPI): void {
 			templateBody(source),
 			parseCommandArgs(invocation[2] ?? ""),
 		);
+		try {
+			if (
+				!(await routeInvocation(event.text, ctx, event.streamingBehavior, pi))
+			) {
+				return { action: "handled" };
+			}
+		} catch (error) {
+			ctx.ui.notify(String(error), "error");
+			return { action: "handled" };
+		}
 		if (event.streamingBehavior) {
 			const content: (TextContent | ImageContent)[] = [
 				{ type: "text", text: expanded },

--- a/home-manager/_mixins/agentic/pi/extensions/prompt-template-display/test-loader.mjs
+++ b/home-manager/_mixins/agentic/pi/extensions/prompt-template-display/test-loader.mjs
@@ -1,3 +1,5 @@
+import { resolve as resolveRouter } from "../provider-router/test-loader.mjs";
+
 const tuiStub = `
 export class Box {
   constructor() { this.children = []; }
@@ -11,11 +13,13 @@ export class Text {
 `;
 
 export async function resolve(specifier, context, nextResolve) {
+	if (context.parentURL?.includes("/node_modules/"))
+		return nextResolve(specifier, context);
 	if (specifier === "@earendil-works/pi-tui") {
 		return {
 			shortCircuit: true,
 			url: `data:text/javascript,${encodeURIComponent(tuiStub)}`,
 		};
 	}
-	return nextResolve(specifier, context);
+	return resolveRouter(specifier, context, nextResolve);
 }

--- a/home-manager/_mixins/agentic/pi/extensions/provider-router/README.md
+++ b/home-manager/_mixins/agentic/pi/extensions/provider-router/README.md
@@ -1,193 +1,135 @@
 # Provider Router
 
-Provider Router is a local Pi extension for subagent model routing. It
-intercepts Pi `tool_call` events for the `subagent` tool. For workflow scripts,
-it wraps `runs.run` and `runs.all` so each child receives the mapped model. For
-legacy structured calls, it writes the child `model` directly. The per-agent
-mapping always wins when the active provider has a model or thinking-level
-entry. Pi then hands the call to `pi-subagents`.
+Provider Router selects models for explicit Pi tasks without changing the inference
+provider. Home Manager generates its maps from unified `header.toml` metadata.
 
-## Deployed Scope
+## Precedence
 
-Home Manager deploys the extension under
-`~/.pi/agent/extensions/provider-router/`. The directory contains
-`agents.json`, `thinking.json`, `index.ts`, `types.d.ts`, `LICENSE`, and `README.md`.
+The first available selection wins for each task:
 
-`index.ts` is the runtime extension. `agents.json` and `thinking.json` are both
-generated from assistant `header.pi.yaml` files. The runtime reads them from
-`~/.pi/agent/extensions/provider-router/`.
+1. An explicit caller model or a user model selection.
+2. A command route.
+3. A directly invoked skill route.
+4. An agent route.
+5. The session model.
 
-## Map Format
+`--model` and native user model changes take priority for the rest of the session.
+A workflow child can supply its own `model`. The router validates that model and
+preserves its selection. Routes cannot select a different inference provider.
 
-`agents.json` is an object keyed by agent name. Each agent value is an object
-keyed by provider name. Each provider value is the model id for that provider.
+## Direct commands and skills
+
+The native `input` event handles `/command` and `/skill:name`. The local
+`prompt-template-display` extension calls the same dispatcher before it consumes
+TUI command input. Both paths validate and stage the route without changing the
+session model. At `before_agent_start`, after prompt preflight, the router applies
+the route through Pi's `setModel` and `setThinkingLevel` APIs.
+
+Routed input requires an idle session. The router rejects routed steering and
+follow-up input with an error. Unrouted input keeps its existing behaviour.
+After `agent_settled`, the router restores the previous session model and thinking
+level. Routes remain active through retries and overflow recovery.
+A user model change cancels restoration and takes priority over later routes.
+Children launched during the task inherit its command or directly invoked skill
+route, unless the caller supplies a model or a more specific command.
+
+Reading a supporting `SKILL.md` never selects a model. The `skills` list on a
+child task also does not select a model.
+
+## Workflow children
+
+The `subagent` tool hook wraps `runs.run` and `runs.all`. Each child specification
+is resolved immediately before its launch. Top-level `await`, `return`, dynamic
+specifications, and the other `runs` methods remain available.
+
+A child can declare `command: "review-code"` or `directSkill: "research-task"`
+to request a route. The wrapper removes these routing fields before native child
+validation. These fields select routing metadata. They do not expand prompt
+content, so the caller must also supply the task instructions.
+
+Legacy single calls, `tasks`, chain steps, parallel chain steps, and
+`action: "append-step"` use the same resolver. Other management actions remain
+unchanged. External extension event-bus delegation does not pass through the
+`tool_call` hook. Use the supported `subagent` workflow path for routed children.
+
+## Generated maps
+
+Home Manager deploys these files under
+`~/.pi/agent/extensions/provider-router/`:
+
+| File | Content |
+|------|---------|
+| `agents.json` | Agent name, inference provider, model ID. |
+| `thinking.json` | Agent name, inference provider, thinking level. |
+| `routes.json` | Command and directly invoked skill routes. |
+
+`routes.json` has this structure:
 
 ```json
 {
-  "garfield": {
-    "anthropic": "claude-sonnet-5",
-    "google": "gemini-3-flash",
-    "openai-codex": "gpt-5.6-terra"
+  "commands": {
+    "review-code": {
+      "agent": "penry",
+      "providers": {
+        "openai-codex": { "model": "gpt-5.6-terra", "thinking": "high" }
+      }
+    }
+  },
+  "skills": {
+    "research-task": {
+      "providers": {
+        "openai-codex": { "thinking": "high" }
+      }
+    }
   }
 }
 ```
 
-For an Anthropic parent session, the runtime writes
-`anthropic/claude-sonnet-5`. For an `openai-codex` parent session, it writes
-`openai-codex/gpt-5.6-terra`.
+Declare routes in the command, skill, or assistant's `header.toml`:
 
-`thinking.json` mirrors that structure with one value per provider drawn from
-Pi's closed set of effort levels (`off`, `minimal`, `low`, `medium`, `high`,
-`xhigh`):
-
-```json
-{
-  "garfield": { "openai-codex": "medium" }
-}
+```toml
+[routing.pi.openai-codex]
+model = "gpt-5.6-terra"
+thinking = "high"
 ```
 
-When both a model and a thinking level are mapped, the runtime emits
-`provider/modelId:thinking`. When only a thinking level is mapped, it reuses
-the active session model id (`ctx.model.id`) as the bare model and emits
-`provider/<active-id>:thinking`. The unsuffixed model id is the only value
-passed to `ctx.modelRegistry.find`; the thinking suffix is Pi routing syntax
-and must not reach the registry lookup.
+Thinking-only routes use the current session model. The accepted levels are
+`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Pi's native
+`getSupportedThinkingLevels` further checks support for the selected model.
 
-## Declaration Format
+## Errors and freshness
 
-Declare provider-specific models and effort in an agent's `header.pi.yaml`. The
-suffix after `model-` or `thinking-` must match the active Pi provider name
-exactly, including hyphens (`openai-codex`, not `openai`):
+Unknown explicit command or skill route names, unavailable models, unsupported
+thinking levels, and malformed map files produce errors. A command or skill with
+routes but no entry for the active provider also produces an error. An agent with
+no route for that provider keeps its existing behaviour.
 
-```yaml
-model-anthropic: claude-sonnet-5
-model-openai-codex: gpt-5.6-terra
-model-google: 'gemini-3-flash'
-thinking-openai-codex: xhigh
-```
+The router uses `modelRegistry.getAvailable()` to validate authenticated models.
+Tool errors return `{ block: true, reason }`, because Pi catches hook exceptions
+and otherwise continues execution. Workflow errors stop the child launch.
+Input errors notify the user and return `handled`.
 
-The provider name is the suffix after `model-` or `thinking-`. The harvester
-accepts plain scalar values, plus matching single or double quotes which it
-strips. It ignores empty values, block scalars, anchors, aliases, unmatched
-quotes, and unquoted values containing `:`. `thinking-<provider>` values are
-validated at evaluation time against the closed set
-`off|minimal|low|medium|high|xhigh`; invalid values fail `nix eval` with a
-clear message. Provider names are not validated; a typo simply becomes a map
-key that never matches the active Pi provider.
-
-Garfield is the only agent in this repo with a `header.pi.yaml`, so he is the
-only agent either map contains. Any agent that does need routing should declare
-both `model-<provider>` and `thinking-<provider>`, so the routing decision is
-readable from the agent's own `header.pi.yaml`. The runtime still accepts
-thinking-only entries (it falls back to `ctx.model.id` for the bare model in
-that case), and bare `model-<provider>` entries without a thinking sibling
-still produce `provider/modelId` without a thinking suffix. Explicit
-`model-<provider>` plus `thinking-<provider>` is the preferred form.
-
-## Runtime Constraints
-
-Provider Router covers the LLM tool-call path only. Current `pi-subagents`
-execution uses `workflowScript`. The router supplies a routing adapter for
-`runs` inside a lexical block. The script keeps its top-level `await` and
-`return` statements. No nested async function is added, because
-`pi-subagents` rejects those functions before child launch.
-
-The adapter routes child specifications passed to `runs.run` and `runs.all`,
-including specifications that the script creates dynamically. It copies the
-other `runs` methods unchanged, including `runs.steer`.
-
-The router retains support for legacy single calls, `tasks[]`, chain steps,
-parallel chain steps, and `action: "append-step"`. It does not change other
-management actions, slash-command calls, or prompt-template-bridge calls. The
-router has no per-project override.
-
-For known agents, the runtime is authoritative. It replaces the child `model`
-whether or not the orchestrator supplied one, and it applies the thinking
-suffix consistently. Unknown agents pass through unchanged. The runtime
-validates the bare model with `ctx.modelRegistry.find(provider, modelId)` before
-it builds the workflow wrapper. The suffixed string never reaches the registry.
-
-When the extension overrides a child model that the orchestrator passed, it
-emits a single line to stderr:
-
-```text
-provider-router: override model for agent=<name> orchestrator=<orig> -> routed=<new>
-```
-
-No log is emitted in the common case where the orchestrator left `model` unset.
-
-## Graceful No-Ops
-
-These miss paths leave the child model unchanged:
-
-1. The agent is absent from both `agents.json` and `thinking.json`.
-2. The agent has no entry for the active provider in either map.
-3. The mapped (or active-session) model is not authenticated locally.
-4. There is no active provider, or no active session model when only a
-   thinking level is mapped.
-
-In all cases, `pi-subagents` receives the original call. Its resolver then
-falls through to `agentConfig.model` from frontmatter. If that is absent, it
-inherits the parent model.
-
-If either sidecar file cannot be read or parsed, the extension uses an empty
-map for that source. Every lookup against that source then follows the first
-miss path.
-
-## Freshness
-
-The extension loads the map at startup. It refreshes the map on Pi
-`session_start` and `resources_discover` events. Long-running sessions may not
-see an out-of-band `home-manager switch`. Run `/reload` or restart the Pi
-session after changing `agents.json`.
+Maps reload on `session_start` and `resources_discover`. After deploying changed
+maps, use `/reload` or start a fresh session. No live session is needed for tests.
 
 ## Verification
 
-Run the regression tests from the repository root with Node.js 24 or later:
+Run the runtime and display tests with Node.js 24 or later:
 
 ```sh
-node --experimental-loader ./home-manager/_mixins/agentic/pi/extensions/provider-router/test-loader.mjs --test home-manager/_mixins/agentic/pi/extensions/provider-router/index.test.mjs
+node --experimental-loader ./home-manager/_mixins/agentic/pi/extensions/provider-router/test-loader.mjs \
+  --experimental-loader ./home-manager/_mixins/agentic/pi/extensions/prompt-template-display/test-loader.mjs \
+  --test home-manager/_mixins/agentic/pi/extensions/provider-router/*.test.mjs \
+  home-manager/_mixins/agentic/pi/extensions/prompt-template-display/index.test.ts
 ```
 
-The tests use the installed `pi-subagents` validator and workflow worker with
-mock child launches. They make no model requests. Set `PI_SUBAGENTS_DIR` to
-test another installation without changing the active Pi session.
-
-Check that Home Manager's evaluated bytes match the deployed maps:
-
-```sh
-home='.#homeConfigurations."martin@skrye".config.home.file'
-agents="$home.\".pi/agent/extensions/provider-router/agents.json\".text"
-thinking="$home.\".pi/agent/extensions/provider-router/thinking.json\".text"
-nix eval --raw "$agents" > /tmp/router-eval.json
-diff /tmp/router-eval.json ~/.pi/agent/extensions/provider-router/agents.json
-nix eval --raw "$thinking" > /tmp/router-thinking-eval.json
-diff /tmp/router-thinking-eval.json ~/.pi/agent/extensions/provider-router/thinking.json
-```
-
-Check deployed files and smoke-test Pi extension loading:
-
-```sh
-test -f ~/.pi/agent/extensions/provider-router/agents.json
-test -f ~/.pi/agent/extensions/provider-router/thinking.json
-test -f ~/.pi/agent/extensions/provider-router/index.ts
-test -f ~/.pi/agent/extensions/provider-router/types.d.ts
-test -f ~/.pi/agent/extensions/provider-router/LICENSE
-test -f ~/.pi/agent/extensions/provider-router/README.md
-pi -p "echo hi" 2>&1 | tee /tmp/pi-provider-router-smoke.log
-! grep -i "failed to load" /tmp/pi-provider-router-smoke.log
-jq '.garfield' ~/.pi/agent/extensions/provider-router/agents.json
-jq '.garfield' ~/.pi/agent/extensions/provider-router/thinking.json
-```
-
-## Current Validation Status
-
-Nix evaluation verifies the generated `agents.json` and `thinking.json` bytes.
-A live Pi session still needs `home-manager switch` and a fresh Pi session, or
-`/reload` in an existing session, before it can exercise the deployed files.
-Do not treat this README as evidence that an interactive Pi session has passed
-provider-routing checks.
+Workflow tests use the installed `pi-subagents` validator and worker with mock
+child launches. Set `PI_SUBAGENTS_DIR` to test another installation. Invocation
+tests use mocked Pi hooks and model APIs. Set `PI_CODING_AGENT_DIR` to the installed
+`@earendil-works/pi-coding-agent` package directory to include native lifecycle tests.
+Those tests use Pi's agent loop and session methods with fake inference and compaction.
+Tests make no model requests and do not change the active Pi session.
 
 ## Licence
 
-BlueOak Model License 1.0.0; see `LICENSE`.
+BlueOak Model License 1.0.0. See `LICENSE`.

--- a/home-manager/_mixins/agentic/pi/extensions/provider-router/index.test.mjs
+++ b/home-manager/_mixins/agentic/pi/extensions/provider-router/index.test.mjs
@@ -21,6 +21,14 @@ writeFileSync(join(mapDir, "agents.json"), JSON.stringify({
 writeFileSync(join(mapDir, "thinking.json"), JSON.stringify({
 	worker: { "openai-codex": "high" },
 }));
+writeFileSync(join(mapDir, "routes.json"), JSON.stringify({
+	commands: {
+		review: { agent: "worker", providers: { "openai-codex": { model: "command-model", thinking: "medium" } } },
+		missing: { providers: { "openai-codex": { model: "unavailable-model" } } },
+		foreign: { providers: { anthropic: { model: "claude-sonnet-5" } } },
+	},
+	skills: { focused: { providers: { "openai-codex": { model: "skill-model", thinking: "low" } } } },
+}));
 const originalHome = process.env.HOME;
 let registerProviderRouter;
 try {
@@ -31,13 +39,17 @@ try {
 	else process.env.HOME = originalHome;
 }
 
-function route(input, provider = "openai-codex") {
+function route(input, provider = "openai-codex", options = {}) {
 	const handlers = new Map();
-	registerProviderRouter({ on: (name, handler) => handlers.set(name, handler) });
-	handlers.get("tool_call")({ toolName: "subagent", input }, {
+	registerProviderRouter({ on: (name, handler) => handlers.set(name, handler), events: { on: () => () => {}, emit: () => {} } });
+	const result = handlers.get("tool_call")({ toolName: options.toolName ?? "subagent", input }, {
 		model: { provider, id: "parent-model" },
-		modelRegistry: { find: (name, id) => name === "openai-codex" && id === "test-model" },
+		modelRegistry: {
+			getAvailable: () => ["test-model", "command-model", "skill-model", "explicit-model", "parent-model"]
+				.map((id) => ({ provider: "openai-codex", id })),
+		},
 	});
+	if (result?.block) throw new Error(result.reason);
 	return input;
 }
 
@@ -45,8 +57,8 @@ function childResult(key, params = {}) {
 	return { key, runId: `test-${key}`, ok: true, output: params.task ?? key, artifactPaths: [] };
 }
 
-async function execute(script) {
-	const input = route({ workflowScript: script });
+async function execute(script, provider = "openai-codex") {
+	const input = route({ workflowScript: script }, provider);
 	assert.deepEqual(validateWorkflowScript(input.workflowScript), { ok: true, errors: [] });
 	const calls = [];
 	const result = await runWorkflowScript({
@@ -83,15 +95,15 @@ return (await runs.run('second', {agent: 'worker', task: first.output + '-second
 	assert.ok(calls.every(({ model }) => model === "openai-codex/test-model:high"));
 });
 
-test("overrides a mapped model but preserves unknown agents", async () => {
+test("preserves an explicit model ahead of the agent route", async () => {
 	const { calls } = await execute(`
 return await runs.all([
-  {key: 'known', agent: 'worker', task: 'known', model: 'other/model'},
-  {key: 'unknown', agent: 'unmapped', task: 'unknown', model: 'other/model'}
+  {key: 'known', agent: 'worker', task: 'known', model: 'openai-codex/explicit-model'},
+  {key: 'unknown', agent: 'unmapped', task: 'unknown', model: 'openai-codex/explicit-model'}
 ]);
 `);
-	assert.equal(calls[0].model, "openai-codex/test-model:high");
-	assert.equal(calls[1].model, "other/model");
+	assert.equal(calls[0].model, "openai-codex/explicit-model");
+	assert.equal(calls[1].model, "openai-codex/explicit-model");
 });
 
 test("preserves other workflow methods and global helpers", async () => {
@@ -105,13 +117,77 @@ return {output: status.output, steer: typeof runs.steer, ref: typeof runs.ref, r
 	assert.deepEqual(result.emits, ["complete"]);
 });
 
-test("keeps scripts unchanged when the provider has no route", () => {
-	const workflowScript = "return 42;";
-	assert.equal(route({ workflowScript }, "unknown").workflowScript, workflowScript);
+test("preserves workflow results when the provider has no route", async () => {
+	const { result, calls } = await execute("return 42;", "unknown");
+	assert.equal(result.value, 42);
+	assert.deepEqual(calls, []);
 });
 
 test("keeps management calls unchanged and routes direct children", () => {
 	const validation = { action: "validate", workflowScript: "return 42;" };
 	assert.deepEqual(route({ ...validation }), validation);
 	assert.equal(route({ agent: "worker", task: "direct" }).model, "openai-codex/test-model:high");
+});
+
+test("routes parallel and chain children with the same precedence", () => {
+	const result = route({
+		tasks: [{ agent: "worker", command: "review" }, { agent: "worker", model: "openai-codex/explicit-model" }],
+		chain: [{ agent: "worker" }, { parallel: [{ agent: "worker", command: "review" }] }],
+	});
+	assert.equal(result.tasks[0].model, "openai-codex/command-model:medium");
+	assert.equal(result.tasks[1].model, "openai-codex/explicit-model");
+	assert.equal(result.chain[0].model, "openai-codex/test-model:high");
+	assert.equal(result.chain[1].parallel[0].model, "openai-codex/command-model:medium");
+});
+
+test("command routing overrides agent defaults but not explicit caller choices", () => {
+	assert.equal(route({ agent: "worker", command: "review" }).model, "openai-codex/command-model:medium");
+	assert.equal(route({ agent: "worker", command: "review", model: "openai-codex/explicit-model" }).model,
+		"openai-codex/explicit-model");
+});
+
+test("supporting skills and file reads do not select a model", () => {
+	assert.equal(route({ agent: "worker", skills: ["focused"] }).model, "openai-codex/test-model:high");
+	const read = { path: "/skills/focused/SKILL.md", directSkill: "focused" };
+	assert.deepEqual(route({ ...read }, "openai-codex", { toolName: "read" }), read);
+	assert.equal(route({ directSkill: "focused" }).model, "openai-codex/skill-model:low");
+});
+
+test("unknown explicit routes and unavailable models block child launch", () => {
+	assert.throws(() => route({ command: "unknown-command" }), /unknown|not found/i);
+	assert.throws(() => route({ directSkill: "unknown-skill" }), /unknown|not found/i);
+	assert.throws(() => route({ command: "missing" }), /unavailable|not found|not available/i);
+	assert.throws(() => route({ command: "foreign" }), /provider|route/i);
+});
+
+test("explicit model selection cannot silently change the inference provider", () => {
+	assert.throws(() => route({ agent: "worker", model: "anthropic/claude-sonnet-5" }), /provider/i);
+});
+
+test("workflow command routes reach native launches without routing-only fields", async () => {
+	const { calls } = await execute(`
+return await runs.all([
+  {key: 'command', agent: 'worker', command: 'review', task: 'review'},
+  {key: 'skill', agent: 'worker', directSkill: 'focused', task: 'focus'}
+]);
+`);
+	assert.equal(calls[0].model, "openai-codex/command-model:medium");
+	assert.equal(calls[1].model, "openai-codex/skill-model:low");
+	assert.ok(calls.every((call) => !("command" in call) && !("directSkill" in call)));
+});
+
+test("an invalid route stops a workflow before any child launches", async () => {
+	const { calls, result } = await execute(`
+try {
+  await runs.all([
+    {key: 'valid', agent: 'worker', task: 'valid'},
+    {key: 'invalid', agent: 'worker', command: 'missing', task: 'invalid'}
+  ]);
+  return 'launched';
+} catch (error) {
+  return error.message;
+}
+`);
+	assert.deepEqual(calls, []);
+	assert.match(result.value, /unavailable/i);
 });

--- a/home-manager/_mixins/agentic/pi/extensions/provider-router/index.ts
+++ b/home-manager/_mixins/agentic/pi/extensions/provider-router/index.ts
@@ -8,267 +8,356 @@ import {
 	type ExtensionAPI,
 	type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai/compat";
 
-type AgentModelMap = Record<string, Record<string, string>>;
-type AgentThinkingMap = Record<string, Record<string, string>>;
-
-interface RoutedTask {
-	agent?: unknown;
-	model?: unknown;
-}
-
-interface RoutedChainStep extends RoutedTask {
-	parallel?: unknown;
-}
-
-type SubagentToolInput = Record<string, unknown> &
-	RoutedTask & {
-		action?: unknown;
-		tasks?: unknown;
-		chain?: unknown;
-		workflowScript?: unknown;
-	};
-
-const mapFile = path.join(
-	os.homedir(),
-	".pi/agent/extensions/provider-router/agents.json",
-);
-const thinkingFile = path.join(
-	os.homedir(),
-	".pi/agent/extensions/provider-router/thinking.json",
-);
-
-const VALID_THINKING_LEVELS = new Set<string>([
-	"off",
-	"minimal",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
-]);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function toAgentModelMap(value: unknown): AgentModelMap {
-	if (!isRecord(value)) return {};
-
-	const result: AgentModelMap = Object.create(null);
-	for (const [agent, providerModels] of Object.entries(value)) {
-		if (!isRecord(providerModels)) continue;
-
-		const models: Record<string, string> = Object.create(null);
-		for (const [provider, modelId] of Object.entries(providerModels)) {
-			if (typeof modelId === "string" && modelId.length > 0) {
-				models[provider] = modelId;
-			}
-		}
-
-		if (Object.keys(models).length > 0) {
-			result[agent] = models;
-		}
-	}
-
-	return result;
-}
-
-function toAgentThinkingMap(value: unknown): AgentThinkingMap {
-	if (!isRecord(value)) return {};
-
-	const result: AgentThinkingMap = Object.create(null);
-	for (const [agent, providerLevels] of Object.entries(value)) {
-		if (!isRecord(providerLevels)) continue;
-
-		const levels: Record<string, string> = Object.create(null);
-		for (const [provider, level] of Object.entries(providerLevels)) {
-			if (typeof level === "string" && VALID_THINKING_LEVELS.has(level)) {
-				levels[provider] = level;
-			}
-		}
-
-		if (Object.keys(levels).length > 0) {
-			result[agent] = levels;
-		}
-	}
-
-	return result;
-}
-
-function loadMap(): AgentModelMap {
-	try {
-		return toAgentModelMap(JSON.parse(fs.readFileSync(mapFile, "utf-8")));
-	} catch {
-		return {};
-	}
-}
-
-function loadThinkingMap(): AgentThinkingMap {
-	try {
-		return toAgentThinkingMap(
-			JSON.parse(fs.readFileSync(thinkingFile, "utf-8")),
-		);
-	} catch {
-		return {};
-	}
-}
-
-function applyModel(
-	task: RoutedTask,
-	provider: string | undefined,
-	map: AgentModelMap,
-	thinkingMap: AgentThinkingMap,
-	ctx: ExtensionContext,
-): void {
-	if (typeof task.agent !== "string" || !provider) return;
-
-	const mappedModel = map[task.agent]?.[provider];
-	const thinking = thinkingMap[task.agent]?.[provider];
-
-	// Known-agent gate: only act when the agent has at least one routing entry
-	// (model or thinking) for the active provider. Unknown agents pass through.
-	if (mappedModel === undefined && thinking === undefined) return;
-
-	// Pick the bare model id. Prefer an explicit model-<provider> override; if
-	// only a thinking-<provider> entry exists, fall back to the active session
-	// model so we can attach the effort suffix without changing the model.
-	let bareModel: string | undefined;
-	if (mappedModel) {
-		bareModel = mappedModel;
-	} else if (
-		thinking &&
-		typeof ctx.model?.id === "string" &&
-		ctx.model.id.length > 0
-	) {
-		bareModel = ctx.model.id;
-	}
-
-	if (!bareModel) return;
-
-	// Validate against the unsuffixed model id only. The thinking suffix is
-	// Pi-specific routing syntax and must never reach modelRegistry.find.
-	if (!ctx.modelRegistry.find(provider, bareModel)) return;
-
-	const routedModel = thinking
-		? `${provider}/${bareModel}:${thinking}`
-		: `${provider}/${bareModel}`;
-
-	// Log when the extension overrides an orchestrator-supplied value. The
-	// common case (orchestrator left model unset) emits nothing.
-	if (typeof task.model === "string" && task.model !== routedModel) {
-		console.error(
-			`provider-router: override model for agent=${task.agent} orchestrator=${task.model} -> routed=${routedModel}`,
-		);
-	}
-
-	task.model = routedModel;
-}
-
-function buildWorkflowRoutes(
-	provider: string | undefined,
-	map: AgentModelMap,
-	thinkingMap: AgentThinkingMap,
-	ctx: ExtensionContext,
-): Record<string, string> {
-	const routes: Record<string, string> = Object.create(null);
-	const agents = new Set([...Object.keys(map), ...Object.keys(thinkingMap)]);
-
-	for (const agent of agents) {
-		const task: RoutedTask = { agent };
-		applyModel(task, provider, map, thinkingMap, ctx);
-		if (typeof task.model === "string") routes[agent] = task.model;
-	}
-
-	return routes;
-}
-
-function wrapWorkflowScript(
-	input: SubagentToolInput,
-	provider: string | undefined,
-	map: AgentModelMap,
-	thinkingMap: AgentThinkingMap,
-	ctx: ExtensionContext,
-): void {
-	if (typeof input.workflowScript !== "string") return;
-
-	const routes = buildWorkflowRoutes(provider, map, thinkingMap, ctx);
-	if (Object.keys(routes).length === 0) return;
-
-	const script = input.workflowScript;
-	input.workflowScript = `
-const __providerRouterModels = ${JSON.stringify(routes)};
-const __providerRouterRoute = (spec) => {
-	if (!spec || typeof spec !== "object" || typeof spec.agent !== "string") return spec;
-	const model = __providerRouterModels[spec.agent];
-	if (!model) return spec;
-	if (typeof spec.model === "string" && spec.model !== model) {
-		console.error(\`provider-router: override model for agent=\${spec.agent} orchestrator=\${spec.model} -> routed=\${model}\`);
-	}
-	return { ...spec, model };
+type Route = { model?: string; thinking?: string };
+type Entry = { agent?: string; providers: Record<string, Route> };
+type Routes = {
+	commands: Record<string, Entry>;
+	skills: Record<string, Entry>;
 };
-const __providerRouterRuns = Object.freeze({
-	...runs,
-	run: (key, spec) => runs.run(key, __providerRouterRoute(spec)),
-	all: (specs) => runs.all(specs.map(__providerRouterRoute)),
-});
-{
-	const runs = __providerRouterRuns;
-${script}
+type Task = Record<string, unknown>;
+type State = {
+	provider?: string;
+	model?: string;
+	agents: Record<string, Record<string, string>>;
+	thinking: Record<string, Record<string, string>>;
+	routes: Routes;
+	available: string[];
+	supportedThinking: Record<string, string[]>;
+	explicitModel?: string;
+	command?: string;
+	directSkill?: string;
+};
+
+const directory = path.join(
+	os.homedir(),
+	".pi/agent/extensions/provider-router",
+);
+
+function load(name: string): any {
+	try {
+		const value = JSON.parse(
+			fs.readFileSync(path.join(directory, name), "utf-8"),
+		);
+		if (!value || typeof value !== "object" || Array.isArray(value))
+			throw new Error("expected an object");
+		return value;
+	} catch (error) {
+		if ((error as { code?: string }).code === "ENOENT") return {};
+		throw new Error(`provider-router: cannot load ${name}: ${String(error)}`);
+	}
 }
-`.trim();
+
+// This function also runs inside the workflow worker, so it has no external references.
+export function resolveTaskRoute(task: Task, state: State): string | undefined {
+	const fail = (message: string): never => {
+		throw new Error(`provider-router: ${message}`);
+	};
+	const levels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+	const provider = state.provider;
+	const entry = (
+		kind: "commands" | "skills",
+		name: unknown,
+	): Entry | undefined => {
+		if (name === undefined) return undefined;
+		if (typeof name !== "string" || !Object.hasOwn(state.routes[kind], name))
+			return fail(`unknown ${kind} route ${String(name)}`);
+		return state.routes[kind][name];
+	};
+	const command = entry("commands", task.command ?? state.command);
+	const skill = entry("skills", task.directSkill ?? state.directSkill);
+	const agent = typeof task.agent === "string" ? task.agent : command?.agent;
+	let route: Route | undefined;
+	const explicitModel = task.model ?? state.explicitModel;
+	if (explicitModel !== undefined) {
+		if (typeof explicitModel !== "string" || !explicitModel.trim())
+			return fail("explicit model must be a non-empty string");
+		const match = explicitModel.match(/^(.*?)(?::([^/:]+))?$/)!;
+		let model = match[1];
+		if (provider && model.startsWith(`${provider}/`))
+			model = model.slice(provider.length + 1);
+		route = { model, thinking: match[2] };
+	} else {
+		for (const candidate of [command, skill]) {
+			if (!candidate || Object.keys(candidate.providers).length === 0) continue;
+			if (!provider || !Object.hasOwn(candidate.providers, provider))
+				return fail(`no route for active provider ${provider ?? "(none)"}`);
+			route = candidate.providers[provider];
+			break;
+		}
+		if (!route && agent && provider) {
+			const model = state.agents[agent]?.[provider];
+			const thinking = state.thinking[agent]?.[provider];
+			if (model !== undefined || thinking !== undefined)
+				route = { model, thinking };
+		}
+	}
+	if (!route) return undefined;
+	if (
+		typeof route !== "object" ||
+		Array.isArray(route) ||
+		Object.keys(route).some((key) => key !== "model" && key !== "thinking")
+	)
+		return fail("unsupported route fields");
+	if (!provider) return fail("a route requires an active inference provider");
+	const model = route.model ?? state.model;
+	if (typeof model !== "string" || !model.trim())
+		return fail("a route requires a model");
+	if (route.thinking !== undefined && !levels.includes(route.thinking))
+		return fail(`unsupported thinking level ${String(route.thinking)}`);
+	if (!state.available.includes(model))
+		return fail(
+			`model ${provider}/${model} is unavailable for the active provider`,
+		);
+	if (
+		route.thinking !== undefined &&
+		!state.supportedThinking[model]?.includes(route.thinking)
+	)
+		return fail(
+			`model ${provider}/${model} does not support thinking level ${route.thinking}`,
+		);
+	return `${provider}/${model}${route.thinking === undefined ? "" : `:${route.thinking}`}`;
+}
+
+export async function routeInvocation(
+	text: string,
+	ctx: ExtensionContext,
+	streaming?: string,
+	pi?: ExtensionAPI,
+): Promise<boolean> {
+	const request: {
+		text: string;
+		ctx: ExtensionContext;
+		streaming?: string;
+		result?: Promise<boolean>;
+	} = { text, ctx, streaming };
+	pi?.events.emit("provider-router:invoke", request);
+	if (!request.result)
+		throw new Error("provider-router: routing extension is not loaded");
+	return request.result;
 }
 
 export default function registerProviderRouter(pi: ExtensionAPI): void {
-	let map = loadMap();
-	let thinkingMap = loadThinkingMap();
-	const reloadMaps = (): void => {
-		map = loadMap();
-		thinkingMap = loadThinkingMap();
+	let maps: Pick<State, "agents" | "thinking" | "routes">;
+	let loadError: unknown;
+	let changing = false;
+	const callerModel = process.argv.some(
+		(arg) => arg === "--model" || arg.startsWith("--model="),
+	);
+	let explicit = callerModel;
+	let abortPending = false;
+	let pending:
+		| {
+				text: string;
+				model: any;
+				thinking?: string;
+				command?: string;
+				directSkill?: string;
+		  }
+		| undefined;
+	let active:
+		| {
+				text: string;
+				model: any;
+				thinking: any;
+				command?: string;
+				directSkill?: string;
+		  }
+		| undefined;
+	const reload = (): void => {
+		try {
+			const routes = load("routes.json");
+			maps = {
+				agents: load("agents.json"),
+				thinking: load("thinking.json"),
+				routes: {
+					commands: routes.commands ?? {},
+					skills: routes.skills ?? {},
+				},
+			};
+			loadError = undefined;
+		} catch (error) {
+			loadError = error;
+		}
 	};
-
-	pi.on("session_start", reloadMaps);
-	pi.on("resources_discover", reloadMaps);
-
+	reload();
+	const stateFor = (ctx: ExtensionContext): State => {
+		if (loadError) throw loadError;
+		const provider = ctx.model?.provider;
+		const available = ctx.modelRegistry
+			.getAvailable()
+			.filter((model) => model.provider === provider);
+		return {
+			...maps,
+			provider,
+			model: ctx.model?.id,
+			command: active?.command,
+			directSkill: active?.directSkill,
+			explicitModel:
+				explicit && provider && ctx.model?.id
+					? `${provider}/${ctx.model.id}:${pi.getThinkingLevel()}`
+					: undefined,
+			available: available.map((model) => model.id),
+			supportedThinking: Object.fromEntries(
+				available.map((model) => [model.id, getSupportedThinkingLevels(model)]),
+			),
+		};
+	};
+	const restore = async (): Promise<void> => {
+		const previous = active;
+		active = undefined;
+		if (!previous) return;
+		changing = true;
+		try {
+			if (!(await pi.setModel(previous.model)))
+				throw new Error("provider-router: could not restore session model");
+			pi.setThinkingLevel(previous.thinking);
+		} finally {
+			changing = false;
+		}
+	};
+	pi.on("session_start", () => {
+		active = undefined;
+		pending = undefined;
+		abortPending = false;
+		explicit = callerModel;
+		reload();
+	});
+	pi.on("resources_discover", reload);
+	pi.on("model_select", (event) => {
+		if (!changing && event.source !== "restore") {
+			explicit = true;
+			active = undefined;
+			pending = undefined;
+			abortPending = false;
+		}
+	});
+	pi.on("agent_settled", restore);
+	pi.on("agent_start", async (_event, ctx) => {
+		if (abortPending) {
+			abortPending = false;
+			ctx.abort();
+		}
+	});
+	pi.on("before_agent_start", async (_event, ctx) => {
+		const request = pending;
+		pending = undefined;
+		if (!request) return;
+		active = {
+			...request,
+			model: ctx.model,
+			thinking: pi.getThinkingLevel(),
+		};
+		changing = true;
+		try {
+			if (!(await pi.setModel(request.model)))
+				throw new Error("provider-router: could not select routed model");
+			if (request.thinking) {
+				pi.setThinkingLevel(request.thinking);
+				if (pi.getThinkingLevel() !== request.thinking)
+					throw new Error("provider-router: could not select routed thinking level");
+			}
+		} catch (error) {
+			abortPending = true;
+			ctx.ui.notify(String(error), "error");
+			await restore();
+		} finally {
+			changing = false;
+		}
+	});
+	const dispatch = async (
+		text: string,
+		ctx: ExtensionContext,
+		streaming?: string,
+	): Promise<boolean> => {
+		pending = undefined;
+		abortPending = false;
+		const match = text.match(/^\/(skill:)?([^\s]+)(?:\s|$)/);
+		if (!match) return true;
+		try {
+			if (loadError) throw loadError;
+			const kind = match[1] ? "skills" : "commands";
+			if (!Object.hasOwn(maps.routes[kind], match[2])) return true;
+			if (active?.text === text && !streaming) return true;
+			const task =
+				kind === "skills" ? { directSkill: match[2] } : { command: match[2] };
+			if (explicit) return true;
+			const state = stateFor(ctx);
+			const resolved = resolveTaskRoute(task, state);
+			if (!resolved) return true;
+			if (streaming || !ctx.isIdle())
+				throw new Error(
+					"provider-router: routed commands and skills require an idle session",
+				);
+			const selected = resolved
+				.slice(state.provider!.length + 1)
+				.match(/^(.*?)(?::([^/:]+))?$/)!;
+			const model = ctx.modelRegistry.find(state.provider!, selected[1]);
+			if (!model)
+				throw new Error(`provider-router: model ${resolved} is unavailable`);
+			pending = {
+				text,
+				model,
+				thinking: selected[2],
+				...task,
+			};
+			return true;
+		} catch (error) {
+			ctx.ui.notify(String(error), "error");
+			return false;
+		}
+	};
+	const unsubscribe = pi.events.on("provider-router:invoke", (request: any) => {
+		request.result = dispatch(request.text, request.ctx, request.streaming);
+	});
+	pi.on("session_shutdown", unsubscribe);
+	pi.on("input", async (event, ctx) => ({
+		action: (await dispatch!(event.text, ctx, event.streamingBehavior))
+			? "continue"
+			: "handled",
+	}));
 	pi.on("tool_call", (event, ctx) => {
-		if (!isToolCallEventType<"subagent", SubagentToolInput>("subagent", event))
-			return;
-
+		if (!isToolCallEventType<"subagent", Task>("subagent", event)) return;
 		const input = event.input;
 		if (input.action && input.action !== "append-step") return;
-
-		const provider = ctx.model?.provider;
-		if (typeof input.workflowScript === "string") {
-			wrapWorkflowScript(input, provider, map, thinkingMap, ctx);
-			return;
-		}
-
-		applyModel(input, provider, map, thinkingMap, ctx);
-
-		if (Array.isArray(input.tasks)) {
-			for (const task of input.tasks) {
-				if (isRecord(task)) {
-					applyModel(task, provider, map, thinkingMap, ctx);
-				}
+		try {
+			const state = stateFor(ctx);
+			if (typeof input.workflowScript === "string") {
+				input.workflowScript = `
+const __providerRouterState = ${JSON.stringify(state)};
+const __providerRouterResolve = ${resolveTaskRoute.toString()};
+const __providerRouterRoute = (spec) => {
+ const model = __providerRouterResolve(spec, __providerRouterState);
+ const {command, directSkill, ...native} = spec;
+ return model ? {...native, model} : native;
+};
+const __providerRouterRuns = Object.freeze({
+ ...runs,
+ run: (key, spec) => runs.run(key, __providerRouterRoute(spec)),
+ all: (specs) => runs.all(specs.map(__providerRouterRoute)),
+});
+{
+ const runs = __providerRouterRuns;
+${input.workflowScript}
+}`.trim();
+				return;
 			}
-		}
-
-		if (Array.isArray(input.chain)) {
-			for (const step of input.chain) {
-				if (!isRecord(step)) continue;
-
-				const chainStep = step as RoutedChainStep;
-				applyModel(chainStep, provider, map, thinkingMap, ctx);
-
-				if (Array.isArray(chainStep.parallel)) {
-					for (const parallelTask of chainStep.parallel) {
-						if (isRecord(parallelTask)) {
-							applyModel(parallelTask, provider, map, thinkingMap, ctx);
-						}
-					}
-				} else if (isRecord(chainStep.parallel)) {
-					applyModel(chainStep.parallel, provider, map, thinkingMap, ctx);
-				}
-			}
+			const apply = (task: unknown): void => {
+				if (!task || typeof task !== "object" || Array.isArray(task)) return;
+				const value = task as Task;
+				const model = resolveTaskRoute(value, state);
+				if (model) value.model = model;
+				delete value.command;
+				delete value.directSkill;
+				if (Array.isArray(value.parallel)) value.parallel.forEach(apply);
+				else if (value.parallel) apply(value.parallel);
+			};
+			apply(input);
+			if (Array.isArray(input.tasks)) input.tasks.forEach(apply);
+			if (Array.isArray(input.chain)) input.chain.forEach(apply);
+		} catch (error) {
+			return { block: true, reason: String(error) };
 		}
 	});
 }

--- a/home-manager/_mixins/agentic/pi/extensions/provider-router/invocation.test.mjs
+++ b/home-manager/_mixins/agentic/pi/extensions/provider-router/invocation.test.mjs
@@ -1,0 +1,411 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { after, test } from "node:test";
+
+const home = mkdtempSync(join(tmpdir(), "pi-invocation-"));
+after(() => rmSync(home, { recursive: true, force: true }));
+const dir = join(home, ".pi/agent/extensions/provider-router");
+mkdirSync(dir, { recursive: true });
+writeFileSync(
+	join(dir, "routes.json"),
+	JSON.stringify({
+		commands: {
+			review: {
+				providers: { "openai-codex": { model: "command", thinking: "high" } },
+			},
+			missing: { providers: { "openai-codex": { model: "missing" } } },
+		},
+		skills: {
+			focused: {
+				providers: { "openai-codex": { model: "skill", thinking: "low" } },
+			},
+		},
+	}),
+);
+const originalHome = process.env.HOME;
+process.env.HOME = home;
+const { default: registerRouter } = await import("./index.ts");
+const { default: registerDisplay } =
+	await import("../prompt-template-display/index.ts");
+if (originalHome === undefined) delete process.env.HOME;
+else process.env.HOME = originalHome;
+
+function harness(display = false) {
+	const handlers = new Map();
+	const notifications = [];
+	const sent = [];
+	const models = ["parent", "command", "skill", "user"].map((id) => ({
+		id,
+		provider: "openai-codex",
+	}));
+	let model = models[0];
+	let thinking = "medium";
+	let aborted = false;
+	const ctx = {
+		get model() {
+			return model;
+		},
+		mode: "tui",
+		isIdle: () => true,
+		abort: () => {
+			aborted = true;
+		},
+		modelRegistry: {
+			getAvailable: () => models,
+			find: (provider, id) =>
+				models.find((item) => item.provider === provider && item.id === id),
+		},
+		ui: { notify: (message) => notifications.push(message) },
+	};
+	const emit = async (name, event) => {
+		for (const handler of handlers.get(name) ?? []) {
+			const result = await handler(event, ctx);
+			if (result?.action === "handled" || result?.block) return result;
+		}
+	};
+	const pi = {
+		events: {
+			on: (name, fn) => {
+				handlers.set(name, [fn]);
+				return () => handlers.delete(name);
+			},
+			emit: (name, data) => {
+				for (const fn of handlers.get(name) ?? []) fn(data);
+			},
+		},
+		on: (name, handler) =>
+			handlers.set(name, [...(handlers.get(name) ?? []), handler]),
+		setModel: async (next) => {
+			model = next;
+			await emit("model_select", { source: "set", model });
+			return true;
+		},
+		getThinkingLevel: () => thinking,
+		setThinkingLevel: (level) => {
+			thinking = level;
+		},
+		registerEntryRenderer: () => {},
+		getCommands: () =>
+			["review", "missing"].map((name) => ({
+				name,
+				source: "prompt",
+				sourceInfo: { source: "file", path: join(home, "template.md") },
+			})),
+		appendEntry: () => {},
+		sendUserMessage: (content) => sent.push(content),
+		sendMessage: (content) => sent.push(content),
+	};
+	writeFileSync(join(home, "template.md"), "Perform the task.");
+	if (display) registerDisplay(pi);
+	registerRouter(pi);
+	return {
+		emit,
+		pi,
+		ctx,
+		notifications,
+		sent,
+		get aborted() {
+			return aborted;
+		},
+	};
+}
+
+test("routes a display-consumed command and restores the session", async () => {
+	const h = harness(true);
+	await h.emit("input", { text: "/review", source: "interactive" });
+	assert.equal(h.ctx.model.id, "parent");
+	await h.emit("before_agent_start", {});
+	await h.emit("agent_start", {});
+	assert.equal(h.ctx.model.id, "command");
+	assert.equal(h.pi.getThinkingLevel(), "high");
+	assert.equal(h.sent.length, 1);
+	await h.emit("agent_end", {});
+	assert.equal(h.ctx.model.id, "command");
+	await h.emit("agent_settled", {});
+	assert.equal(h.ctx.model.id, "parent");
+	assert.equal(h.pi.getThinkingLevel(), "medium");
+});
+
+test("direct skill invocation routes but supporting reads do not", async () => {
+	const h = harness();
+	await h.emit("tool_call", {
+		toolName: "read",
+		input: { path: "focused/SKILL.md" },
+	});
+	assert.equal(h.ctx.model.id, "parent");
+	await h.emit("input", { text: "/skill:focused task", source: "interactive" });
+	await h.emit("before_agent_start", {});
+	await h.emit("agent_start", {});
+	assert.equal(h.ctx.model.id, "skill");
+	await h.emit("agent_settled", {});
+	assert.equal(h.ctx.model.id, "parent");
+});
+
+test("a user model choice wins and prevents stale restoration", async () => {
+	const h = harness();
+	await h.emit("input", { text: "/review", source: "interactive" });
+	await h.emit("before_agent_start", {});
+	await h.emit("agent_start", {});
+	await h.pi.setModel({ provider: "openai-codex", id: "user" });
+	await h.emit("agent_settled", {});
+	await h.emit("input", { text: "/review", source: "interactive" });
+	assert.equal(h.ctx.model.id, "user");
+});
+
+test("an explicit model choice cancels a staged route", async () => {
+	const h = harness();
+	await h.emit("input", { text: "/review" });
+	await h.pi.setModel({ provider: "openai-codex", id: "user" });
+	await h.emit("before_agent_start", {});
+	await h.emit("agent_start", {});
+	await h.emit("agent_settled", {});
+	assert.equal(h.ctx.model.id, "user");
+});
+
+test("a failed preflight leaves no model change or route on the next input", async () => {
+	const h = harness();
+	await h.emit("input", { text: "/review" });
+	assert.equal(h.ctx.model.id, "parent");
+	await h.emit("input", { text: "ordinary prompt" });
+	await h.emit("before_agent_start", {});
+	await h.emit("agent_start", {});
+	assert.equal(h.ctx.model.id, "parent");
+});
+
+test("failed model selection aborts the run and restores session settings", async () => {
+	const h = harness();
+	const setModel = h.pi.setModel;
+	h.pi.setModel = async (model) =>
+		model.id === "command" ? false : setModel(model);
+	await h.emit("input", { text: "/review" });
+	await h.emit("before_agent_start", {});
+	await h.emit("agent_start", {});
+	assert.equal(h.aborted, true);
+	assert.equal(h.ctx.model.id, "parent");
+	assert.equal(h.pi.getThinkingLevel(), "medium");
+	assert.match(h.notifications[0], /could not select routed model/);
+});
+
+for (const continuation of [
+	"HTTP retry",
+	"overflow recovery",
+	"queued follow-up",
+]) {
+	test(`keeps the route across ${continuation} until settlement`, async () => {
+		const h = harness();
+		await h.emit("input", { text: "/review" });
+		await h.emit("before_agent_start", {});
+		await h.emit("agent_start", {});
+		await h.emit("agent_end", {});
+		await h.emit("before_agent_start", {});
+		await h.emit("agent_start", {});
+		assert.equal(h.ctx.model.id, "command");
+		assert.equal(h.pi.getThinkingLevel(), "high");
+		await h.emit("agent_end", {});
+		await h.emit("agent_settled", {});
+		assert.equal(h.ctx.model.id, "parent");
+		assert.equal(h.pi.getThinkingLevel(), "medium");
+	});
+}
+
+test("cancellation and thrown run errors restore at settlement", async () => {
+	for (const reason of ["aborted", "error"]) {
+		const h = harness();
+		await h.emit("input", { text: "/review" });
+		await h.emit("before_agent_start", {});
+		await h.emit("agent_start", {});
+		await h.emit("agent_end", { messages: [{ stopReason: reason }] });
+		await h.emit("agent_settled", {});
+		assert.equal(h.ctx.model.id, "parent");
+	}
+});
+
+test("unsupported model effort blocks direct skill input", async () => {
+	const h = harness();
+	h.ctx.modelRegistry.find("openai-codex", "skill").supportedThinking = ["off"];
+	await h.emit("input", { text: "/skill:focused", source: "interactive" });
+	assert.equal(h.ctx.model.id, "parent");
+	assert.match(h.notifications[0], /does not support thinking level low/);
+});
+
+test("display-consumed unavailable and streaming routes never dispatch", async () => {
+	for (const event of [
+		{ text: "/missing" },
+		{ text: "/review", streamingBehavior: "steer" },
+	]) {
+		const h = harness(true);
+		await h.emit("input", { ...event, source: "interactive" });
+		assert.equal(h.sent.length, 0);
+		assert.equal(h.ctx.model.id, "parent");
+		assert.equal(h.notifications.length, 1);
+	}
+});
+
+const nativeDirectory = process.env.PI_CODING_AGENT_DIR;
+test(
+	"native Pi applies routes after preflight and keeps them through retries",
+	{
+		skip:
+			!nativeDirectory &&
+			"Set PI_CODING_AGENT_DIR to test the installed Pi runtime",
+	},
+	async () => {
+		const { AgentSession } = await import(
+			pathToFileURL(join(nativeDirectory, "dist/core/agent-session.js"))
+		);
+		const { Agent } = await import(
+			pathToFileURL(
+				join(
+					nativeDirectory,
+					"node_modules/@earendil-works/pi-agent-core/dist/agent.js",
+				),
+			)
+		);
+		for (const outcome of [
+			"success",
+			"retry",
+			"overflow",
+			"aborted",
+			"throw",
+			"preflight",
+		]) {
+			const h = harness();
+			const requests = [];
+			const session = Object.create(AgentSession.prototype);
+			const agent = new Agent({
+				initialState: {
+					model: h.ctx.model,
+					thinkingLevel: "medium",
+					systemPrompt: "base",
+				},
+				streamFn: (model, context, options) => {
+					requests.push({
+						model: model.id,
+						context,
+						reasoning: options.reasoning,
+					});
+					if (outcome === "throw")
+						throw new Error("synthetic transport failure");
+					const failed =
+						requests.length === 1 && ["retry", "overflow"].includes(outcome);
+					const message = {
+						role: "assistant",
+						provider: model.provider,
+						model: model.id,
+						api: "openai-responses",
+						content: [],
+						timestamp: Date.now(),
+						stopReason: failed
+							? "error"
+							: outcome === "aborted"
+								? "aborted"
+								: "stop",
+						errorMessage: failed
+							? outcome === "retry"
+								? "503 Service Unavailable"
+								: "context window exceeded"
+							: undefined,
+						usage: {
+							input: 0,
+							output: 0,
+							totalTokens: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+						},
+					};
+					return {
+						async *[Symbol.asyncIterator]() {
+							yield { type: "done", message };
+						},
+						result: async () => message,
+					};
+				},
+			});
+			const setModel = h.pi.setModel;
+			h.pi.setModel = async (model) => {
+				agent.state.model = model;
+				return setModel(model);
+			};
+			const setThinking = h.pi.setThinkingLevel;
+			h.pi.setThinkingLevel = (thinking) => {
+				agent.state.thinkingLevel = thinking;
+				setThinking(thinking);
+			};
+			h.ctx.abort = () => agent.abort();
+			let compacted = false;
+			Object.assign(session, {
+				agent,
+				_retryAttempt: 0,
+				_pendingNextTurnMessages: [],
+				_baseSystemPrompt: "base",
+				settingsManager: {
+					getRetrySettings: () => ({
+						enabled: true,
+						maxRetries: 1,
+						baseDelayMs: 0,
+					}),
+					getCompactionSettings: () => ({ enabled: false }),
+				},
+				_modelRuntime: {
+					hasConfiguredAuth: () => outcome !== "preflight",
+					checkAuth: async () => undefined,
+					isUsingOAuth: () => false,
+				},
+				_emit() {},
+				_flushPendingBashMessages() {},
+				_flushPendingCustomMessages() {},
+				_compactBeforeNextAssistantResponse: async (context) => context,
+				_checkCompaction: async () => {
+					if (outcome !== "overflow" || compacted) return false;
+					compacted = true;
+					agent.state.messages.pop();
+					return true;
+				},
+				_extensionRunner: {
+					hasHandlers: () => true,
+					emitInput: async (text) =>
+						(await h.emit("input", { text })) ?? { action: "continue" },
+					emitBeforeAgentStart: async () => h.emit("before_agent_start", {}),
+					emit: (event) => h.emit(event.type, event),
+				},
+			});
+			session._installAgentNextTurnRefresh();
+			agent.subscribe(async (event) => {
+				if (event.type === "message_end" && event.message.role === "assistant")
+					session._lastAssistantMessage = event.message;
+				await h.emit(event.type, event);
+			});
+			if (outcome === "preflight") {
+				await assert.rejects(
+					session.prompt("/review", { expandPromptTemplates: false }),
+					/No API key/,
+				);
+				assert.equal(requests.length, 0);
+			} else {
+				await session.prompt("/review", { expandPromptTemplates: false });
+				assert.equal(
+					requests.length,
+					["retry", "overflow"].includes(outcome) ? 2 : 1,
+					outcome,
+				);
+				assert.ok(
+					requests.every((request) => request.model === "command"),
+					outcome,
+				);
+				assert.ok(
+					requests.every((request) => request.reasoning === "high"),
+					outcome,
+				);
+				assert.ok(
+					requests.every((request) => request.context.systemPrompt === "base"),
+					outcome,
+				);
+			}
+			assert.equal(h.ctx.model.id, "parent", outcome);
+			assert.equal(h.pi.getThinkingLevel(), "medium", outcome);
+		}
+	},
+);

--- a/home-manager/_mixins/agentic/pi/extensions/provider-router/test-loader.mjs
+++ b/home-manager/_mixins/agentic/pi/extensions/provider-router/test-loader.mjs
@@ -8,6 +8,14 @@ export function isToolCallEventType(name, event) {
 `;
 
 export async function resolve(specifier, context, nextResolve) {
+	if (context.parentURL?.includes("/node_modules/"))
+		return nextResolve(specifier, context);
+	if (specifier === "@earendil-works/pi-ai/compat") {
+		return {
+			shortCircuit: true,
+			url: `data:text/javascript,${encodeURIComponent('export function getSupportedThinkingLevels(model) { return model.supportedThinking ?? ["off", "minimal", "low", "medium", "high", "xhigh"]; }')}`,
+		};
+	}
 	if (specifier === "@earendil-works/pi-coding-agent") {
 		return {
 			shortCircuit: true,

--- a/home-manager/_mixins/agentic/pi/extensions/provider-router/types.d.ts
+++ b/home-manager/_mixins/agentic/pi/extensions/provider-router/types.d.ts
@@ -1,33 +1,73 @@
 declare module "node:fs" {
-  export function readFileSync(path: string, encoding: "utf-8"): string;
+	export function readFileSync(path: string, encoding: "utf-8"): string;
+}
+
+declare const process: { argv: string[] };
+
+declare module "@earendil-works/pi-ai/compat" {
+	export function getSupportedThinkingLevels(model: unknown): string[];
 }
 
 declare module "node:path" {
-  export function join(...paths: string[]): string;
+	export function join(...paths: string[]): string;
 }
 
 declare module "node:os" {
-  export function homedir(): string;
+	export function homedir(): string;
 }
 
 declare module "@earendil-works/pi-coding-agent" {
-  export interface ExtensionContext {
-    model?: {
-      id?: string;
-      provider?: string;
-    };
-    modelRegistry: {
-      find(provider: string, modelId: string): unknown;
-    };
-  }
+	export interface ExtensionContext {
+		model?: {
+			id?: string;
+			provider?: string;
+		};
+		modelRegistry: {
+			find(provider: string, modelId: string): unknown;
+			getAvailable(): { provider: string; id: string }[];
+		};
+		isIdle(): boolean;
+		abort(): void;
+		ui: { notify(message: string, level: string): void };
+	}
 
-  export interface ExtensionAPI {
-    on(event: "session_start" | "resources_discover", handler: (...args: unknown[]) => void): void;
-    on(event: "tool_call", handler: (event: unknown, ctx: ExtensionContext) => void): void;
-  }
+	export interface ExtensionAPI {
+		events: {
+			emit(name: string, data: unknown): void;
+			on(name: string, handler: (data: any) => void): () => void;
+		};
+		on(event: "session_shutdown", handler: () => void): void;
+		setModel(model: any): Promise<boolean>;
+		getThinkingLevel(): string;
+		setThinkingLevel(level: string): void;
+		on(
+			event: "session_start" | "resources_discover",
+			handler: (...args: unknown[]) => void,
+		): void;
+		on(
+			event: "tool_call",
+			handler: (event: unknown, ctx: ExtensionContext) => void,
+		): void;
+		on(
+			event: "model_select",
+			handler: (event: { source: string }) => void,
+		): void;
+		on(event: "agent_settled", handler: () => Promise<void>): void;
+		on(
+			event: "agent_start" | "before_agent_start",
+			handler: (event: unknown, ctx: ExtensionContext) => Promise<void>,
+		): void;
+		on(
+			event: "input",
+			handler: (
+				event: { text: string; streamingBehavior?: string },
+				ctx: ExtensionContext,
+			) => Promise<{ action: string }>,
+		): void;
+	}
 
-  export function isToolCallEventType<TName extends string, TInput extends Record<string, unknown>>(
-    toolName: TName,
-    event: unknown,
-  ): event is { input: TInput };
+	export function isToolCallEventType<
+		TName extends string,
+		TInput extends Record<string, unknown>,
+	>(toolName: TName, event: unknown): event is { input: TInput };
 }

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -53,15 +53,31 @@ in
     # sops-nix.service twice on ravi (the unit is a store symlink placed
     # outside systemd.user.services, so the generation diff can miss it),
     # which left sops templates rendering old content until a manual
-    # daemon-reload. Both commands are idempotent, and the failure guards
-    # keep activation working when the user bus is unreachable, for
-    # example during a remote push-home.
-    activation.refreshSopsNix = lib.mkIf host.is.linux (
-      lib.hm.dag.entryAfter [ "reloadSystemd" ] ''
-        run ${pkgs.systemd}/bin/systemctl --user daemon-reload || true
-        run ${pkgs.systemd}/bin/systemctl --user restart sops-nix.service || true
-      ''
-    );
+    # daemon-reload. Assistant secret deployment requires this refresh to
+    # succeed before it replaces the previously installed files.
+    activation.refreshSopsNix = lib.mkMerge [
+      (lib.mkIf host.is.linux (
+        lib.hm.dag.entryAfter [ "reloadSystemd" "sops-nix" ] ''
+          run ${pkgs.systemd}/bin/systemctl --user daemon-reload || ${
+            if config.agentic.assistants.requiresSecrets then "exit 1" else "true"
+          }
+          run ${pkgs.systemd}/bin/systemctl --user restart sops-nix.service || ${
+            if config.agentic.assistants.requiresSecrets then "exit 1" else "true"
+          }
+        ''
+      ))
+      (lib.mkIf (host.is.darwin && config.agentic.assistants.requiresSecrets) (
+        lib.hm.dag.entryAfter [ "sops-nix" "linkGeneration" ] ''
+          run ${pkgs.coreutils}/bin/env ${
+            lib.escapeShellArgs (
+              lib.mapAttrsToList (
+                name: value: "${name}=${value}"
+              ) config.launchd.agents.sops-nix.config.EnvironmentVariables
+            )
+          } ${config.launchd.agents.sops-nix.config.Program}
+        ''
+      ))
+    ];
     homeDirectory =
       if host.is.darwin then
         "/Users/${username}"


### PR DESCRIPTION
Use one header.toml per agent, command or skill to keep shared metadata and client-specific model routes together. Preserve regular Codex SKILL.md files, including nested skills, and restore Pi session settings after routed invocations. Replace whole-directory cleanup with verified ownership records so activation removes obsolete generated files, preserves manual files and refreshes required secrets before deployment.

Validated with 32 cleanup tests, the metadata and Pi routing suites, just eval, just build-home and inspection of the generated activation order.
